### PR TITLE
perf: stop re-reading and re-aggregating unchanged session history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ rust:
 	cargo build --release
 
 build: rust
+	@$(call relink_if_stale,debug)
 	swift build
 
 run: rust
@@ -19,5 +20,15 @@ clean:
 	swift package clean
 
 bundle: rust
+	@$(call relink_if_stale,release)
 	swift build -c release
 	scripts/bundle.sh
+
+# SwiftPM does not track the Rust staticlib as a dependency: with no Swift
+# source changes it reuses the cached executable and silently ships stale
+# Rust code. Drop the executable whenever the staticlib is newer.
+define relink_if_stale
+	if [ target/release/libtb_core_ffi.a -nt .build/$(1)/TokenBar ]; then \
+		rm -f .build/$(1)/TokenBar; \
+	fi
+endef

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -1185,7 +1185,7 @@ fn map_window(label: &str, window: CodexWindow, now: DateTime<Utc>) -> UsageWind
         remaining_percent: (100.0 - used).max(0.0),
         resets_at: resets_at.map(|date| date.to_rfc3339_opts(SecondsFormat::Millis, true)),
         reset_text: resets_at.map(|date| reset_text(date, now)),
-        window_minutes: (window.limit_window_seconds > 0).then(|| window.limit_window_seconds / 60),
+        window_minutes: (window.limit_window_seconds > 0).then_some(window.limit_window_seconds / 60),
         historical_expected_percent: None,
         run_out_probability: None,
     }

--- a/crates/tb_core_ffi/src/lib.rs
+++ b/crates/tb_core_ffi/src/lib.rs
@@ -51,9 +51,13 @@ static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
         .expect("build tokio runtime for tb_core_ffi")
 });
 
-/// year → (computed-at, mapped graph payload). Same role as the Tauri
-/// AppState cache: lets a popover re-open within seconds skip a full re-parse.
-static GRAPH_CACHE: LazyLock<Mutex<HashMap<String, (Instant, serde_json::Value)>>> =
+/// year → (computed-at, source token, mapped graph payload). Same role as
+/// the Tauri AppState cache, plus a change token: when the cache entry ages
+/// past the oneshot window but `latest_source_mtime_ms` still matches the
+/// token, the entry is re-stamped and served — an idle machine never pays
+/// for a full re-aggregation just because time passed.
+type GraphCacheEntry = (Instant, u64, serde_json::Value);
+static GRAPH_CACHE: LazyLock<Mutex<HashMap<String, GraphCacheEntry>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 static TAILER: LazyLock<UsageTailer> = LazyLock::new(UsageTailer::new);
@@ -91,15 +95,30 @@ unsafe fn year_from(year: *const c_char) -> Result<String, String> {
 }
 
 fn graph_cached(year: &str, max_age: Duration) -> Option<serde_json::Value> {
-    let cache = GRAPH_CACHE.lock().ok()?;
-    let (at, data) = cache.get(year)?;
-    (at.elapsed() <= max_age).then(|| data.clone())
+    let mut cache = GRAPH_CACHE.lock().ok()?;
+    let (at, token, data) = cache.get_mut(year)?;
+    if at.elapsed() <= max_age {
+        return Some(data.clone());
+    }
+    // Aged out — but if no source file changed since the compute, the graph
+    // cannot have changed either. Re-stamp so the next calls inside the
+    // oneshot window skip the probe entirely.
+    let fresh = tokscale_core::latest_source_mtime_ms(&Default::default()).ok()?;
+    if fresh == *token {
+        *at = Instant::now();
+        return Some(data.clone());
+    }
+    None
 }
 
 fn graph_compute(year: &str) -> Result<serde_json::Value, String> {
+    // Probe before parsing: a write that lands mid-compute moves the mtime
+    // past this token, so the next aged-out read recomputes rather than
+    // serving a graph that missed it.
+    let token = tokscale_core::latest_source_mtime_ms(&Default::default()).unwrap_or(0);
     let data = usage_graph::run(year)?;
     if let Ok(mut cache) = GRAPH_CACHE.lock() {
-        cache.insert(year.to_string(), (Instant::now(), data.clone()));
+        cache.insert(year.to_string(), (Instant::now(), token, data.clone()));
     }
     Ok(data)
 }

