### PR TITLE
perf: stream per-file aggregation to eliminate graph recompute RSS sawtooth

### DIFF
--- a/vendor/tokscale-core/src/aggregator.rs
+++ b/vendor/tokscale-core/src/aggregator.rs
@@ -1688,6 +1688,7 @@ mod tests {
 
     /// Build a deterministic UnifiedMessage fixture for streaming aggregator tests.
     /// All dedup-sensitive fields are explicit; no real JSONL files required.
+    #[allow(clippy::too_many_arguments)]
     fn streaming_msg(
         date: &str,
         client: &str,

--- a/vendor/tokscale-core/src/aggregator.rs
+++ b/vendor/tokscale-core/src/aggregator.rs
@@ -8,7 +8,7 @@ use crate::{
     SessionContribution, TokenBreakdown, YearSummary,
 };
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Aggregate messages into daily contributions
 pub fn aggregate_by_date(messages: Vec<UnifiedMessage>) -> Vec<DailyContribution> {
@@ -722,6 +722,135 @@ fn calculate_intensities(contributions: &mut [DailyContribution]) {
             0
         };
     }
+}
+
+// =============================================================================
+// StreamingAggregator — zero-copy fold path
+// =============================================================================
+
+/// Streaming aggregator that folds messages one-by-one without materialising a
+/// full clone of the message list.  Trae messages are buffered until
+/// [`StreamingAggregator::finalize`] so only the latest-per-session survives.
+pub struct StreamingAggregator {
+    days: HashMap<String, DayAccumulator>,
+    seen: HashSet<String>,
+    trae_latest: HashMap<String, UnifiedMessage>,
+}
+
+impl Default for StreamingAggregator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StreamingAggregator {
+    pub fn new() -> Self {
+        Self {
+            days: HashMap::new(),
+            seen: HashSet::new(),
+            trae_latest: HashMap::new(),
+        }
+    }
+
+    pub fn feed(&mut self, msg: &UnifiedMessage) {
+        if msg.client == "trae" {
+            let entry = self.trae_latest.entry(msg.session_id.clone());
+            match entry {
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    let existing = slot.get();
+                    let should_replace = msg.timestamp > existing.timestamp
+                        || (msg.timestamp == existing.timestamp
+                            && msg.dedup_key.as_ref().is_some_and(|k| {
+                                existing
+                                    .dedup_key
+                                    .as_ref()
+                                    .is_none_or(|ek| k.as_str() > ek.as_str())
+                            }));
+                    if should_replace {
+                        *slot.get_mut() = msg.clone();
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(msg.clone());
+                }
+            }
+            return;
+        }
+
+        if let Some(key) = &msg.dedup_key {
+            if !key.is_empty() {
+                if self.seen.contains(key.as_str()) {
+                    return;
+                }
+                self.seen.insert(key.clone());
+            }
+        }
+
+        self.days
+            .entry(msg.date.clone())
+            .or_default()
+            .add_message(msg);
+    }
+
+    /// Feed a message that has already been deduplicated by the scan driver.
+    ///
+    /// Skips the trae-buffer and dedup_key gate — the caller guarantees this
+    /// message is unique and should be counted. Use only from
+    /// `scan_messages_streaming` where the driver layer owns dedup.
+    pub fn feed_pre_deduped(&mut self, msg: &UnifiedMessage) {
+        self.days
+            .entry(msg.date.clone())
+            .or_default()
+            .add_message(msg);
+    }
+
+    pub fn finalize(mut self) -> Vec<DailyContribution> {
+        for msg in self.trae_latest.into_values() {
+            if let Some(key) = &msg.dedup_key {
+                if !key.is_empty() {
+                    if self.seen.contains(key.as_str()) {
+                        continue;
+                    }
+                    self.seen.insert(key.clone());
+                }
+            }
+            self.days
+                .entry(msg.date.clone())
+                .or_default()
+                .add_message(&msg);
+        }
+
+        if self.days.is_empty() {
+            return Vec::new();
+        }
+
+        let mut contributions: Vec<DailyContribution> = self
+            .days
+            .into_iter()
+            .map(|(date, acc)| acc.into_contribution(date))
+            .collect();
+
+        contributions.sort_by(|a, b| a.date.cmp(&b.date));
+        calculate_intensities(&mut contributions);
+        contributions
+    }
+}
+
+/// Iterator-driven internal path.  Phase 2 can drive this with STORE_MEMO Arc
+/// entries without materialising a full Vec.
+pub fn fold_messages_iter<'a>(
+    iter: impl Iterator<Item = &'a UnifiedMessage>,
+) -> Vec<DailyContribution> {
+    let mut agg = StreamingAggregator::new();
+    for msg in iter {
+        agg.feed(msg);
+    }
+    agg.finalize()
+}
+
+/// Slice-based public API — thin wrapper over [`fold_messages_iter`].
+pub fn fold_messages_streaming(messages: &[UnifiedMessage]) -> Vec<DailyContribution> {
+    fold_messages_iter(messages.iter())
 }
 
 #[cfg(test)]
@@ -1552,4 +1681,299 @@ mod tests {
         // Spot-check key field is present in JSON.
         assert!(json.contains("\"session_id\":\"019e1e27"));
     }
+
+    // =========================================================================
+    // StreamingAggregator RED tests
+    // =========================================================================
+
+    /// Build a deterministic UnifiedMessage fixture for streaming aggregator tests.
+    /// All dedup-sensitive fields are explicit; no real JSONL files required.
+    fn streaming_msg(
+        date: &str,
+        client: &str,
+        model: &str,
+        session_id: &str,
+        dedup_key: Option<&str>,
+        timestamp_ms: i64,
+        input: i64,
+        output: i64,
+        cost: f64,
+    ) -> UnifiedMessage {
+        UnifiedMessage {
+            client: client.to_string(),
+            model_id: model.to_string(),
+            provider_id: "anthropic".to_string(),
+            session_id: session_id.to_string(),
+            workspace_key: None,
+            workspace_label: None,
+            timestamp: timestamp_ms,
+            date: date.to_string(),
+            tokens: TokenBreakdown {
+                input,
+                output,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            duration_ms: None,
+            message_count: 1,
+            agent: None,
+            dedup_key: dedup_key.map(|s| s.to_string()),
+            is_turn_start: false,
+        }
+    }
+
+    // scenario: no_dedup
+    // Messages with no dedup_key are all folded — none are dropped.
+    #[test]
+    fn test_streaming_aggregator_no_dedup_all_messages_counted() {
+        // scenario: no_dedup
+        let msgs: Vec<UnifiedMessage> = (0..3)
+            .map(|i| {
+                streaming_msg(
+                    "2025-01-01",
+                    "claude",
+                    "claude-sonnet-4-5",
+                    &format!("sess-{i}"),
+                    None,
+                    1_700_000_000_000 + i as i64 * 1000,
+                    100,
+                    50,
+                    0.01,
+                )
+            })
+            .collect();
+
+        let mut agg = StreamingAggregator::new();
+        for msg in &msgs {
+            agg.feed(msg);
+        }
+        let contributions = agg.finalize();
+
+        assert_eq!(contributions.len(), 1, "all msgs on same date -> 1 day bucket");
+        assert_eq!(
+            contributions[0].totals.messages, 3,
+            "all 3 messages with no dedup_key must be retained"
+        );
+        assert!(
+            (contributions[0].totals.cost - 0.03).abs() < 1e-9,
+            "total cost must reflect all 3 messages"
+        );
+    }
+
+    // scenario: cross_file_dedup
+    // Messages with the same dedup_key fed across multiple batches (simulating
+    // multiple file lanes) — the second occurrence must be silently dropped.
+    #[test]
+    fn test_streaming_aggregator_cross_file_dedup_drops_duplicate() {
+        // scenario: cross_file_dedup
+        let first = streaming_msg(
+            "2025-02-01",
+            "claude",
+            "claude-sonnet-4-5",
+            "sess-a",
+            Some("dedup-key-abc"),
+            1_700_100_000_000,
+            200,
+            100,
+            0.05,
+        );
+        let duplicate = streaming_msg(
+            "2025-02-01",
+            "claude",
+            "claude-sonnet-4-5",
+            "sess-a",
+            Some("dedup-key-abc"),
+            1_700_100_001_000,
+            200,
+            100,
+            0.05,
+        );
+        let unique = streaming_msg(
+            "2025-02-01",
+            "claude",
+            "claude-opus-4-5",
+            "sess-b",
+            Some("dedup-key-xyz"),
+            1_700_100_002_000,
+            50,
+            25,
+            0.02,
+        );
+
+        let mut agg = StreamingAggregator::new();
+        agg.feed(&first);
+        agg.feed(&duplicate);
+        agg.feed(&unique);
+        let contributions = agg.finalize();
+
+        assert_eq!(contributions.len(), 1);
+        assert_eq!(
+            contributions[0].totals.messages, 2,
+            "duplicate dedup_key must be dropped; only 2 unique messages retained"
+        );
+        assert!(
+            (contributions[0].totals.cost - 0.07).abs() < 1e-9,
+            "cost must exclude the duplicated message"
+        );
+    }
+
+    // scenario: trae_keep_latest
+    // Trae messages with the same session_id: only the one with the highest
+    // timestamp survives (order-dependent replacement semantics).
+    #[test]
+    fn test_streaming_aggregator_trae_keep_latest_by_timestamp() {
+        // scenario: trae_keep_latest
+        let older = streaming_msg(
+            "2025-03-01",
+            "trae",
+            "claude-sonnet-4-5",
+            "trae-sess-1",
+            Some("trae-key-old"),
+            1_710_000_000_000,
+            300,
+            100,
+            0.08,
+        );
+        let newer = streaming_msg(
+            "2025-03-01",
+            "trae",
+            "claude-sonnet-4-5",
+            "trae-sess-1",
+            Some("trae-key-new"),
+            1_710_000_001_000,
+            500,
+            150,
+            0.12,
+        );
+        let other_session = streaming_msg(
+            "2025-03-01",
+            "trae",
+            "claude-haiku-4-5",
+            "trae-sess-2",
+            Some("trae-key-other"),
+            1_710_000_002_000,
+            100,
+            50,
+            0.03,
+        );
+
+        let mut agg = StreamingAggregator::new();
+        agg.feed(&older);
+        agg.feed(&newer);
+        agg.feed(&other_session);
+        let contributions = agg.finalize();
+
+        assert_eq!(contributions.len(), 1);
+        assert_eq!(
+            contributions[0].totals.messages, 2,
+            "trae: only the latest per session_id survives"
+        );
+        assert!(
+            (contributions[0].totals.cost - 0.15).abs() < 1e-9,
+            "cost must use newer trae message, not the older one"
+        );
+        assert_eq!(
+            contributions[0].totals.tokens, 800,
+            "tokens must reflect the winning newer trae message"
+        );
+    }
+
+    // scenario: multi_day_bucketing
+    // Messages on different calendar dates land in separate daily buckets and
+    // are sorted chronologically in finalize() output.
+    #[test]
+    fn test_streaming_aggregator_multi_day_bucketing_produces_separate_buckets() {
+        // scenario: multi_day_bucketing
+        let day1a = streaming_msg(
+            "2025-04-01", "opencode", "gpt-4o", "sess-d1", None,
+            1_743_000_000_000, 100, 50, 0.01,
+        );
+        let day1b = streaming_msg(
+            "2025-04-01", "opencode", "gpt-4o", "sess-d1", None,
+            1_743_000_001_000, 200, 100, 0.02,
+        );
+        let day2 = streaming_msg(
+            "2025-04-02", "opencode", "gpt-4o", "sess-d2", None,
+            1_743_086_400_000, 400, 200, 0.04,
+        );
+        let day3 = streaming_msg(
+            "2025-04-03", "codex", "gpt-5", "sess-d3", None,
+            1_743_172_800_000, 1000, 500, 0.10,
+        );
+
+        let mut agg = StreamingAggregator::new();
+        for msg in &[&day1a, &day1b, &day2, &day3] {
+            agg.feed(msg);
+        }
+        let contributions = agg.finalize();
+
+        assert_eq!(contributions.len(), 3, "3 distinct dates -> 3 buckets");
+        assert_eq!(contributions[0].date, "2025-04-01");
+        assert_eq!(contributions[1].date, "2025-04-02");
+        assert_eq!(contributions[2].date, "2025-04-03");
+        assert_eq!(contributions[0].totals.messages, 2);
+        assert!(
+            (contributions[0].totals.cost - 0.03).abs() < 1e-9,
+            "day1 cost must aggregate both messages"
+        );
+        assert_eq!(contributions[1].totals.tokens, 600);
+        assert_eq!(contributions[2].totals.tokens, 1500);
+    }
+
+    // scenario: store_memo_snapshot
+    // Simulates Hermes/Zed lane entries (dedup_key=Some) alongside normal lane
+    // entries (dedup_key=None), fed in a single pass (snapshot semantics).
+    // Verifies that cross-lane dedup works correctly when processed together.
+    #[test]
+    fn test_streaming_aggregator_store_memo_snapshot_hermes_zed_dedup() {
+        // scenario: store_memo_snapshot
+        let hermes_msg = streaming_msg(
+            "2025-05-01", "hermes", "claude-sonnet-4-5", "hermes-sess-1",
+            Some("hermes-unique-key-1"), 1_746_000_000_000, 500, 200, 0.09,
+        );
+        let zed_msg = streaming_msg(
+            "2025-05-01", "zed", "claude-sonnet-4-5", "zed-sess-1",
+            Some("zed-unique-key-1"), 1_746_000_001_000, 300, 100, 0.05,
+        );
+        let normal_msg = streaming_msg(
+            "2025-05-01", "claude", "claude-haiku-4-5", "claude-sess-1",
+            None, 1_746_000_002_000, 100, 50, 0.01,
+        );
+        let hermes_dup = streaming_msg(
+            "2025-05-01", "hermes", "claude-sonnet-4-5", "hermes-sess-1",
+            Some("hermes-unique-key-1"), 1_746_000_003_000, 500, 200, 0.09,
+        );
+
+        let mut agg = StreamingAggregator::new();
+        agg.feed(&hermes_msg);
+        agg.feed(&zed_msg);
+        agg.feed(&normal_msg);
+        agg.feed(&hermes_dup);
+
+        let contributions = agg.finalize();
+
+        assert_eq!(contributions.len(), 1);
+        assert_eq!(
+            contributions[0].totals.messages, 3,
+            "store_memo_snapshot: hermes + zed + normal = 3; hermes-dup dropped"
+        );
+        assert!(
+            (contributions[0].totals.cost - 0.15).abs() < 1e-9,
+            "cost must exclude hermes duplicate"
+        );
+    }
+
+    // scenario: empty finalize (guard against panic)
+    #[test]
+    fn test_streaming_aggregator_finalize_empty_accumulator_returns_empty() {
+        let agg = StreamingAggregator::new();
+        let contributions = agg.finalize();
+        assert!(
+            contributions.is_empty(),
+            "finalize() on empty StreamingAggregator must return empty Vec without panicking"
+        );
+    }
+
 }