--- a/crates/tb_core_ffi/src/usage_tail.rs
+++ b/crates/tb_core_ffi/src/usage_tail.rs
@@ -1,16 +1,12 @@
 //! Live tokens/min + per-(client, agent, model) trace for the popover and the
 //! menu-bar cat animation.
 //!
-//! Wave 2: parsing is delegated to the vendored `tokscale-core` crate, the same
-//! source the contribution graph uses, so the live signal covers every agent
-//! tokscale supports — not just the hand-tailed Claude/Codex/Hermes of before.
-//! tokscale-core has no streaming/tail API, but `parse_local_clients` is sync
-//! and cache-backed (disk message cache + Codex incremental + SQLite WAL
-//! invalidation), so re-parsing on every tick only touches changed files.
-//!
-//! Each `tick()` re-parses the last couple of days and *replaces* the in-memory
-//! event window. Snapshot-replace (rather than incremental append) means we
-//! lean on tokscale's own dedup and never carry cross-tick duplicates.
+//! Each `tick()` re-parses only files whose mtime falls inside the event
+//! window plus a small margin (`modified_after`), so steady-state cost is a
+//! stat sweep plus parsing the handful of currently-active session files.
+//! The event window is replaced wholesale each tick — snapshot-replace rather
+//! than incremental append means tokscale's own dedup handles duplicates and
+//! cross-tick state never accumulates.
 
 use chrono::{Duration, Local};
 use parking_lot::Mutex;