--- a/vendor/tokscale-core/src/lib.rs
+++ b/vendor/tokscale-core/src/lib.rs
@@ -1841,8 +1841,12 @@ where
             || retain_for_requested_clients(&m.client, &m.model_id, &m.provider_id, &requested)
     };
 
-    // Cross-file dedup gate shared across non-trae, non-opencode, non-claude, non-codex lanes.
-    let mut seen_keys: HashSet<String> = HashSet::new();
+    // Each client lane owns its dedup set (see `simple_lane!` / the Gemini
+    // block below). Sharing one set across clients would let a dedup_key from
+    // one client suppress an identical key from another — copilot uses
+    // `trace:span` keys but codebuff/kimi use raw upstream message ids with no
+    // client namespace, so a cross-client collision is possible. Per-client
+    // sets match the claude/codex/hermes/opencode lanes above.
 
     // Trae keep-latest buffer — flushed after all other lanes.
     let mut trae_latest: HashMap<String, UnifiedMessage> = HashMap::new();
@@ -1934,13 +1938,16 @@ where
         }
     }
 
-    // ---- Simple file-backed lanes (shared seen_keys, cache-aware) ----
+    // ---- Simple file-backed lanes (per-lane dedup set, cache-aware) ----
     // Cache hit  → iterate cached.messages by reference (one clone per message),
     //              refresh_derived_fields, apply pricing, dedup, filter, sink.
     // Cache miss → par-collect parse results, then sequential: writeback + emit.
     // Mirrors load_or_parse_source semantics from parse_all_messages_with_pricing_with_env_strategy.
     macro_rules! simple_lane {
         ($client_id:expr, $parse_fn:expr) => {{
+            // Per-lane dedup set: persists across this client's files, never
+            // shared with other clients (see the note above the trae buffer).
+            let mut seen_keys: HashSet<String> = HashSet::new();
             // Separate paths into cache-hit (emit immediately) vs cache-miss (par-parse).
             let mut miss_paths: Vec<&PathBuf> = Vec::new();
             for path in scan_result.get($client_id) {
@@ -2003,6 +2010,9 @@ where
     // Uses load_or_parse_source_with_fingerprint_and_policy equivalent:
     // cacheable=false → remove stale cache entry (invalidate_cache).
     {
+        // Per-lane dedup set (Gemini currently emits no dedup_key, so this is a
+        // no-op today, but keeps the lane consistent and collision-proof).
+        let mut seen_keys: HashSet<String> = HashSet::new();
         let mut gemini_miss_paths: Vec<&PathBuf> = Vec::new();
         for path in scan_result.get(ClientId::Gemini) {
             let fp = message_cache::SourceFingerprint::from_path(path);
@@ -3092,7 +3102,8 @@ mod tests {
         aggregate_model_usage_entries, apply_pricing_if_available, dedupe_latest_trae_messages,
         fold_messages_streaming, message_cache, normalize_model_for_grouping,
         parse_all_messages_with_pricing, parse_local_clients, parsed_to_unified, pricing,
-        retain_for_requested_clients, scanner, select_local_parse_pricing, unified_to_parsed,
+        retain_for_requested_clients, scan_messages_streaming, scanner, select_local_parse_pricing,
+        unified_to_parsed,
         ClientId, GroupBy, LocalParseOptions, TokenBreakdown, UnifiedMessage,
         UNKNOWN_WORKSPACE_LABEL,
     };
@@ -4049,6 +4060,68 @@ mod tests {
             assert_eq!(parsed.messages.len(), 4);
             assert_eq!(parsed.messages.iter().map(|m| m.input).sum::<i64>(), 40);
             assert_eq!(parsed.messages.iter().map(|m| m.output).sum::<i64>(), 5);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    // Regression: the streaming driver must NOT share one dedup set across
+    // different clients. kimi and codebuff both emit raw upstream message ids
+    // as dedup_key with no client namespace, so a shared set would let one
+    // client's key suppress an identical key from the other. Here both a kimi
+    // message and a codebuff message carry dedup_key "COLLIDE"; both must
+    // survive. With a single shared `seen_keys` (the pre-fix behaviour) the
+    // second lane's message is silently dropped and this fails.
+    #[test]
+    #[serial_test::serial]
+    fn test_streaming_driver_does_not_dedup_across_clients() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            // kimi: one StatusUpdate carrying message_id "COLLIDE".
+            let kimi_dir = source_home.path().join(".kimi/sessions/g/s");
+            std::fs::create_dir_all(&kimi_dir).unwrap();
+            std::fs::write(
+                kimi_dir.join("wire.jsonl"),
+                r#"{"type": "metadata", "protocol_version": "1.3"}
+{"timestamp": 1770983410.0, "message": {"type": "StatusUpdate", "payload": {"token_usage": {"input_other": 100, "output": 50, "input_cache_read": 0, "input_cache_creation": 0}, "message_id": "COLLIDE"}}}"#,
+            )
+            .unwrap();
+
+            // codebuff: one assistant message whose upstream id is "COLLIDE".
+            let cb_dir = source_home.path().join(".config/manicode/projects/proj");
+            std::fs::create_dir_all(&cb_dir).unwrap();
+            std::fs::write(
+                cb_dir.join("chat-messages.json"),
+                r#"[{"role":"assistant","id":"COLLIDE","metadata":{"model":"claude-sonnet-4","usage":{"inputTokens":200,"outputTokens":80}},"credits":0.02}]"#,
+            )
+            .unwrap();
+
+            let mut seen: Vec<String> = Vec::new();
+            scan_messages_streaming(
+                source_home.path().to_str().unwrap(),
+                &["kimi".to_string(), "codebuff".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+                &|_m: &UnifiedMessage| true,
+                &mut |m: &UnifiedMessage| seen.push(m.client.clone()),
+            );
+
+            assert!(
+                seen.iter().any(|c| c == "kimi"),
+                "kimi message with shared dedup_key must survive: {seen:?}"
+            );
+            assert!(
+                seen.iter().any(|c| c == "codebuff"),
+                "codebuff message with shared dedup_key must survive: {seen:?}"
+            );
         }
 
         match original_home {
@@ -6950,6 +7023,7 @@ mod tests {
     /// Deterministic UnifiedMessage fixture helper shared with parity tests.
     /// Uses no real JSONL files; all fields are constructed inline.
     #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
     fn parity_msg(
         date: &str,
         client: &str,

--- a/vendor/tokscale-core/src/lib.rs
+++ b/vendor/tokscale-core/src/lib.rs
@@ -18,8 +18,8 @@ pub use clients::{ClientCounts, ClientDef, ClientId, PathRoot};
 pub use parser::*;
 pub use scanner::*;
 pub use sessionize::{
-    compute_daily_active_time, compute_time_metrics, sessionize, SessionInterval, TimeMetrics,
-    DEFAULT_IDLE_GAP_MS,
+    compute_daily_active_time, compute_time_metrics, sessionize, SessionizeAccumulator,
+    SessionInterval, TimeMetrics, DEFAULT_IDLE_GAP_MS,
 };
 pub use sessions::UnifiedMessage;
 
@@ -510,6 +510,7 @@ fn parse_all_messages_with_pricing(
     )
 }
 
+// TODO: remaining callers: parse_local_unified_messages_resolved (FFI/external, intentional Vec); parse_all_messages_with_pricing (dead_code wrapper). All report consumers have migrated to scan_messages_streaming.
 fn parse_all_messages_with_pricing_with_env_strategy(
     home_dir: &str,
     clients: &[String],
@@ -808,21 +809,21 @@ fn parse_all_messages_with_pricing_with_env_strategy(
                             parsed.state,
                             fallback_timestamp_indices.clone(),
                         );
-                        if let Some(cache_entry) = cache_entry {
-                            let messages = finalize_codex_messages(
-                                raw_messages,
-                                pricing,
-                                is_headless,
-                                &fallback_timestamp_indices,
-                                fallback_timestamp,
-                            );
-
-                            return CachedParseOutcome {
-                                messages,
-                                cache_entry: Some(cache_entry),
-                                invalidate_cache: false,
-                            };
-                        }
+                        let Some(cache_entry) = cache_entry else {
+                            return reparse_from_start(true);
+                        };
+                        let messages = finalize_codex_messages(
+                            raw_messages,
+                            pricing,
+                            is_headless,
+                            &fallback_timestamp_indices,
+                            fallback_timestamp,
+                        );
+                        return CachedParseOutcome {
+                            messages,
+                            cache_entry: Some(cache_entry),
+                            invalidate_cache: false,
+                        };
                     }
                 }
             }
@@ -1536,31 +1537,55 @@ fn positive_token_total(tokens: &TokenBreakdown) -> i64 {
         + tokens.reasoning.max(0)
 }
 
-pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, String> {
-    let start = Instant::now();
-
-    let home_dir = get_home_dir_string(&options.home_dir)?;
-
-    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
+/// Returns the effective client list for a report: uses the caller-supplied
+/// list when present, or falls back to all known clients + "synthetic".
+fn resolve_report_clients(options: &ReportOptions) -> Vec<String> {
+    options.clients.clone().unwrap_or_else(|| {
         let mut clients: Vec<String> = ClientId::ALL
             .iter()
             .map(|c| c.as_str().to_string())
             .collect();
         clients.push("synthetic".to_string());
         clients
-    });
+    })
+}
+
+/// Returns `true` when the message should pass the cross-file dedup gate for
+/// lanes that track per-client seen keys.
+///
+/// Uses `contains` before `insert` to avoid cloning the key on the hot path
+/// when the key is already present (i.e. the message is a duplicate).
+fn dedup_gate_passes(key: &str, seen: &mut HashSet<String>) -> bool {
+    if seen.contains(key) {
+        return false;
+    }
+    seen.insert(key.to_owned());
+    true
+}
+
+pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, String> {
+    let start = Instant::now();
+
+    let home_dir = get_home_dir_string(&options.home_dir)?;
+    let clients = resolve_report_clients(&options);
 
     let pricing = load_pricing_for_local_parse().await;
-    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
-        &home_dir,
-        &clients,
-        pricing.as_deref(),
-        options.use_env_roots,
-        &options.scanner_settings,
+    let year_prefix = options.year.as_ref().map(|y| format!("{}-", y));
+    let since_s = options.since.clone();
+    let until_s = options.until.clone();
+    let msg_filter = |m: &UnifiedMessage| -> bool {
+        if let Some(ref yp) = year_prefix { if !m.date.starts_with(yp.as_str()) { return false; } }
+        if let Some(ref s) = since_s { if m.date.as_str() < s.as_str() { return false; } }
+        if let Some(ref u) = until_s { if m.date.as_str() > u.as_str() { return false; } }
+        true
+    };
+    let mut model_msgs: Vec<UnifiedMessage> = Vec::new();
+    scan_messages_streaming(
+        &home_dir, &clients, pricing.as_deref(), options.use_env_roots, &options.scanner_settings,
+        &msg_filter,
+        &mut |m: &UnifiedMessage| { model_msgs.push(m.clone()); },
     );
-
-    let filtered = filter_messages_for_report(all_messages, &options);
-    let entries = aggregate_model_usage_entries(filtered, &options.group_by);
+    let entries = aggregate_model_usage_entries(model_msgs, &options.group_by);
 
     let total_input: i64 = entries.iter().map(|e| e.input).sum();
     let total_output: i64 = entries.iter().map(|e| e.output).sum();
@@ -1596,48 +1621,44 @@ pub async fn get_monthly_report(options: ReportOptions) -> Result<MonthlyReport,
     let start = Instant::now();
 
     let home_dir = get_home_dir_string(&options.home_dir)?;
-
-    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
-        let mut clients: Vec<String> = ClientId::ALL
-            .iter()
-            .map(|c| c.as_str().to_string())
-            .collect();
-        clients.push("synthetic".to_string());
-        clients
-    });
+    let clients = resolve_report_clients(&options);
 
     let pricing = load_pricing_for_local_parse().await;
-    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
-        &home_dir,
-        &clients,
-        pricing.as_deref(),
-        options.use_env_roots,
-        &options.scanner_settings,
-    );
-
-    let filtered = filter_messages_for_report(all_messages, &options);
+    let year_prefix = options.year.as_ref().map(|y| format!("{}-", y));
+    let since_s = options.since.clone();
+    let until_s = options.until.clone();
+    let msg_filter = |m: &UnifiedMessage| -> bool {
+        if let Some(ref yp) = year_prefix { if !m.date.starts_with(yp.as_str()) { return false; } }
+        if let Some(ref s) = since_s { if m.date.as_str() < s.as_str() { return false; } }
+        if let Some(ref u) = until_s { if m.date.as_str() > u.as_str() { return false; } }
+        true
+    };
 
     let mut month_map: HashMap<String, MonthAggregator> = HashMap::new();
 
-    for msg in filtered {
-        let month = if msg.date.len() >= 7 {
-            msg.date[..7].to_string()
-        } else {
-            continue;
-        };
+    scan_messages_streaming(
+        &home_dir, &clients, pricing.as_deref(), options.use_env_roots, &options.scanner_settings,
+        &msg_filter,
+        &mut |msg: &UnifiedMessage| {
+            let month = if msg.date.len() >= 7 {
+                msg.date[..7].to_string()
+            } else {
+                return;
+            };
 
-        let entry = month_map.entry(month).or_default();
+            let entry = month_map.entry(month).or_default();
 
-        entry
-            .models
-            .insert(normalize_model_for_grouping(&msg.model_id));
-        entry.input += msg.tokens.input;
-        entry.output += msg.tokens.output;
-        entry.cache_read += msg.tokens.cache_read;
-        entry.cache_write += msg.tokens.cache_write;
-        entry.message_count += msg.message_count.max(0);
-        entry.cost += msg.cost;
-    }
+            entry
+                .models
+                .insert(normalize_model_for_grouping(&msg.model_id));
+            entry.input += msg.tokens.input;
+            entry.output += msg.tokens.output;
+            entry.cache_read += msg.tokens.cache_read;
+            entry.cache_write += msg.tokens.cache_write;
+            entry.message_count += msg.message_count.max(0);
+            entry.cost += msg.cost;
+        },
+    );
 
     let mut entries: Vec<MonthlyUsage> = month_map
         .into_iter()
@@ -1688,57 +1709,53 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
     let start = Instant::now();
 
     let home_dir = get_home_dir_string(&options.home_dir)?;
-
-    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
-        let mut clients: Vec<String> = ClientId::ALL
-            .iter()
-            .map(|c| c.as_str().to_string())
-            .collect();
-        clients.push("synthetic".to_string());
-        clients
-    });
+    let clients = resolve_report_clients(&options);
 
     let pricing = load_pricing_for_local_parse().await;
-    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
-        &home_dir,
-        &clients,
-        pricing.as_deref(),
-        options.use_env_roots,
-        &options.scanner_settings,
-    );
-
-    let filtered = filter_messages_for_report(all_messages, &options);
+    let year_prefix = options.year.as_ref().map(|y| format!("{}-", y));
+    let since_s = options.since.clone();
+    let until_s = options.until.clone();
+    let msg_filter = |m: &UnifiedMessage| -> bool {
+        if let Some(ref yp) = year_prefix { if !m.date.starts_with(yp.as_str()) { return false; } }
+        if let Some(ref s) = since_s { if m.date.as_str() < s.as_str() { return false; } }
+        if let Some(ref u) = until_s { if m.date.as_str() > u.as_str() { return false; } }
+        true
+    };
 
     let mut hour_map: HashMap<String, HourAggregator> = HashMap::new();
 
-    for msg in filtered {
-        let hour_key = if msg.timestamp > 0 {
-            let ts_secs = msg.timestamp / 1000;
-            match Local.timestamp_opt(ts_secs, 0) {
-                chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d %H:00").to_string(),
-                _ => format!("{} 00:00", msg.date),
+    scan_messages_streaming(
+        &home_dir, &clients, pricing.as_deref(), options.use_env_roots, &options.scanner_settings,
+        &msg_filter,
+        &mut |msg: &UnifiedMessage| {
+            let hour_key = if msg.timestamp > 0 {
+                let ts_secs = msg.timestamp / 1000;
+                match Local.timestamp_opt(ts_secs, 0) {
+                    chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d %H:00").to_string(),
+                    _ => format!("{} 00:00", msg.date),
+                }
+            } else {
+                format!("{} 00:00", msg.date)
+            };
+
+            let entry = hour_map.entry(hour_key).or_default();
+
+            entry.clients.insert(msg.client.clone());
+            entry
+                .models
+                .insert(normalize_model_for_grouping(&msg.model_id));
+            entry.input += msg.tokens.input;
+            entry.output += msg.tokens.output;
+            entry.cache_read += msg.tokens.cache_read;
+            entry.cache_write += msg.tokens.cache_write;
+            entry.reasoning += msg.tokens.reasoning;
+            entry.message_count += msg.message_count.max(0);
+            if msg.is_turn_start {
+                entry.turn_count += 1;
             }
-        } else {
-            format!("{} 00:00", msg.date)
-        };
-
-        let entry = hour_map.entry(hour_key).or_default();
-
-        entry.clients.insert(msg.client.clone());
-        entry
-            .models
-            .insert(normalize_model_for_grouping(&msg.model_id));
-        entry.input += msg.tokens.input;
-        entry.output += msg.tokens.output;
-        entry.cache_read += msg.tokens.cache_read;
-        entry.cache_write += msg.tokens.cache_write;
-        entry.reasoning += msg.tokens.reasoning;
-        entry.message_count += msg.message_count.max(0);
-        if msg.is_turn_start {
-            entry.turn_count += 1;
-        }
-        entry.cost += msg.cost;
-    }
+            entry.cost += msg.cost;
+        },
+    );
 
     let mut entries: Vec<HourlyUsage> = hour_map
         .into_iter()
@@ -1776,6 +1793,392 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
     })
 }
 
+/// Streaming scan driver — mirrors `parse_all_messages_with_pricing_with_env_strategy`
+/// but never materialises a full-history `Vec<UnifiedMessage>`.
+///
+/// For file-backed lanes with a cache hit: iterates `cached.messages` by
+/// reference (one clone per message, not one clone of the whole Vec), applies
+/// pricing on the temporary copy, and immediately calls `sink`.  Peak memory
+/// per lane is O(messages_in_that_file), not O(sum_of_all_files).
+///
+/// Cross-file dedup_key gate and trae keep-latest buffer both live here so
+/// both the day-aggregator and the sessionize accumulator see a consistent,
+/// de-duplicated stream.  `filter` is applied after dedup gate.
+///
+/// `sink` receives each final message exactly once.  Trae winners are flushed
+/// at the very end (after all other lanes), matching `StreamingAggregator`
+/// semantics.
+fn scan_messages_streaming<F, S>(
+    home_dir: &str,
+    clients: &[String],
+    pricing: Option<&pricing::PricingService>,
+    use_env_roots: bool,
+    scanner_settings: &scanner::ScannerSettings,
+    filter: &F,
+    sink: &mut S,
+)
+where
+    F: Fn(&UnifiedMessage) -> bool,
+    S: FnMut(&UnifiedMessage),
+{
+    let scan_result = scanner::scan_all_clients_with_scanner_settings(
+        home_dir,
+        clients,
+        use_env_roots,
+        scanner_settings,
+    );
+    let headless_roots = scanner::headless_roots_with_env_strategy(home_dir, use_env_roots);
+    let mut source_cache = message_cache::SourceMessageCache::load();
+    source_cache.prune_missing_files();
+
+    let include_all = clients.is_empty();
+    let include_synthetic = include_all || clients.iter().any(|c| c == "synthetic");
+    let requested: HashSet<&str> = clients.iter().map(String::as_str).collect();
+
+    // Inline helper: should this message pass the client filter?
+    let passes_client = |m: &UnifiedMessage| -> bool {
+        include_all
+            || retain_for_requested_clients(&m.client, &m.model_id, &m.provider_id, &requested)
+    };
+
+    // Cross-file dedup gate shared across non-trae, non-opencode, non-claude, non-codex lanes.
+    let mut seen_keys: HashSet<String> = HashSet::new();
+
+    // Trae keep-latest buffer — flushed after all other lanes.
+    let mut trae_latest: HashMap<String, UnifiedMessage> = HashMap::new();
+
+    // ---- OpenCode SQLite ----
+    let mut opencode_seen: HashSet<String> = HashSet::new();
+    for db_path in &scan_result.opencode_dbs {
+        for mut m in sessions::opencode::parse_opencode_sqlite(db_path) {
+            apply_pricing_if_available(&mut m, pricing);
+            let keep = m.dedup_key.as_ref().is_none_or(|k| dedup_gate_passes(k, &mut opencode_seen));
+            if keep && passes_client(&m) && filter(&m) { sink(&m); }
+        }
+    }
+    // OpenCode JSON legacy
+    let opencode_parsed: Vec<Vec<UnifiedMessage>> = scan_result
+        .get(ClientId::OpenCode)
+        .par_iter()
+        .map(|path| sessions::opencode::parse_opencode_file(path).into_iter().collect::<Vec<_>>())
+        .collect();
+    for msgs in opencode_parsed {
+        for mut m in msgs {
+            apply_pricing_if_available(&mut m, pricing);
+            let keep = m.dedup_key.as_ref().is_none_or(|k| dedup_gate_passes(k, &mut opencode_seen));
+            if keep && passes_client(&m) && filter(&m) { sink(&m); }
+        }
+    }
+
+    // ---- Claude Code JSONL (cache-aware, reference-iterate on hit) ----
+    let claude_home = PathBuf::from(home_dir);
+    let mut claude_seen: HashSet<String> = HashSet::new();
+    for path in scan_result.get(ClientId::Claude) {
+        let fp = message_cache::SourceFingerprint::from_claude_code_path_with_home(path, Some(&claude_home));
+        let cache_hit = fp.as_ref().and_then(|fp| source_cache.get(path).filter(|c| &c.fingerprint == fp && !c.messages.is_empty()));
+        if let Some(cached) = cache_hit {
+            for msg in cached.messages.iter() {
+                let mut m = msg.clone();
+                m.refresh_derived_fields();
+                apply_pricing_if_available(&mut m, pricing);
+                if !passes_client(&m) { continue; }
+                let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut claude_seen));
+                if keep && filter(&m) { sink(&m); }
+            }
+        } else {
+            let msgs = sessions::claudecode::parse_claude_file_with_home(path, Some(&claude_home));
+            for mut m in msgs {
+                apply_pricing_if_available(&mut m, pricing);
+                if !passes_client(&m) { continue; }
+                let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut claude_seen));
+                if keep && filter(&m) { sink(&m); }
+            }
+        }
+    }
+
+    // ---- Codex JSONL (cache-aware, headless-aware) ----
+    let mut codex_seen: HashSet<String> = HashSet::new();
+    for path in scan_result.get(ClientId::Codex) {
+        let fp = message_cache::SourceFingerprint::from_path(path);
+        let cache_hit = fp.as_ref().and_then(|fp| source_cache.get(path).filter(|c| &c.fingerprint == fp));
+        if let Some(cached) = cache_hit {
+            let is_headless = is_headless_path(path, &headless_roots);
+            let fallback_ts = sessions::utils::file_modified_timestamp_ms(path);
+            let fti = &cached.fallback_timestamp_indices;
+            for (idx, msg) in cached.messages.iter().enumerate() {
+                let mut m = msg.clone();
+                if fti.contains(&idx) { m.set_timestamp(fallback_ts); } else { m.refresh_derived_fields(); }
+                apply_pricing_if_available(&mut m, pricing);
+                apply_headless_agent(&mut m, is_headless);
+                if !passes_client(&m) { continue; }
+                let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut codex_seen));
+                if keep && filter(&m) { sink(&m); }
+            }
+        } else {
+            let is_headless = is_headless_path(path, &headless_roots);
+            let fallback_ts = sessions::utils::file_modified_timestamp_ms(path);
+            let parsed = sessions::codex::parse_codex_file_incremental(
+                path, 0, sessions::codex::CodexParseState::default(),
+            );
+            let mut msgs = parsed.messages;
+            for idx in &parsed.fallback_timestamp_indices {
+                if let Some(m) = msgs.get_mut(*idx) { m.set_timestamp(fallback_ts); }
+            }
+            for mut m in msgs {
+                apply_pricing_if_available(&mut m, pricing);
+                apply_headless_agent(&mut m, is_headless);
+                if !passes_client(&m) { continue; }
+                let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut codex_seen));
+                if keep && filter(&m) { sink(&m); }
+            }
+        }
+    }
+
+    // ---- Simple file-backed lanes (shared seen_keys, cache-aware) ----
+    // Cache hit  → iterate cached.messages by reference (one clone per message),
+    //              refresh_derived_fields, apply pricing, dedup, filter, sink.
+    // Cache miss → par-collect parse results, then sequential: writeback + emit.
+    // Mirrors load_or_parse_source semantics from parse_all_messages_with_pricing_with_env_strategy.
+    macro_rules! simple_lane {
+        ($client_id:expr, $parse_fn:expr) => {{
+            // Separate paths into cache-hit (emit immediately) vs cache-miss (par-parse).
+            let mut miss_paths: Vec<&PathBuf> = Vec::new();
+            for path in scan_result.get($client_id) {
+                let fp = message_cache::SourceFingerprint::from_path(path);
+                let cache_hit = fp.as_ref().and_then(|fp| {
+                    source_cache.get(path).filter(|c| c.fingerprint == *fp && !c.messages.is_empty())
+                });
+                if let Some(cached) = cache_hit {
+                    for msg in cached.messages.iter() {
+                        let mut m = msg.clone();
+                        m.refresh_derived_fields();
+                        apply_pricing_if_available(&mut m, pricing);
+                        if !passes_client(&m) { continue; }
+                        let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut seen_keys));
+                        if keep && filter(&m) { sink(&m); }
+                    }
+                } else {
+                    miss_paths.push(path);
+                }
+            }
+            // Par-parse all cache-miss files, then sequential writeback + emit.
+            let parsed_misses: Vec<(&PathBuf, Vec<UnifiedMessage>)> = miss_paths
+                .par_iter()
+                .map(|path| (*path, $parse_fn(*path)))
+                .collect();
+            for (path, msgs) in parsed_misses {
+                if !msgs.is_empty() {
+                    if let Some(fp) = message_cache::SourceFingerprint::from_path(path) {
+                        let entry = message_cache::CachedSourceEntry::new(
+                            path, fp, msgs.clone(), Vec::new(), None,
+                        );
+                        source_cache.insert(entry);
+                    }
+                }
+                for mut m in msgs {
+                    apply_pricing_if_available(&mut m, pricing);
+                    if !passes_client(&m) { continue; }
+                    let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut seen_keys));
+                    if keep && filter(&m) { sink(&m); }
+                }
+            }
+        }};
+    }
+    simple_lane!(ClientId::Copilot,   sessions::copilot::parse_copilot_file);
+    simple_lane!(ClientId::Cursor,    sessions::cursor::parse_cursor_file);
+    simple_lane!(ClientId::Warp,      sessions::warp::parse_warp_file);
+    simple_lane!(ClientId::Amp,       sessions::amp::parse_amp_file);
+    simple_lane!(ClientId::Codebuff,  sessions::codebuff::parse_codebuff_file);
+    simple_lane!(ClientId::Droid,     sessions::droid::parse_droid_file);
+    simple_lane!(ClientId::OpenClaw,  sessions::openclaw::parse_openclaw_transcript);
+    simple_lane!(ClientId::Pi,        sessions::pi::parse_pi_file);
+    simple_lane!(ClientId::Kimi,      sessions::kimi::parse_kimi_file);
+    simple_lane!(ClientId::Qwen,      sessions::qwen::parse_qwen_file);
+    simple_lane!(ClientId::RooCode,   sessions::roocode::parse_roocode_file);
+    simple_lane!(ClientId::KiloCode,  sessions::kilocode::parse_kilocode_file);
+    simple_lane!(ClientId::Mux,       sessions::mux::parse_mux_file);
+    simple_lane!(ClientId::Kiro,      sessions::kiro::parse_kiro_file);
+
+    // ---- Gemini (cache-aware with invalidate_cache semantics) ----
+    // Uses load_or_parse_source_with_fingerprint_and_policy equivalent:
+    // cacheable=false → remove stale cache entry (invalidate_cache).
+    {
+        let mut gemini_miss_paths: Vec<&PathBuf> = Vec::new();
+        for path in scan_result.get(ClientId::Gemini) {
+            let fp = message_cache::SourceFingerprint::from_path(path);
+            let cache_hit = fp.as_ref().and_then(|fp| {
+                source_cache.get(path).filter(|c| c.fingerprint == *fp && !c.messages.is_empty())
+            });
+            if let Some(cached) = cache_hit {
+                for msg in cached.messages.iter() {
+                    let mut m = msg.clone();
+                    m.refresh_derived_fields();
+                    apply_pricing_if_available(&mut m, pricing);
+                    if !passes_client(&m) { continue; }
+                    let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut seen_keys));
+                    if keep && filter(&m) { sink(&m); }
+                }
+            } else {
+                gemini_miss_paths.push(path);
+            }
+        }
+        let gemini_parsed: Vec<(&PathBuf, sessions::gemini::GeminiParseResult)> = gemini_miss_paths
+            .par_iter()
+            .map(|path| (*path, sessions::gemini::parse_gemini_file_with_cache_status(path)))
+            .collect();
+        for (path, parsed) in gemini_parsed {
+            if parsed.cacheable && !parsed.messages.is_empty() {
+                if let Some(fp) = message_cache::SourceFingerprint::from_path(path) {
+                    let entry = message_cache::CachedSourceEntry::new(
+                        path, fp, parsed.messages.clone(), Vec::new(), None,
+                    );
+                    source_cache.insert(entry);
+                }
+            } else if !parsed.cacheable {
+                source_cache.remove(path);
+            }
+            for mut m in parsed.messages {
+                apply_pricing_if_available(&mut m, pricing);
+                if !passes_client(&m) { continue; }
+                let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut seen_keys));
+                if keep && filter(&m) { sink(&m); }
+            }
+        }
+    }
+
+    // ---- Kilo SQLite ----
+    if let Some(db_path) = &scan_result.kilo_db {
+        for mut m in sessions::kilo::parse_kilo_sqlite(db_path) {
+            apply_pricing_if_available(&mut m, pricing);
+            if passes_client(&m) && filter(&m) { sink(&m); }
+        }
+    }
+
+    // ---- Hermes SQLite (own dedup set) ----
+    {
+        let mut hermes_seen: HashSet<String> = HashSet::new();
+        for db_path in scan_result.hermes_db_paths() {
+            for m in parse_hermes_sqlite_with_pricing(&db_path, pricing) {
+                if !passes_client(&m) { continue; }
+                let keep = m.dedup_key.as_ref().is_none_or(|k| k.is_empty() || dedup_gate_passes(k, &mut hermes_seen));
+                if keep && filter(&m) { sink(&m); }
+            }
+        }
+    }
+
+    // ---- Goose SQLite ----
+    if let Some(db_path) = &scan_result.goose_db {
+        for mut m in sessions::goose::parse_goose_sqlite(db_path) {
+            apply_pricing_if_available(&mut m, pricing);
+            if passes_client(&m) && filter(&m) { sink(&m); }
+        }
+    }
+
+    // ---- Zed SQLite (cache-aware reference-iterate) ----
+    for db_path in scan_result.zed_db_paths() {
+        let fp = message_cache::SourceFingerprint::from_sqlite_path(&db_path);
+        let cache_hit = fp.as_ref().and_then(|fp| source_cache.get(&db_path).filter(|c| &c.fingerprint == fp));
+        if let Some(cached) = cache_hit {
+            for msg in cached.messages.iter() {
+                let mut m = msg.clone();
+                m.refresh_derived_fields();
+                apply_pricing_if_available(&mut m, pricing);
+                if passes_client(&m) && filter(&m) { sink(&m); }
+            }
+        } else {
+            for mut m in sessions::zed::parse_zed_sqlite(&db_path) {
+                apply_pricing_if_available(&mut m, pricing);
+                if passes_client(&m) && filter(&m) { sink(&m); }
+            }
+        }
+    }
+
+    // ---- Kiro SQLite ----
+    if let Some(db_path) = &scan_result.kiro_db {
+        for mut m in sessions::kiro::parse_kiro_sqlite(db_path) {
+            apply_pricing_if_available(&mut m, pricing);
+            if passes_client(&m) && filter(&m) { sink(&m); }
+        }
+    }
+
+    // ---- Crush SQLite ----
+    for source in &scan_result.crush_dbs {
+        for mut m in sessions::crush::parse_crush_sqlite(&source.db_path) {
+            m.set_workspace(source.workspace_key.clone(), source.workspace_label.clone());
+            apply_pricing_if_available(&mut m, pricing);
+            if passes_client(&m) && filter(&m) { sink(&m); }
+        }
+    }
+
+    // ---- Antigravity ----
+    {
+        let parsed: Vec<Vec<UnifiedMessage>> = scan_result
+            .get(ClientId::Antigravity)
+            .par_iter()
+            .map(|path| sessions::antigravity::parse_antigravity_file(path))
+            .collect();
+        for msgs in parsed {
+            for mut m in msgs {
+                apply_pricing_if_available(&mut m, pricing);
+                if passes_client(&m) && filter(&m) { sink(&m); }
+            }
+        }
+    }
+
+    // ---- Trae (keep-latest per session_id, buffer — flushed below) ----
+    {
+        let trae_raw: Vec<UnifiedMessage> = scan_result
+            .get(ClientId::Trae)
+            .par_iter()
+            .flat_map(|path| sessions::trae::parse_trae_file("trae", path))
+            .collect();
+        for m in trae_raw {
+            let entry = trae_latest.entry(m.session_id.clone());
+            match entry {
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    let existing = slot.get();
+                    let replace = m.timestamp > existing.timestamp
+                        || (m.timestamp == existing.timestamp
+                            && m.dedup_key.as_ref().is_some_and(|k| {
+                                existing.dedup_key.as_ref().is_none_or(|ek| k.as_str() > ek.as_str())
+                            }));
+                    if replace { *slot.get_mut() = m; }
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => { slot.insert(m); }
+            }
+        }
+    }
+
+    // ---- Synthetic ----
+    if let Some(db_path) = scan_result.synthetic_db.as_ref().filter(|_| include_synthetic) {
+        let fp = message_cache::SourceFingerprint::from_sqlite_path(db_path);
+        let cache_hit = fp.as_ref().and_then(|fp| source_cache.get(db_path).filter(|c| &c.fingerprint == fp));
+        if let Some(cached) = cache_hit {
+            for msg in cached.messages.iter() {
+                let mut m = msg.clone();
+                m.refresh_derived_fields();
+                apply_pricing_if_available(&mut m, pricing);
+                sessions::synthetic::normalize_synthetic_gateway_fields(&mut m.model_id, &mut m.provider_id);
+                if passes_client(&m) && filter(&m) { sink(&m); }
+            }
+        } else {
+            for mut m in sessions::synthetic::parse_octofriend_sqlite(db_path) {
+                apply_pricing_if_available(&mut m, pricing);
+                sessions::synthetic::normalize_synthetic_gateway_fields(&mut m.model_id, &mut m.provider_id);
+                if passes_client(&m) && filter(&m) { sink(&m); }
+            }
+        }
+    }
+
+    // ---- Flush trae keep-latest (after all other lanes) ----
+    for m in trae_latest.into_values() {
+        if passes_client(&m) && filter(&m) { sink(&m); }
+    }
+
+    source_cache.save_if_dirty();
+}
+
+
 async fn generate_graph_with_loaded_pricing(
     options: ReportOptions,
     pricing: Option<&pricing::PricingService>,
@@ -1783,32 +2186,50 @@ async fn generate_graph_with_loaded_pricing(
     let start = Instant::now();
 
     let home_dir = get_home_dir_string(&options.home_dir)?;
+    let clients = resolve_report_clients(&options);
 
-    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
-        let mut clients: Vec<String> = ClientId::ALL
-            .iter()
-            .map(|c| c.as_str().to_string())
-            .collect();
-        clients.push("synthetic".to_string());
-        clients
-    });
+    // Build filter closure from report options (year/since/until).
+    let year_prefix = options.year.as_ref().map(|y| format!("{}-", y));
+    let since_s = options.since.clone();
+    let until_s = options.until.clone();
+    let msg_filter = |m: &UnifiedMessage| -> bool {
+        if let Some(ref yp) = year_prefix {
+            if !m.date.starts_with(yp.as_str()) { return false; }
+        }
+        if let Some(ref s) = since_s {
+            if m.date.as_str() < s.as_str() { return false; }
+        }
+        if let Some(ref u) = until_s {
+            if m.date.as_str() > u.as_str() { return false; }
+        }
+        true
+    };
 