@@ -52,12 +48,17 @@ pub struct TraceBucket {
 
 pub struct UsageTailer {
     events: Mutex<Vec<UsageEvent>>,
+    /// `latest_source_mtime_ms` token from the last parse; when it hasn't
+    /// moved, the event window is still correct (rate queries re-filter by
+    /// timestamp on read) and the tick skips the parse entirely.
+    last_source_token: Mutex<Option<u64>>,
 }
 
 impl UsageTailer {
     pub fn new() -> Self {
         Self {
             events: Mutex::new(Vec::new()),
+            last_source_token: Mutex::new(None),
         }
     }
 
@@ -66,20 +67,34 @@ impl UsageTailer {
     /// and only used as a "did anything happen" hint by callers).
     pub fn tick(&self) -> usize {
         // `since` is date-granular; reach back one day so a sub-hour window that
-        // straddles midnight still sees yesterday's tail. tokscale's cache keeps
-        // this bounded regardless of total history size.
+        // straddles midnight still sees yesterday's tail.
         let since = (Local::now() - Duration::days(1))
             .format("%Y-%m-%d")
             .to_string();
+        // `modified_after` is what bounds the per-tick parse cost: a session
+        // log whose mtime predates the event window can't contain in-window
+        // events (logs are append-only, mtime >= last event's timestamp), so
+        // only files active within the window — plus a small margin for write
+        // latency and clock skew — are re-parsed each tick.
+        let window_reach_ms = (EVENT_WINDOW_SECS + 300) * 1000;
         let options = tokscale_core::LocalParseOptions {
             since: Some(since),
+            modified_after: Some((now_ms() - window_reach_ms) as u64),
             ..Default::default()
         };
+
+        // No source changed since the last parse → the window is already
+        // correct; skip the parse. Probe failure falls through to a parse.
+        let token = tokscale_core::latest_source_mtime_ms(&options).ok();
+        if token.is_some() && *self.last_source_token.lock() == token {
+            return self.events.lock().len();
+        }
 
         let parsed = match tokscale_core::parse_local_clients(options) {
             Ok(parsed) => parsed,
             Err(_) => return self.events.lock().len(),
         };
+        *self.last_source_token.lock() = token;
 
         let cutoff = now_ms() - EVENT_WINDOW_SECS * 1000;
         let mut next: Vec<UsageEvent> = parsed
@@ -110,6 +125,7 @@ impl UsageTailer {
         len
     }
 
+    #[allow(dead_code)] // kept for API symmetry with rate_in_window
     pub fn rate_per_min(&self) -> f32 {
         self.window_total(60) as f32
     }

--- a/vendor/tokscale-core/src/lib.rs
+++ b/vendor/tokscale-core/src/lib.rs
@@ -300,6 +300,12 @@ pub struct LocalParseOptions {
     /// Persistent scanner config loaded from `~/.config/tokscale/settings.json`.
     /// Defaults to empty when callers don't care about user-configured paths.
     pub scanner_settings: scanner::ScannerSettings,
+    /// Skip parsing file-backed session logs whose mtime (unix ms) is older
+    /// than this. Lets high-frequency callers (live tails) avoid re-parsing
+    /// an entire history when they only need recent messages — callers align
+    /// it with `since`. Database-backed sources (SQLite) are always parsed:
+    /// WAL writes may not touch the main db file's mtime.
+    pub modified_after: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -2011,6 +2017,75 @@ fn parse_local_unified_messages_resolved(
     );
     Ok(filter_unified_messages(messages, &options))
 }
+/// Max mtime (unix ms) across every file the local scan would read — the
+/// cheapest "did anything change" probe for callers that cache reports
+/// derived from `parse_local_clients` / the unified-message parsers.
+/// Database-backed sources contribute both the db file and its `-wal`
+/// sidecar (WAL writes may leave the main db file's mtime untouched).
+/// Stat failures contribute nothing, so a vanished file alone never
+/// invalidates a caller's cache — its replacement or sibling will.
+pub fn latest_source_mtime_ms(options: &LocalParseOptions) -> Result<u64, String> {
+    let (home_dir, clients) = resolve_local_parse_request(options)?;
+    let scan_result = scanner::scan_all_clients_with_scanner_settings(
+        &home_dir,
+        &clients,
+        options.use_env_roots,
+        &options.scanner_settings,
+    );
+    let mut latest: u64 = 0;
+    for files in scan_result.files.iter() {
+        for path in files {
+            latest = latest.max(file_mtime_ms(path).unwrap_or(0));
+        }
+    }
+    let mut dbs: Vec<PathBuf> = scan_result.opencode_dbs.clone();
+    let single_dbs = [
+        &scan_result.synthetic_db,
+        &scan_result.kilo_db,
+        &scan_result.hermes_db,
+        &scan_result.goose_db,
+        &scan_result.zed_db,
+        &scan_result.kiro_db,
+    ];
+    dbs.extend(single_dbs.into_iter().flatten().cloned());
+    dbs.extend(scan_result.crush_dbs.iter().map(|c| c.db_path.clone()));
+    for db in dbs {
+        latest = latest.max(file_mtime_ms(&db).unwrap_or(0));
+        let mut wal = db.into_os_string();
+        wal.push("-wal");
+        latest = latest.max(file_mtime_ms(Path::new(&wal)).unwrap_or(0));
+    }
+    Ok(latest)
+}
+
+/// File mtime as unix ms; `None` on any stat failure.
+fn file_mtime_ms(path: &Path) -> Option<u64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let duration = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
+    Some(duration.as_millis() as u64)
+}
+
+/// Drop file-backed session logs older than `threshold_ms` (unix ms, mtime)
+/// from a scan. Database-backed sources are left untouched: SQLite WAL writes
+/// may not update the main db file's mtime, so they are always parsed. Any
+/// stat failure keeps the file — over-parsing is safe, silently skipping is not.
+fn prune_scan_result_by_mtime(scan_result: &mut scanner::ScanResult, threshold_ms: u64) {
+    for files in scan_result.files.iter_mut() {
+        files.retain(|path| {
+            let Ok(meta) = std::fs::metadata(path) else {
+                return true;
+            };
+            let Ok(modified) = meta.modified() else {
+                return true;
+            };
+            let Ok(duration) = modified.duration_since(std::time::UNIX_EPOCH) else {
+                return true;
+            };
+            duration.as_millis() as u64 >= threshold_ms
+        });
+    }
+}
+
 pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages, String> {
     let start = Instant::now();
 
@@ -2027,12 +2102,15 @@ pub fn parse_local_clients(options: LocalParseOptions) -> Result<ParsedMessages,
     let include_all = clients.is_empty();
     let include_synthetic = include_all || clients.iter().any(|c| c == "synthetic");
 
-    let scan_result = scanner::scan_all_clients_with_scanner_settings(
+    let mut scan_result = scanner::scan_all_clients_with_scanner_settings(
         &home_dir,
         &clients,
         options.use_env_roots,
         &options.scanner_settings,
     );
+    if let Some(threshold_ms) = options.modified_after {
+        prune_scan_result_by_mtime(&mut scan_result, threshold_ms);
+    }
     let headless_roots =
         scanner::headless_roots_with_env_strategy(&home_dir, options.use_env_roots);
 
@@ -3540,6 +3618,7 @@ mod tests {
                 until: None,
                 year: None,
                 scanner_settings: scanner::ScannerSettings::default(),
+                modified_after: None,
             })
             .unwrap();
 
@@ -4081,6 +4160,7 @@ mod tests {
                 until: None,
                 year: None,
                 scanner_settings: scanner::ScannerSettings::default(),
+                modified_after: None,
             })
             .unwrap();
 
@@ -4275,6 +4355,7 @@ mod tests {
                 until: None,
                 year: None,
                 scanner_settings: scanner::ScannerSettings::default(),
+                modified_after: None,
             })
             .unwrap();
 
@@ -5652,6 +5733,7 @@ mod tests {
             until: None,
             year: None,
             scanner_settings: scanner::ScannerSettings::default(),
+            modified_after: None,
         })
         .unwrap();
 
@@ -5713,6 +5795,7 @@ mod tests {
             until: None,
             year: None,
             scanner_settings: scanner::ScannerSettings::default(),
+            modified_after: None,
         })
         .unwrap();
 