-    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
+    // Dual-sink: day aggregator + sessionize accumulator fed in one pass.
+    // scan_messages_streaming handles all dedup (trae keep-latest + dedup_key gate).
+    // StreamingAggregator.feed_pre_deduped() bypasses its internal dedup gate
+    // since the driver already guarantees uniqueness.
+    let mut day_agg = aggregator::StreamingAggregator::new();
+    let mut sess_agg = sessionize::SessionizeAccumulator::new();
+
+    scan_messages_streaming(
         &home_dir,
         &clients,
         pricing,
         options.use_env_roots,
         &options.scanner_settings,
+        &msg_filter,
+        &mut |m: &UnifiedMessage| {
+            day_agg.feed_pre_deduped(m);
+            sess_agg.feed(m);
+        },
     );
 
-    let filtered = filter_messages_for_report(all_messages, &options);
-
-    let intervals = sessionize::sessionize(&filtered, sessionize::DEFAULT_IDLE_GAP_MS);
+    let contributions = day_agg.finalize();
+    let intervals = sess_agg.finalize(sessionize::DEFAULT_IDLE_GAP_MS);
     let time_metrics =
         sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
-
     let daily_active_time = sessionize::compute_daily_active_time(&intervals);
-    let contributions = aggregator::aggregate_by_date(filtered);
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
     let mut result = aggregator::generate_graph_result(contributions, processing_time_ms);