@@ -5779,6 +5862,7 @@ mod tests {
             until: None,
             year: None,
             scanner_settings: scanner::ScannerSettings::default(),
+            modified_after: None,
         })
         .unwrap();
         assert_eq!(parsed_default.counts.get(ClientId::OpenCode), 0);
@@ -5797,6 +5881,7 @@ mod tests {
                 opencode_db_paths: vec![external_db.clone()],
                 ..Default::default()
             },
+            modified_after: None,
         })
         .unwrap();
         assert_eq!(
@@ -5835,6 +5920,7 @@ mod tests {
             until: None,
             year: None,
             scanner_settings: scanner::ScannerSettings::default(),
+            modified_after: None,
         })
         .unwrap();
         assert_eq!(parsed_default.counts.get(ClientId::Hermes), 0);
@@ -5853,6 +5939,7 @@ mod tests {
                 extra_scan_paths,
                 ..Default::default()
             },
+            modified_after: None,
         })
         .unwrap();
 
@@ -5890,6 +5977,7 @@ mod tests {
             until: None,
             year: None,
             scanner_settings: scanner::ScannerSettings::default(),
+            modified_after: None,
         })
         .unwrap();
         assert_eq!(parsed_default.counts.get(ClientId::Zed), 0);
@@ -5908,6 +5996,7 @@ mod tests {
                 extra_scan_paths,
                 ..Default::default()
             },
+            modified_after: None,
         })
         .unwrap();
 
@@ -5954,6 +6043,7 @@ mod tests {
                 extra_scan_paths,
                 ..Default::default()
             },
+            modified_after: None,
         })
         .unwrap();
 
@@ -5983,6 +6073,7 @@ mod tests {
                 extra_scan_paths,
                 ..Default::default()
             },
+            modified_after: None,
         })
         .unwrap();
 
@@ -6037,6 +6128,7 @@ mod tests {
                 extra_scan_paths,
                 ..Default::default()
             },
+            modified_after: None,
         })
         .unwrap();
 
@@ -6114,6 +6206,7 @@ mod tests {
                 opencode_db_paths: vec![external_db.clone()],
                 ..Default::default()
             },
+            modified_after: None,
         })
         .unwrap();
 
@@ -6166,6 +6259,7 @@ mod tests {
             until: None,
             year: None,
             scanner_settings: scanner::ScannerSettings::default(),
+            modified_after: None,
         })
         .unwrap();
 
@@ -6357,6 +6451,7 @@ mod tests {
             until: None,
             year: None,
             scanner_settings: scanner::ScannerSettings::default(),
+            modified_after: None,
         })
         .unwrap();
 

--- a/vendor/tokscale-core/src/message_cache.rs
+++ b/vendor/tokscale-core/src/message_cache.rs
@@ -8,6 +8,7 @@ use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::UNIX_EPOCH;
 
 const CACHE_SCHEMA_VERSION: u32 = 16;
@@ -17,6 +18,41 @@ const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;
 const FINGERPRINT_SAMPLE_BYTES: usize = 4096;
 const FINGERPRINT_SAMPLE_POINTS: usize = 5;
 const HASH_BUFFER_BYTES: usize = 64 * 1024;
+
+/// Process-level memo keyed by (path, size, modified_ns). On a cache hit the
+/// caller skips `compute_sample_hashes` + `hash_prefix` (the expensive I/O +
+/// SHA-256 work). On lock poison or stat failure the caller falls back to the
+/// full recompute path — FAIL-LOUD, never returns stale/empty data.
+struct HashMemoEntry {
+    size: u64,
+    modified_ns: u64,
+    sample_hashes: Vec<FileSampleHash>,
+    content_hash: [u8; 32],
+}
+
+static HASH_MEMO: LazyLock<Mutex<HashMap<PathBuf, HashMemoEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Process-level memo for the deserialized store. On a cache hit (`path +
+/// size + modified_ns` all match) `load()` skips the bincode deserialize.
+/// Path is compared so a test-env config-dir switch never returns data from
+/// a different store file.
+struct StoreMemo {
+    cache_file: PathBuf,
+    file_size: u64,
+    file_modified_ns: u64,
+    entries: HashMap<CachedPath, Arc<CachedSourceEntry>>,
+}
+
+static STORE_MEMO: LazyLock<Mutex<Option<StoreMemo>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+/// Convert a `Duration` (typically elapsed since UNIX_EPOCH) to nanoseconds
+/// as `u64`.
+/// u64 holds ~584 years of ns since epoch — truncation is theoretical.
+fn duration_to_nanos(d: std::time::Duration) -> u64 {
+    d.as_nanos() as u64
+}
 
 fn cache_dir() -> Option<PathBuf> {
     if crate::paths::is_config_dir_overridden()
@@ -286,10 +322,97 @@ struct CachedSourceStore {
 
 #[derive(Default)]
 pub(crate) struct SourceMessageCache {
-    pub entries: HashMap<CachedPath, CachedSourceEntry>,
+    pub entries: HashMap<CachedPath, Arc<CachedSourceEntry>>,
     dirty: bool,
     dirty_keys: HashSet<CachedPath>,
     deleted_paths: HashSet<CachedPath>,
+}
+
+/// Return the memo's entry map if `path + size + mtime_ns` all match.
+/// Returns `None` on lock poison, stat failure, or any mismatch.
+fn store_memo_entries_if_current(
+    path: &Path,
+) -> Option<HashMap<CachedPath, Arc<CachedSourceEntry>>> {
+    let guard = STORE_MEMO.lock().ok()?;
+    let memo = guard.as_ref()?;
+    if memo.cache_file != path {
+        return None;
+    }
+    let meta = fs::metadata(path).ok()?;
+    let size = meta.len();
+    let modified_ns = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(duration_to_nanos)?;
+    if size != memo.file_size || modified_ns != memo.file_modified_ns {
+        return None;
+    }
+    Some(memo.entries.clone())
+}
+
+/// Write or replace the STORE_MEMO entry. Silently skips on lock poison or
+/// unreadable mtime — a miss on the next `load()` will just re-read disk.
+fn store_memo_update(
+    path: &Path,
+    meta: &std::fs::Metadata,
+    entries: &HashMap<CachedPath, Arc<CachedSourceEntry>>,
+) {
+    let size = meta.len();
+    let Some(modified_ns) = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(duration_to_nanos)
+    else {
+        return;
+    };
+    if let Ok(mut guard) = STORE_MEMO.lock() {
+        *guard = Some(StoreMemo {
+            cache_file: path.to_path_buf(),
+            file_size: size,
+            file_modified_ns: modified_ns,
+            entries: entries.clone(),
+        });
+    }
+}
+
+/// Load from legacy cache paths without memoizing (path would differ from
+/// the canonical path so the memo would never be a valid hit).
+fn load_from_legacy_paths() -> SourceMessageCache {
+    legacy_cache_paths()
+        .into_iter()
+        .find_map(|p| read_store_from_path(&p))
+        .map(|store| SourceMessageCache {
+            entries: store
+                .entries
+                .into_iter()
+                .map(|e| (e.path.clone(), Arc::new(e)))
+                .collect(),
+            dirty: false,
+            dirty_keys: HashSet::new(),
+            deleted_paths: HashSet::new(),
+        })
+        .unwrap_or_default()
+}
+
+/// Build the `merged_entries` base for `save_if_dirty`. Tries STORE_MEMO
+/// first to skip re-reading the on-disk store; falls back to disk on a miss.
+fn save_merge_base(
+    final_path: &Path,
+) -> HashMap<CachedPath, Arc<CachedSourceEntry>> {
+    if let Some(entries) = store_memo_entries_if_current(final_path) {
+        return entries;
+    }
+    read_store_from_path(final_path)
+        .map(|store| {
+            store
+                .entries
+                .into_iter()
+                .map(|e| (e.path.clone(), Arc::new(e)))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 impl SourceMessageCache {
@@ -305,6 +428,22 @@ impl SourceMessageCache {
                 return Self::default();
             }
         }
+
+        // Check STORE_MEMO before acquiring the file lock. A hit means the
+        // on-disk store is almost certainly unchanged — the stat is taken
+        // outside the file lock, so a concurrent atomic-rename writer can
+        // theoretically race it; (path, size, mtime_ns) collision makes a
+        // false hit vanishingly unlikely. Path is part of the key so a
+        // test-env config-dir switch never returns data from a different file.
+        if let Some(entries) = store_memo_entries_if_current(&path) {
+            return Self {
+                entries,
+                dirty: false,
+                dirty_keys: HashSet::new(),
+                deleted_paths: HashSet::new(),
+            };
+        }
+
         let lock_file = match OpenOptions::new()
             .read(true)
             .write(true)
@@ -319,22 +458,31 @@ impl SourceMessageCache {
             return Self::default();
         }
 
+        // Stat inside the shared lock for a consistent size+mtime pair.
+        let locked_meta = fs::metadata(&path).ok();
+
         let store = match read_store_from_path_status(&path) {
             CacheReadStatus::Loaded(store) => Some(store),
-            CacheReadStatus::Missing => legacy_cache_paths()
-                .into_iter()
-                .find_map(|path| read_store_from_path(&path)),
+            CacheReadStatus::Missing => {
+                // Legacy paths: load but do not memoize (path mismatch).
+                return load_from_legacy_paths();
+            }
             CacheReadStatus::Invalid => None,
         };
         let Some(store) = store else {
             return Self::default();
         };
 
-        let entries = store
+        let entries: HashMap<CachedPath, Arc<CachedSourceEntry>> = store
             .entries
             .into_iter()
-            .map(|entry| (entry.path.clone(), entry))
+            .map(|entry| (entry.path.clone(), Arc::new(entry)))
             .collect();
+
+        // Update STORE_MEMO so the next load() on an unchanged file is free.
+        if let Some(meta) = locked_meta.as_ref() {
+            store_memo_update(&path, meta, &entries);
+        }
 
         Self {
             entries,
@@ -346,7 +494,7 @@ impl SourceMessageCache {
 
     pub(crate) fn insert(&mut self, entry: CachedSourceEntry) {
         let key = entry.path.clone();
-        self.entries.insert(key.clone(), entry);
+        self.entries.insert(key.clone(), Arc::new(entry));
         self.deleted_paths.remove(&key);
         self.dirty_keys.insert(key);
         self.dirty = true;
@@ -354,7 +502,7 @@ impl SourceMessageCache {
 
     pub(crate) fn get(&self, path: &Path) -> Option<&CachedSourceEntry> {
         let key = CachedPath::from_path(path);
-        self.entries.get(&key)
+        self.entries.get(&key).map(|a| a.as_ref())
     }
 
     pub(crate) fn remove(&mut self, path: &Path) {
@@ -363,6 +511,11 @@ impl SourceMessageCache {
             self.dirty_keys.remove(&key);
             self.deleted_paths.insert(key);
             self.dirty = true;
+        }
+        // Evict from HASH_MEMO so a deleted session file leaves no stale memo
+        // entry. Lock poison → silently skip; next access recomputes.
+        if let Ok(mut memo) = HASH_MEMO.lock() {
+            memo.remove(path);
         }
     }
 
@@ -377,10 +530,17 @@ impl SourceMessageCache {
             return;
         }
 
-        for path in removed_paths {
-            self.entries.remove(&path);
-            self.dirty_keys.remove(&path);
-            self.deleted_paths.insert(path);
+        for path in &removed_paths {
+            let path_buf = path.to_path_buf();
+            self.entries.remove(path);
+            self.dirty_keys.remove(path);
+            self.deleted_paths.insert(path.clone());
+            // Evict from HASH_MEMO so deleted session files leave no stale
+            // memo entries. Lock poison → silently skip; next access
+            // recomputes.
+            if let Ok(mut memo) = HASH_MEMO.lock() {
+                memo.remove(&path_buf);
+            }
         }
         self.dirty = true;
     }
@@ -417,16 +577,10 @@ impl SourceMessageCache {
             return;
         }
 
-        let mut merged_entries: HashMap<CachedPath, CachedSourceEntry> =
-            read_store_from_path(&final_path)
-                .map(|store| {
-                    store
-                        .entries
-                        .into_iter()
-                        .map(|entry| (entry.path.clone(), entry))
-                        .collect()
-                })
-                .unwrap_or_default();
+        // Build the merged entries. Try STORE_MEMO first to skip re-reading
+        // the on-disk store; fall back to disk read on a miss.
+        let mut merged_entries: HashMap<CachedPath, Arc<CachedSourceEntry>> =
+            save_merge_base(&final_path);
 
         for path in &self.deleted_paths {
             if !path.to_path_buf().exists() {
@@ -434,19 +588,19 @@ impl SourceMessageCache {
             }
         }
         for path in &self.dirty_keys {
-            if let Some(entry) = self.entries.get(path) {
-                merged_entries.insert(path.clone(), entry.clone());
+            if let Some(arc) = self.entries.get(path) {
+                merged_entries.insert(path.clone(), Arc::clone(arc));
             }
         }
 
         let store = CachedSourceStore {
             schema_version: CACHE_SCHEMA_VERSION,
-            entries: merged_entries.values().cloned().collect(),
+            entries: merged_entries.values().map(|e| (**e).clone()).collect(),
         };
 
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos() as u64)
+            .map(duration_to_nanos)
             .unwrap_or(0);
         let tmp_path = dir.join(format!(
             ".{}.{}.{:x}.tmp",
@@ -477,6 +631,12 @@ impl SourceMessageCache {
         if write_result.is_err() {
             let _ = fs::remove_file(&tmp_path);
             return;
+        }
+
+        // Stat final_path while exclusive lock is still held, then refresh
+        // STORE_MEMO so the next load() skips the disk read (race-safe).
+        if let Ok(meta) = fs::metadata(&final_path) {
+            store_memo_update(&final_path, &meta, &merged_entries);
         }
 
         self.entries = merged_entries;
@@ -614,10 +774,36 @@ fn file_fingerprint_parts(path: &Path) -> Option<(u64, u64, Vec<FileSampleHash>,
         .modified()
         .ok()?
         .duration_since(UNIX_EPOCH)
-        .ok()?
-        .as_nanos() as u64;
+        .ok()
+        .map(duration_to_nanos)?;
+
+    // Check HASH_MEMO: if (path, size, modified_ns) all match, skip the
+    // expensive compute_sample_hashes + hash_prefix (file I/O + SHA-256).
+    // Lock poison or stat failure → fall through to full recompute (FAIL-LOUD).
+    if let Ok(memo) = HASH_MEMO.lock() {
+        if let Some(entry) = memo.get(path) {
+            if entry.size == size && entry.modified_ns == modified_ns {
+                return Some((size, modified_ns, entry.sample_hashes.clone(), entry.content_hash));
+            }
+        }
+    }
+
     let sample_hashes = compute_sample_hashes(path, size)?;
     let content_hash = hash_prefix(path, size)?;
+
+    // Update HASH_MEMO. Silently skip on lock poison — next call recomputes.
+    if let Ok(mut memo) = HASH_MEMO.lock() {
+        memo.insert(
+            path.to_path_buf(),
+            HashMemoEntry {
+                size,
+                modified_ns,
+                sample_hashes: sample_hashes.clone(),
+                content_hash,
+            },
+        );
+    }
+
     Some((size, modified_ns, sample_hashes, content_hash))
 }
 


### PR DESCRIPTION
Fixes #1.

On a 3.1 GB / 16,129-file `~/.claude/projects`, every 10 s tail tick burst to 360–566% CPU with ~2.7 GB RSS. After this PR, with an *actively writing* Claude Code session on the machine, the app holds 15–22% CPU between data changes, short ≤140% bursts only when a session log actually changed, and ~1.2–1.7 GB RSS.

## Changes

**`vendor/tokscale-core/src/message_cache.rs`**
- `HASH_MEMO`: memoize `(sample_hashes, content_hash)` by `(path, size, mtime_ns)`. A cache hit previously still read + SHA-256-hashed every file on every fingerprint check; unchanged files are now one stat. Entries are evicted alongside `remove()` / `prune_missing_files()`. Same staleness assumption as cargo/make (nanosecond mtime + size).
- `STORE_MEMO`: keep the deserialized store resident, revalidated by the cache file's `(path, size, mtime_ns)` — path included so a config-dir switch can never serve another store's data. `load()` skips the full bincode deserialize on a hit; `save_if_dirty()` skips the merge re-read and refreshes the memo while the exclusive lock is held. The atomic temp-file rename invariant is untouched.

**`vendor/tokscale-core/src/lib.rs`**
- `LocalParseOptions.modified_after` (unix ms): prunes file-backed session logs by mtime before parsing. SQLite-backed sources are always parsed (WAL writes may not touch the main db file's mtime); any stat failure keeps the file.
- `latest_source_mtime_ms()`: max mtime across every file the scan would read (db files probe their `-wal` sidecar too) — the cheapest "did anything change" probe for callers that cache derived reports.

**`crates/tb_core_ffi`**
- The tail tick sets `modified_after` to its event window plus a small margin, so each tick parses only currently-active session files instead of the whole history.
- Both the graph oneshot cache and the tail tick are token-gated on the probe: an aged-out graph whose sources haven't moved is re-stamped and served; a tick with no source change skips its parse. An idle machine no longer pays for time passing.
- Drive-by: two pre-existing clippy lints (`then_some`, a `dead_code` allow).

**`Makefile`**
- SwiftPM does not track the Rust staticlib referenced via `-L`/`-l` unsafeFlags: with no Swift source changes it reuses the cached executable and silently ships stale Rust code (this bit me while validating this very PR — three measurement rounds ran an app whose Rust layer was unpatched). `make build`/`make bundle` now drop the executable when `libtb_core_ffi.a` is newer.

## Measurements (same machine, 5 s sampling, active Claude Code session writing logs throughout)

| | baseline (beta.4) | this PR |
|---|---|---|
| tail tick (10 s) | 360–566% CPU burst, every tick | no per-tick burst; 15–22% steady |
| data actually changed | full re-aggregation regardless | short ≤140% burst, then settles |
| idle, no log changes | full graph re-aggregation every TTL expiry | served from cache (token unchanged) |
| RSS | ~2.7 GB | ~1.2–1.7 GB |
| `cargo test -p tokscale-core` | 830 passed | 830 passed |
| `cargo clippy -- -D warnings` | — | clean |

## Notes

- The `(size, mtime_ns)`-unchanged ⇒ content-unchanged assumption is the same one cargo and make rely on; APFS mtime is nanosecond-granular.
- Items in `message_cache.rs` live in the vendored `tokscale-core` and may be worth forwarding to junhoyeo/tokscale.
- Known remaining cost (out of scope here, noted in #1): when a log *does* change, the graph path still re-materializes and re-aggregates the full history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)