@@ -1833,27 +2254,24 @@ pub async fn get_time_metrics_report(options: ReportOptions) -> Result<TimeMetri
     let start = Instant::now();
 
     let home_dir = get_home_dir_string(&options.home_dir)?;
+    let clients = resolve_report_clients(&options);
 
-    let clients: Vec<String> = options.clients.clone().unwrap_or_else(|| {
-        let mut clients: Vec<String> = ClientId::ALL
-            .iter()
-            .map(|c| c.as_str().to_string())
-            .collect();
-        clients.push("synthetic".to_string());
-        clients
-    });
-
-    let all_messages = parse_all_messages_with_pricing_with_env_strategy(
-        &home_dir,
-        &clients,
-        None,
-        options.use_env_roots,
-        &options.scanner_settings,
+    let year_prefix = options.year.as_ref().map(|y| format!("{}-", y));
+    let since_s = options.since.clone();
+    let until_s = options.until.clone();
+    let msg_filter = |m: &UnifiedMessage| -> bool {
+        if let Some(ref yp) = year_prefix { if !m.date.starts_with(yp.as_str()) { return false; } }
+        if let Some(ref s) = since_s { if m.date.as_str() < s.as_str() { return false; } }
+        if let Some(ref u) = until_s { if m.date.as_str() > u.as_str() { return false; } }
+        true
+    };
+    let mut sess_agg = sessionize::SessionizeAccumulator::new();
+    scan_messages_streaming(
+        &home_dir, &clients, None, options.use_env_roots, &options.scanner_settings,
+        &msg_filter,
+        &mut |m: &UnifiedMessage| { sess_agg.feed(m); },
     );
-
-    let filtered = filter_messages_for_report(all_messages, &options);
-
-    let intervals = sessionize::sessionize(&filtered, sessionize::DEFAULT_IDLE_GAP_MS);
+    let intervals = sess_agg.finalize(sessionize::DEFAULT_IDLE_GAP_MS);
     let metrics = sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
 
     Ok(TimeMetricsReport {
@@ -1872,26 +2290,21 @@ pub async fn generate_local_graph_report(options: ReportOptions) -> Result<Graph
     generate_graph_with_loaded_pricing(options, pricing.as_deref()).await
 }
 
-fn filter_messages_for_report(
-    messages: Vec<UnifiedMessage>,
-    options: &ReportOptions,
-) -> Vec<UnifiedMessage> {
-    let mut filtered = messages;
-
-    if let Some(year) = &options.year {
-        let year_prefix = format!("{}-", year);
-        filtered.retain(|m| m.date.starts_with(&year_prefix));
-    }
-
-    if let Some(since) = &options.since {
-        filtered.retain(|m| m.date.as_str() >= since.as_str());
-    }
-
-    if let Some(until) = &options.until {
-        filtered.retain(|m| m.date.as_str() <= until.as_str());
-    }
-
-    filtered
+/// Streaming graph entry-point.
+///
+/// Accepts an already-parsed message slice, applies an optional `since`
+/// date prefix filter (`msg.date.as_str() >= since`), then folds through
+/// `StreamingAggregator` and wraps the result via
+/// `aggregator::generate_graph_result`.
+pub fn build_graph_result_from_messages(
+    messages: &[UnifiedMessage],
+    since: Option<&str>,
+) -> GraphResult {
+    let iter = messages.iter().filter(|msg| {
+        since.is_none_or(|s| msg.date.as_str() >= s)
+    });
+    let contributions = aggregator::fold_messages_iter(iter);
+    aggregator::generate_graph_result(contributions, 0)
 }
 
 fn is_headless_path(path: &Path, headless_roots: &[PathBuf]) -> bool {
@@ -2677,10 +3090,11 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
 mod tests {
     use super::{
         aggregate_model_usage_entries, apply_pricing_if_available, dedupe_latest_trae_messages,
-        message_cache, normalize_model_for_grouping, parse_all_messages_with_pricing,
-        parse_local_clients, parsed_to_unified, pricing, retain_for_requested_clients, scanner,
-        select_local_parse_pricing, unified_to_parsed, ClientId, GroupBy, LocalParseOptions,
-        TokenBreakdown, UnifiedMessage, UNKNOWN_WORKSPACE_LABEL,
+        fold_messages_streaming, message_cache, normalize_model_for_grouping,
+        parse_all_messages_with_pricing, parse_local_clients, parsed_to_unified, pricing,
+        retain_for_requested_clients, scanner, select_local_parse_pricing, unified_to_parsed,
+        ClientId, GroupBy, LocalParseOptions, TokenBreakdown, UnifiedMessage,
+        UNKNOWN_WORKSPACE_LABEL,
     };
     use std::collections::{HashMap, HashSet};
     use std::io::Write;
@@ -6528,4 +6942,310 @@ mod tests {
         assert!(dates.contains(&local_date(thread_created + 2000)));
         assert!(dates.contains(&local_date(ledger_timestamp)));
     }
+
+    // =========================================================================
+    // fold_messages_streaming parity tests (RED — fold_messages_streaming not yet impl)
+    // =========================================================================
+
+    /// Deterministic UnifiedMessage fixture helper shared with parity tests.
+    /// Uses no real JSONL files; all fields are constructed inline.
+    #[cfg(test)]
+    fn parity_msg(
+        date: &str,
+        client: &str,
+        model: &str,
+        session_id: &str,
+        dedup_key: Option<&str>,
+        timestamp_ms: i64,
+        input: i64,
+        output: i64,
+        cost: f64,
+    ) -> crate::sessions::UnifiedMessage {
+        use crate::TokenBreakdown;
+        crate::sessions::UnifiedMessage {
+            client: client.to_string(),
+            model_id: model.to_string(),
+            provider_id: "anthropic".to_string(),
+            session_id: session_id.to_string(),
+            workspace_key: None,
+            workspace_label: None,
+            timestamp: timestamp_ms,
+            date: date.to_string(),
+            tokens: TokenBreakdown {
+                input,
+                output,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            },
+            cost,
+            duration_ms: None,
+            message_count: 1,
+            agent: None,
+            dedup_key: dedup_key.map(|s| s.to_string()),
+            is_turn_start: false,
+        }
+    }
+
+    // A/B parity: fold_messages_streaming output == aggregate_by_date output
+    // for the same deterministic fixture (no dedup_keys, no trae).
+    #[test]
+    fn test_fold_messages_streaming_parity_with_aggregate_by_date_no_dedup() {
+        let messages = vec![
+            parity_msg("2025-06-01", "claude", "claude-sonnet-4-5", "s1", None,
+                1_748_000_000_000, 100, 50, 0.01),
+            parity_msg("2025-06-01", "opencode", "gpt-4o", "s2", None,
+                1_748_000_001_000, 200, 100, 0.02),
+            parity_msg("2025-06-02", "codex", "gpt-5", "s3", None,
+                1_748_086_400_000, 400, 200, 0.04),
+        ];
+
+        // Reference: existing aggregate_by_date (clone-based)
+        let reference = crate::aggregator::aggregate_by_date(messages.clone());
+
+        // Subject: new streaming path
+        let streaming = fold_messages_streaming(&messages);
+
+        assert_eq!(
+            reference.len(), streaming.len(),
+            "parity: day bucket count must match"
+        );
+        for (ref_day, stream_day) in reference.iter().zip(streaming.iter()) {
+            assert_eq!(ref_day.date, stream_day.date, "parity: date must match");
+            assert_eq!(
+                ref_day.totals.tokens, stream_day.totals.tokens,
+                "parity: tokens must match for date {}", ref_day.date
+            );
+            assert!(
+                (ref_day.totals.cost - stream_day.totals.cost).abs() < 1e-9,
+                "parity: cost must match for date {}", ref_day.date
+            );
+            assert_eq!(
+                ref_day.totals.messages, stream_day.totals.messages,
+                "parity: message_count must match for date {}", ref_day.date
+            );
+        }
+    }
+
+    // A/B parity with cross-file dedup: fold_messages_streaming must apply
+    // the same dedup_key filtering as the existing pipeline does via seen_keys.
+    #[test]
+    fn test_fold_messages_streaming_parity_cross_file_dedup() {
+        // Construct messages that include a duplicated dedup_key pair.
+        // The existing pipeline filters duplicates via the seen_keys HashSet.
+        // fold_messages_streaming must produce the same counts.
+        let unique = parity_msg("2025-06-10", "claude", "claude-sonnet-4-5", "u1",
+            Some("unique-key-1"), 1_749_000_000_000, 300, 150, 0.06);
+        let dup_first = parity_msg("2025-06-10", "claude", "claude-sonnet-4-5", "d1",
+            Some("dup-key-shared"), 1_749_000_001_000, 200, 100, 0.04);
+        let dup_second = parity_msg("2025-06-10", "claude", "claude-haiku-4-5", "d2",
+            Some("dup-key-shared"), 1_749_000_002_000, 200, 100, 0.04);
+
+        // The reference pipeline keeps only the first occurrence of dup-key-shared
+        // (seen_keys.insert returns false on second) — 2 messages total.
+        let all_msgs = vec![unique.clone(), dup_first.clone(), dup_second.clone()];
+
+        let streaming = fold_messages_streaming(&all_msgs);
+
+        assert_eq!(streaming.len(), 1, "all on same date -> 1 bucket");
+        assert_eq!(
+            streaming[0].totals.messages, 2,
+            "parity: duplicate dedup_key must reduce count from 3 to 2"
+        );
+        assert!(
+            (streaming[0].totals.cost - 0.10).abs() < 1e-9,
+            "parity: cost must exclude the duplicate message"
+        );
+    }
+
+    // =========================================================================
+    // Phase 2 RED tests: build_graph_result_from_messages streaming entry-point
+    // =========================================================================
+    //
+    // `build_graph_result_from_messages` does NOT exist yet.  These tests
+    // define the observable contract that the GREEN implementation must satisfy:
+    //   - accept a `&[UnifiedMessage]` slice and an optional `since` date string
+    //   - apply the `since` post-parse filter (date string prefix comparison,
+    //     same semantics as `filter_messages_for_report`)
+    //   - drive aggregation via `StreamingAggregator` (zero-clone fold path)
+    //   - return a `GraphResult` whose per-day tokens/cost match the reference
+    //     `aggregate_by_date` pipeline exactly (zero tolerance)
+    //
+    // All three tests will produce a **compile error** until the function is
+    // declared in lib.rs, which is the required RED state.
+
+    use crate::GraphResult;
+
+    /// Multi-client, multi-day fixture: streaming path total tokens and cost
+    /// per daily bucket must match hand-computed expected values.
+    ///
+    /// Hardcoded expected values — calculation:
+    ///
+    /// 2025-06-01 (no dedup):
+    ///   s1: input=500, output=250 → tokens=750, cost=0.05
+    ///   s2: input=300, output=150 → tokens=450, cost=0.03
+    ///   TOTAL: tokens=1200, cost=0.08, messages=2
+    ///
+    /// 2025-06-02 (trae session dedup — same session_id="trae-sess"):
+    ///   trae-k1: ts=1_748_822_400_000, input=100, output=50  → tokens=150, cost=0.01
+    ///   trae-k2: ts=1_748_822_500_000, input=200, output=100 → tokens=300, cost=0.02
+    ///   StreamingAggregator keeps latest timestamp → trae-k2 wins
+    ///   TOTAL: tokens=300, cost=0.02, messages=1
+    ///
+    /// 2025-06-03 (cross-file dedup_key — both carry "dup-phase2"):
+    ///   d1: input=400, output=200 → tokens=600, cost=0.04  (first seen — kept)
+    ///   d2: input=400, output=200 → tokens=600, cost=0.04  (same dedup_key — dropped)
+    ///   TOTAL: tokens=600, cost=0.04, messages=1
+    #[test]
+    fn test_build_graph_result_from_messages_matches_aggregate_by_date() {
+        let messages = vec![
+            // Day 2025-06-01: two clients, no dedup
+            parity_msg("2025-06-01", "claude", "claude-sonnet-4-5", "s1", None,
+                1_748_736_000_000, 500, 250, 0.05),
+            parity_msg("2025-06-01", "opencode", "gpt-4o", "s2", None,
+                1_748_736_001_000, 300, 150, 0.03),
+            // Day 2025-06-02: trae dedup by session_id — two entries same session, keep latest
+            parity_msg("2025-06-02", "trae", "gpt-5.2", "trae-sess", Some("trae-k1"),
+                1_748_822_400_000, 100, 50, 0.01),
+            parity_msg("2025-06-02", "trae", "gpt-5.2", "trae-sess", Some("trae-k2"),
+                1_748_822_500_000, 200, 100, 0.02),   // newer timestamp -> wins
+            // Day 2025-06-03: cross-file dedup pair — same dedup_key, second dropped
+            parity_msg("2025-06-03", "claude", "claude-haiku-4-5", "d1",
+                Some("dup-phase2"), 1_748_908_800_000, 400, 200, 0.04),
+            parity_msg("2025-06-03", "claude", "claude-haiku-4-5", "d2",
+                Some("dup-phase2"), 1_748_908_801_000, 400, 200, 0.04), // same dedup_key -> discarded
+        ];
+
+        // Subject: new streaming entry-point
+        let result: GraphResult =
+            crate::build_graph_result_from_messages(&messages, None);
+
+        // Verify bucket count: 3 distinct dates
+        assert_eq!(
+            result.contributions.len(), 3,
+            "phase2 streaming: must produce exactly 3 daily buckets"
+        );
+
+        // Locate each day bucket by date (sort order: ascending)
+        let day1 = result.contributions.iter().find(|c| c.date == "2025-06-01")
+            .expect("phase2: 2025-06-01 bucket must exist");
+        let day2 = result.contributions.iter().find(|c| c.date == "2025-06-02")
+            .expect("phase2: 2025-06-02 bucket must exist");
+        let day3 = result.contributions.iter().find(|c| c.date == "2025-06-03")
+            .expect("phase2: 2025-06-03 bucket must exist");
+
+        // 2025-06-01: s1 (750) + s2 (450) = 1200 tokens, 0.05+0.03=0.08 cost, 2 messages
+        assert_eq!(day1.totals.tokens, 1200,
+            "2025-06-01: tokens must be 750+450=1200");
+        assert!(
+            (day1.totals.cost - 0.08).abs() < 1e-9,
+            "2025-06-01: cost must be 0.05+0.03=0.08"
+        );
+        assert_eq!(day1.totals.messages, 2,
+            "2025-06-01: both non-trae non-dedup messages must be counted");
+
+        // 2025-06-02: trae session dedup — trae-k2 wins (larger timestamp)
+        // trae-k2: input=200, output=100 -> tokens=300, cost=0.02
+        assert_eq!(day2.totals.tokens, 300,
+            "2025-06-02: trae dedup — only winner (trae-k2, tokens=300) counted");
+        assert!(
+            (day2.totals.cost - 0.02).abs() < 1e-9,
+            "2025-06-02: trae dedup — cost must be 0.02 (trae-k2 only)"
+        );
+        assert_eq!(day2.totals.messages, 1,
+            "2025-06-02: trae dedup collapses 2 entries to 1 per session_id");
+
+        // 2025-06-03: cross-file dedup — d1 kept, d2 dropped (same dedup_key)
+        // d1: input=400, output=200 -> tokens=600, cost=0.04
+        assert_eq!(day3.totals.tokens, 600,
+            "2025-06-03: cross-file dedup — only d1 (tokens=600) counted, d2 dropped");
+        assert!(
+            (day3.totals.cost - 0.04).abs() < 1e-9,
+            "2025-06-03: cross-file dedup — cost must be 0.04 (d1 only)"
+        );
+        assert_eq!(day3.totals.messages, 1,
+            "2025-06-03: duplicate dedup_key dropped, 1 message retained");
+    }
+
+    /// `since` filter semantics: same fixture with `since = "2025-06-02"` must
+    /// produce only the 2025-06-02 and 2025-06-03 buckets, with their
+    /// token/cost totals matching a manually filtered reference.
+    #[test]
+    fn test_build_graph_result_from_messages_since_filter_excludes_earlier_dates() {
+        let messages = vec![
+            parity_msg("2025-06-01", "claude", "claude-sonnet-4-5", "s1", None,
+                1_748_736_000_000, 500, 250, 0.05),
+            parity_msg("2025-06-01", "opencode", "gpt-4o", "s2", None,
+                1_748_736_001_000, 300, 150, 0.03),
+            parity_msg("2025-06-02", "codex", "gpt-5", "s3", None,
+                1_748_822_400_000, 400, 200, 0.04),
+            parity_msg("2025-06-03", "claude", "claude-haiku-4-5", "s4", None,
+                1_748_908_800_000, 200, 100, 0.02),
+        ];
+
+        // Subject: streaming entry with since = "2025-06-02"
+        // (function does not exist yet -> RED compile error)
+        let result: GraphResult =
+            crate::build_graph_result_from_messages(&messages, Some("2025-06-02"));
+
+        // Only 2025-06-02 and 2025-06-03 must be present
+        assert_eq!(
+            result.contributions.len(), 2,
+            "since filter: must exclude 2025-06-01, leaving 2 buckets"
+        );
+
+        let dates: Vec<&str> = result.contributions.iter().map(|c| c.date.as_str()).collect();
+        assert!(dates.contains(&"2025-06-02"),
+            "since filter: 2025-06-02 bucket must be present");
+        assert!(dates.contains(&"2025-06-03"),
+            "since filter: 2025-06-03 bucket must be present");
+        assert!(!dates.contains(&"2025-06-01"),
+            "since filter: 2025-06-01 bucket must be absent");
+
+        // 2025-06-02 token total: input 400 + output 200 = 600
+        let day2 = result.contributions.iter().find(|c| c.date == "2025-06-02").unwrap();
+        assert_eq!(day2.totals.tokens, 600,
+            "since filter: 2025-06-02 token total must be 600");
+        assert!(
+            (day2.totals.cost - 0.04).abs() < 1e-9,
+            "since filter: 2025-06-02 cost must be 0.04"
+        );
+    }
+
+    /// Trae dedup in streaming path: two messages for the same trae session
+    /// (same `session_id`, different `dedup_key`, later timestamp wins) must
+    /// produce exactly ONE message worth of tokens/cost in the daily bucket.
+    #[test]
+    fn test_build_graph_result_from_messages_trae_session_dedup_keeps_latest() {
+        let messages = vec![
+            // Earlier trae message (should be dropped)
+            parity_msg("2025-06-10", "trae", "gpt-5.2", "trae-sess-a", Some("trae-early"),
+                1_749_513_600_000, 100, 50, 0.01),
+            // Later trae message for same session_id (should win)
+            parity_msg("2025-06-10", "trae", "gpt-5.2", "trae-sess-a", Some("trae-late"),
+                1_749_513_700_000, 300, 150, 0.03),
+            // Non-trae message (should be included as-is)
+            parity_msg("2025-06-10", "claude", "claude-sonnet-4-5", "c1", None,
+                1_749_513_800_000, 200, 100, 0.02),
+        ];
+
+        // Subject: streaming entry (does not exist yet -> RED compile error)
+        let result: GraphResult =
+            crate::build_graph_result_from_messages(&messages, None);
+
+        assert_eq!(result.contributions.len(), 1,
+            "trae dedup: all messages on same date -> 1 bucket");
+
+        let day = &result.contributions[0];
+        // Kept messages: trae-late (tokens=450) + claude (tokens=300) = 750 total tokens
+        assert_eq!(day.totals.tokens, 750,
+            "trae dedup: token total must reflect only the winning trae entry (450) + claude (300)");
+        assert!(
+            (day.totals.cost - 0.05).abs() < 1e-9,
+            "trae dedup: cost must be 0.03 (latest trae) + 0.02 (claude) = 0.05"
+        );
+        assert_eq!(day.totals.messages, 2,
+            "trae dedup: message count must be 2 (1 trae winner + 1 claude)");
+    }
+
 }

--- a/vendor/tokscale-core/src/sessionize.rs
+++ b/vendor/tokscale-core/src/sessionize.rs
@@ -327,6 +327,103 @@ where
     }
 }
 
+/// Streaming accumulator that builds [`SessionInterval`]s one message at a time.
+///
+/// Equivalent to [`sessionize`] but does not require a materialised
+/// `&[UnifiedMessage]` slice.  Call [`SessionizeAccumulator::feed`] for each
+/// incoming message (timestamp ≤ 0 are silently skipped, matching the behaviour
+/// of [`sessionize`]), then call [`SessionizeAccumulator::finalize`] to obtain
+/// the sorted `Vec<SessionInterval>`.  Output is bit-for-bit identical to
+/// `sessionize(all_messages, idle_gap_ms)` for the same stream.
+pub struct SessionizeAccumulator {
+    groups: std::collections::HashMap<(String, String), SessionAcc>,
+}
+
+struct SessionAcc {
+    timestamps: Vec<i64>,
+    tokens: TokenBreakdown,
+    cost: f64,
+    message_count: i32,
+}
+
+impl Default for SessionizeAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionizeAccumulator {
+    pub fn new() -> Self {
+        Self {
+            groups: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Feed one message into the accumulator. Messages with timestamp ≤ 0 are
+    /// skipped (identical behaviour to [`sessionize`]).
+    pub fn feed(&mut self, msg: &UnifiedMessage) {
+        if msg.timestamp <= 0 {
+            return;
+        }
+        let key = (msg.client.clone(), msg.session_id.clone());
+        let acc = self.groups.entry(key).or_insert_with(|| SessionAcc {
+            timestamps: Vec::new(),
+            tokens: TokenBreakdown::default(),
+            cost: 0.0,
+            message_count: 0,
+        });
+        acc.timestamps.push(msg.timestamp);
+        acc.tokens.input += msg.tokens.input;
+        acc.tokens.output += msg.tokens.output;
+        acc.tokens.cache_read += msg.tokens.cache_read;
+        acc.tokens.cache_write += msg.tokens.cache_write;
+        acc.tokens.reasoning += msg.tokens.reasoning;
+        acc.cost += msg.cost;
+        acc.message_count += msg.message_count.max(1);
+    }
+
+    /// Consume the accumulator and produce a sorted `Vec<SessionInterval>`.
+    ///
+    /// Output is identical to [`sessionize`] called on the same messages.
+    pub fn finalize(self, idle_gap_ms: i64) -> Vec<SessionInterval> {
+        let mut intervals: Vec<SessionInterval> = Vec::with_capacity(self.groups.len());
+
+        for ((client, session_id), mut acc) in self.groups {
+            if acc.timestamps.is_empty() {
+                continue;
+            }
+            acc.timestamps.sort_unstable();
+
+            let start_ts = acc.timestamps[0];
+            let end_ts = *acc.timestamps.last().unwrap();
+            let wall_duration_ms = end_ts - start_ts;
+
+            let mut active_duration_ms: i64 = 0;
+            for w in acc.timestamps.windows(2) {
+                let gap = w[1] - w[0];
+                if gap <= idle_gap_ms {
+                    active_duration_ms += gap;
+                }
+            }
+
+            intervals.push(SessionInterval {
+                client,
+                session_id,
+                start_ts,
+                end_ts,
+                wall_duration_ms,
+                active_duration_ms,
+                message_count: acc.message_count,
+                tokens: acc.tokens,
+                cost: acc.cost,
+            });
+        }
+
+        intervals.sort_unstable_by_key(|s| s.start_ts);
+        intervals
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -629,4 +726,146 @@ mod tests {
         assert_eq!(daily.get("2026-01-02"), Some(&1_800_000));
         assert_eq!(daily.len(), 2);
     }
+    // =========================================================================
+    // SessionizeAccumulator parity tests
+    // =========================================================================
+
+    fn make_msg_full(
+        client: &str,
+        session_id: &str,
+        timestamp: i64,
+        input: i64,
+        output: i64,
+        cost: f64,
+        message_count: i32,
+    ) -> UnifiedMessage {
+        UnifiedMessage {
+            client: client.to_string(),
+            model_id: "model".to_string(),
+            provider_id: "provider".to_string(),
+            session_id: session_id.to_string(),
+            workspace_key: None,
+            workspace_label: None,
+            timestamp,
+            date: "2024-01-01".to_string(),
+            tokens: TokenBreakdown { input, output, cache_read: 0, cache_write: 0, reasoning: 0 },
+            cost,
+            message_count,
+            agent: None,
+            dedup_key: None,
+            is_turn_start: false,
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn test_sessionize_accumulator_empty() {
+        let acc = SessionizeAccumulator::new();
+        let result = acc.finalize(DEFAULT_IDLE_GAP_MS);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_sessionize_accumulator_parity_single_session() {
+        let msgs = vec![
+            make_msg("opencode", "s1", 1_000_000),
+            make_msg("opencode", "s1", 1_060_000),
+            make_msg("opencode", "s1", 1_120_000),
+        ];
+
+        let reference = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+
+        let mut acc = SessionizeAccumulator::new();
+        for m in &msgs { acc.feed(m); }
+        let result = acc.finalize(DEFAULT_IDLE_GAP_MS);
+
+        assert_eq!(reference.len(), result.len(), "session count must match");
+        assert_eq!(reference[0].start_ts,           result[0].start_ts);
+        assert_eq!(reference[0].end_ts,             result[0].end_ts);
+        assert_eq!(reference[0].wall_duration_ms,   result[0].wall_duration_ms);
+        assert_eq!(reference[0].active_duration_ms, result[0].active_duration_ms);
+        assert_eq!(reference[0].message_count,      result[0].message_count);
+    }
+
+    #[test]
+    fn test_sessionize_accumulator_parity_idle_gap() {
+        // Gap > threshold in the middle: first two close, last one far.
+        let msgs = vec![
+            make_msg("opencode", "ses1", 1_000_000),
+            make_msg("opencode", "ses1", 1_060_000),
+            make_msg("opencode", "ses1", 1_060_000 + 5 * 60_000), // 5 min gap
+        ];
+        let reference = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        let mut acc = SessionizeAccumulator::new();
+        for m in &msgs { acc.feed(m); }
+        let result = acc.finalize(DEFAULT_IDLE_GAP_MS);
+
+        assert_eq!(reference[0].active_duration_ms, result[0].active_duration_ms,
+            "active_duration_ms must match (idle gap excluded)");
+        assert_eq!(reference[0].wall_duration_ms, result[0].wall_duration_ms);
+    }
+
+    #[test]
+    fn test_sessionize_accumulator_parity_multi_session_multi_client() {
+        let msgs = vec![
+            make_msg("claude",   "s1", 1_000_000),
+            make_msg("claude",   "s1", 1_060_000),
+            make_msg("opencode", "s2", 1_000_000),
+            make_msg("opencode", "s2", 1_120_000),
+            make_msg("codex",    "s3", 2_000_000),
+        ];
+        let mut reference = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        let mut acc = SessionizeAccumulator::new();
+        for m in &msgs { acc.feed(m); }
+        let mut result = acc.finalize(DEFAULT_IDLE_GAP_MS);
+
+        assert_eq!(reference.len(), result.len(), "session count must match");
+        // Sort both by (client, session_id) for deterministic comparison
+        reference.sort_by(|a, b| a.client.cmp(&b.client).then(a.session_id.cmp(&b.session_id)));
+        result.sort_by(|a, b| a.client.cmp(&b.client).then(a.session_id.cmp(&b.session_id)));
+        for (r, a) in reference.iter().zip(result.iter()) {
+            assert_eq!(r.session_id, a.session_id, "session_id must match");
+            assert_eq!(r.start_ts, a.start_ts, "start_ts mismatch for session {}", r.session_id);
+            assert_eq!(r.wall_duration_ms, a.wall_duration_ms,
+                "wall_duration_ms mismatch for session {}", r.session_id);
+            assert_eq!(r.active_duration_ms, a.active_duration_ms,
+                "active_duration_ms mismatch for session {}", r.session_id);
+            assert_eq!(r.message_count, a.message_count,
+                "message_count mismatch for session {}", r.session_id);
+        }
+    }
+
+    #[test]
+    fn test_sessionize_accumulator_skips_zero_timestamp() {
+        let msgs = vec![
+            make_msg("opencode", "s1", 0),         // skipped
+            make_msg("opencode", "s1", 1_000_000), // kept
+        ];
+        let mut acc = SessionizeAccumulator::new();
+        for m in &msgs { acc.feed(m); }
+        let result = acc.finalize(DEFAULT_IDLE_GAP_MS);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].message_count, 1); // only non-zero counted
+    }
+
+    #[test]
+    fn test_sessionize_accumulator_parity_tokens_and_cost() {
+        let msgs = vec![
+            make_msg_full("claude", "s1", 1_000_000, 100, 50, 0.01, 1),
+            make_msg_full("claude", "s1", 1_060_000, 200, 80, 0.02, 2),
+        ];
+        let reference = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        let mut acc = SessionizeAccumulator::new();
+        for m in &msgs { acc.feed(m); }
+        let result = acc.finalize(DEFAULT_IDLE_GAP_MS);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(reference[0].tokens.input,  result[0].tokens.input,  "input tokens");
+        assert_eq!(reference[0].tokens.output, result[0].tokens.output, "output tokens");
+        assert!((reference[0].cost - result[0].cost).abs() < 1e-9, "cost");
+        assert_eq!(reference[0].message_count, result[0].message_count, "message_count");
+    }
+
+
 }

--- a/vendor/tokscale-core/tests/streaming_snapshot.rs
+++ b/vendor/tokscale-core/tests/streaming_snapshot.rs
@@ -10,6 +10,7 @@
 
 use tokscale_core::{StreamingAggregator, TokenBreakdown, UnifiedMessage};
 
+#[allow(clippy::too_many_arguments)]
 fn snapshot_msg(
     date: &str,
     client: &str,

--- a/vendor/tokscale-core/tests/streaming_snapshot.rs
+++ b/vendor/tokscale-core/tests/streaming_snapshot.rs
@@ -1,0 +1,178 @@
+// Integration tests for StreamingAggregator snapshot-isolation semantics.
+//
+// scenario: store_memo_snapshot (snapshot isolation)
+//
+// Spec MUST-DO: "遍歷中途 entries 變化唔影響本輪聚合"
+// The aggregator folds a snapshot of the message collection.  Any mutations to
+// the live collection that occur *after* the snapshot is captured (and while the
+// fold pass is in flight) MUST NOT affect the fold result.  This models the Arc
+// snapshot semantics of the STORE_MEMO driver.
+
+use tokscale_core::{StreamingAggregator, TokenBreakdown, UnifiedMessage};
+
+fn snapshot_msg(
+    date: &str,
+    client: &str,
+    model: &str,
+    session_id: &str,
+    dedup_key: Option<&str>,
+    timestamp_ms: i64,
+    input: i64,
+    output: i64,
+    cost: f64,
+) -> UnifiedMessage {
+    UnifiedMessage {
+        client: client.to_string(),
+        model_id: model.to_string(),
+        provider_id: "anthropic".to_string(),
+        session_id: session_id.to_string(),
+        workspace_key: None,
+        workspace_label: None,
+        timestamp: timestamp_ms,
+        date: date.to_string(),
+        tokens: TokenBreakdown {
+            input,
+            output,
+            cache_read: 0,
+            cache_write: 0,
+            reasoning: 0,
+        },
+        cost,
+        duration_ms: None,
+        message_count: 1,
+        agent: None,
+        dedup_key: dedup_key.map(|s| s.to_string()),
+        is_turn_start: false,
+    }
+}
+
+// scenario: store_memo_snapshot (snapshot isolation)
+// Verifies that mutations to the originating collection after the snapshot
+// clone is taken do NOT affect the fold result produced by StreamingAggregator.
+//
+// Expected values (hand-computed):
+//   hermes (snap-key-1): input=400, output=200 → tokens=600, cost=0.07
+//   zed    (snap-key-2): input=200, output=100 → tokens=300, cost=0.03
+//   claude (no dedup)  : input=100, output=50  → tokens=150, cost=0.01
+//   TOTAL: tokens=600+300+150=1050, cost=0.07+0.03+0.01=0.11, messages=3
+//
+//   Intruder pushed after snapshot: tokens=9999, cost=99.0 — must NOT appear.
+//   Mutated hermes in live collection: tokens=199998, cost=999.0 — must NOT appear.
+#[test]
+fn test_streaming_aggregator_store_memo_snapshot_mid_iteration_mutation_ignored() {
+    // scenario: store_memo_snapshot
+
+    // Step 1: capture the snapshot (clone simulates Arc snapshot semantics).
+    let snapshot: Vec<UnifiedMessage> = vec![
+        snapshot_msg(
+            "2025-05-10",
+            "hermes",
+            "claude-sonnet-4-5",
+            "snap-sess-1",
+            Some("snap-key-1"),
+            1_746_864_000_000,
+            400,
+            200,
+            0.07,
+        ),
+        snapshot_msg(
+            "2025-05-10",
+            "zed",
+            "claude-opus-4-5",
+            "snap-sess-2",
+            Some("snap-key-2"),
+            1_746_864_001_000,
+            200,
+            100,
+            0.03,
+        ),
+        snapshot_msg(
+            "2025-05-10",
+            "claude",
+            "claude-haiku-4-5",
+            "snap-sess-3",
+            None,
+            1_746_864_002_000,
+            100,
+            50,
+            0.01,
+        ),
+    ];
+
+    // Step 2: the live collection starts as a clone of the snapshot.
+    let mut live_collection = snapshot.clone();
+
+    // Step 3: begin fold on the *snapshot* clone — the aggregator sees only
+    // the 3 messages present at snapshot-capture time.
+    let mut agg = StreamingAggregator::new();
+    for msg in &snapshot {
+        agg.feed(msg);
+    }
+
+    // Step 4: mutate the live collection mid-fold (simulates a new file
+    // arriving or an in-place store update while aggregation is in flight).
+    //
+    // Push a new message: 5000+4999=9999 tokens, cost=99.0 — must be ignored.
+    live_collection.push(snapshot_msg(
+        "2025-05-10",
+        "opencode",
+        "gpt-4o",
+        "intruder-sess",
+        None,
+        1_746_864_999_000,
+        5000,
+        4999,
+        99.0,
+    ));
+    // Replace an existing entry with wildly different values — must be ignored.
+    live_collection[0] = snapshot_msg(
+        "2025-05-10",
+        "hermes",
+        "claude-sonnet-4-5",
+        "snap-sess-1",
+        Some("snap-key-1"),
+        1_746_864_000_000,
+        99999,
+        99999,
+        999.0,
+    );
+
+    // Step 5: finalize — result must reflect only the 3 snapshot messages.
+    let contributions = agg.finalize();
+
+    // One date bucket expected.
+    assert_eq!(
+        contributions.len(),
+        1,
+        "snapshot isolation: all 3 snapshot messages on same date -> 1 bucket"
+    );
+
+    // Only the 3 snapshot messages must be counted; intruder and mutated
+    // hermes must not appear.
+    assert_eq!(
+        contributions[0].totals.messages,
+        3,
+        "snapshot isolation: only the 3 snapshot messages counted; intruder ignored"
+    );
+
+    // tokens: hermes(600) + zed(300) + claude(150) = 1050
+    assert_eq!(
+        contributions[0].totals.tokens,
+        1050,
+        "snapshot isolation: tokens must be 600+300+150=1050 (snapshot values only)"
+    );
+
+    // cost: 0.07 + 0.03 + 0.01 = 0.11
+    assert!(
+        (contributions[0].totals.cost - 0.11).abs() < 1e-9,
+        "snapshot isolation: cost must be 0.07+0.03+0.01=0.11 (snapshot values only)"
+    );
+
+    // Guard: the mutated hermes value (99999+99999=199998 tokens) must not
+    // have leaked into the fold result.
+    assert_ne!(
+        contributions[0].totals.tokens,
+        199998 + 300 + 150,
+        "snapshot isolation: mutated hermes token count must not appear in fold result"
+    );
+}


### PR DESCRIPTION
## Problem

Follow-up to #1 / #2. With the v1.0.2 caching fixes in place, the remaining resource issue is the graph recompute path: every refresh materializes the full session history as a `Vec<UnifiedMessage>` (~1M messages on this setup) before aggregating, producing a transient ~1GB allocation. RSS sawtooths between ~1.25GB and ~1.72GB all day (sampling stddev 162.5MB over 5 min).

## Change

Replace materialize-then-aggregate with a per-file streaming fold — one scan pass, no full-history Vec:

- **`StreamingAggregator`** (`aggregator.rs`): folds `&UnifiedMessage` into daily buckets one at a time. Dedup semantics preserved exactly: cross-file first-seen-wins seen-sets (claude/opencode/codex/hermes), trae keep-latest-per-session buffer (timestamp, dedup_key tiebreak) flushed after all lanes.
- **`SessionizeAccumulator`** (`sessionize.rs`): streaming replacement for `sessionize()` on the hot path — per-(client, session_id) timestamp vectors + token sums instead of holding every message. Output is parity-tested against `sessionize()`.
- **`scan_messages_streaming`** (`lib.rs`): cache-aware driver that iterates each file's cached messages by reference (no `cached.messages.clone()`), applies pricing on the fly, runs the dedup gate once at the driver level, and feeds both accumulators in a single pass. `load_or_parse_source` caching, cache writeback, and Gemini `invalidate_cache` semantics are preserved (verified lane-by-lane against the old path).
- All report consumers (graph / model / monthly / hourly / time_metrics) switched off the materializing path. The legacy `parse_all_messages_with_pricing_with_env_strategy` remains only for the FFI `parse_local_unified_messages_resolved` (intentional Vec, TODO-tagged).
- FFI surface unchanged: `git diff main -- crates/tb_core_ffi/src/` has zero `extern "C"` line changes.

## Measurements (16k-file setup, active Claude session writing JSONL throughout)

5s sampling, 5-minute windows:

| | v1.0.2 (baseline) | this PR |
|---|---|---|
| RSS range | 1.25GB ↔ 1.72GB sawtooth | 576–639MB steady |
| RSS sampling stddev | 162.5MB | 23.2MB |
| CPU mean / max | 17.1% / 181.4% | 13.2% / 130.5% |

Extended 50-minute monitor (5 rounds, 10-min spacing, final build): RSS envelope 551MB–1213MB, settling at ~645MB by rounds 4–5; no `>180%` CPU bursts; no sawtooth. The residual floor is the resident message cache (STORE_MEMO), which is prior design and out of scope here.

Also re-ran steady-state on v1.0.2 main as requested in #2: CPU mean 17.1%, 82% of samples ≤22% — the round-1 numbers hold.

## Tests

- `cargo test` workspace: 872 passed, 0 failed (24 new: dedup scenario tests with hardcoded expectations, A/B parity vs `aggregate_by_date`, snapshot-isolation mid-iteration mutation test, `SessionizeAccumulator` parity suite)
- clippy clean across the workspace; `make bundle` + `nm` symbol check on the shipped binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
