### PR TITLE
fix(ffi): harden the C-ABI boundary — catch panics, recover poison, guard inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,13 @@ members = ["crates/tb_core_ffi", "vendor/tokscale-core"]
 [profile.release]
 lto = true
 strip = "debuginfo"
-# This builds a staticlib called over a C ABI from Swift. A panic must never
-# unwind across that boundary (UB), and we can't catch_unwind every entry
-# point cheaply, so abort on panic: a panic anywhere — including in serde,
-# tokio or reqwest — terminates the process deterministically instead of
-# unwinding into undefined behavior. Tests still unwind (dev profile).
-panic = "abort"
+# This builds a staticlib called over a C ABI from Swift. A panic must not
+# unwind across that boundary — since Rust 1.81 an `extern "C"` fn that unwinds
+# is a defined process abort (not UB), but a whole-app abort throws away the
+# per-card resilience the Swift side is built for. So rather than `panic =
+# "abort"`, every FFI entry point wraps its body in `catch_unwind` (see
+# `guarded` in tb_core_ffi/src/lib.rs) and turns a panic into an error envelope:
+# a panic inside one report — a serde error, a bad index in a ported module, an
+# `.expect()` — degrades that one card to an error and leaves the rest of the
+# app running. Unwinding also makes the Mutex poison-recovery in lib.rs /
+# agent_usage.rs meaningful again (a Mutex is only poisoned on unwind).

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -182,6 +182,11 @@ enum SelfTest {
         expect(AgentLimitsCard.reorder(order, from: "a", to: "a") == order, "reorder onto itself is a no-op")
         expect(AgentLimitsCard.reorder(order, from: "x", to: "b") == order, "reorder unknown id is a no-op")
 
+        // FFI envelope/error contract (hermetic; no FFI allocation or live data).
+        for (label, passed) in TBCore.envelopeContractChecks() {
+            expect(passed, "envelope: \(label)")
+        }
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBarCore/TBCore.swift
+++ b/Sources/TokenBarCore/TBCore.swift
@@ -1,5 +1,12 @@
 import CTB
 import Foundation
+import os
+
+/// FFI-boundary log. Backend failures and contract drift would otherwise vanish
+/// — every app-side caller wraps these in `try?` to keep the last good numbers,
+/// so the only record of a failure is here. Logs the entry-point type and the
+/// error string only; never a decoded payload body (agent usage carries emails).
+let ffiLog = Logger(subsystem: "com.nyanako.tokenbar", category: "ffi")
 
 /// Errors crossing the Rust FFI boundary.
 public enum TBCoreError: Error {
@@ -26,21 +33,59 @@ struct TBEnvelope<T: Decodable>: Decodable {
 /// invoke from a background thread/actor in app code. `agentUsage()` is also
 /// network-bound.
 public enum TBCore {
-    /// Decode a JSON payload returned by a tb_* entry point, then free it.
-    static func decode<T: Decodable>(_ raw: UnsafeMutablePointer<CChar>?) throws -> T {
-        guard let raw else { throw TBCoreError.nullPointer }
+    /// Copy the FFI string out of the heap buffer and free it, so decoding never
+    /// races the C allocation. Returns nil for a NULL pointer. This is the single
+    /// legal consumer of a tb_* return pointer — `tb_free` happens here exactly
+    /// once, on every path (the `defer`), which is what keeps the boundary free
+    /// of leaks and double-frees.
+    private static func takeBytes(_ raw: UnsafeMutablePointer<CChar>?) -> Data? {
+        guard let raw else { return nil }
         defer { tb_free(raw) }
-        let data = Data(bytes: raw, count: strlen(raw))
-        return try JSONDecoder().decode(T.self, from: data)
+        return Data(bytes: raw, count: strlen(raw))
+    }
+
+    /// Decode a bare JSON payload returned by a tb_* entry point, then free it.
+    /// (Used by the legacy `tb_probe` shape; enveloped entry points use `unwrap`.)
+    static func decode<T: Decodable>(_ raw: UnsafeMutablePointer<CChar>?) throws -> T {
+        guard let data = takeBytes(raw) else {
+            ffiLog.error("FFI returned NULL for \(String(describing: T.self), privacy: .public)")
+            throw TBCoreError.nullPointer
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            ffiLog.error(
+                "FFI decode \(String(describing: T.self), privacy: .public) failed: \(String(describing: error), privacy: .public)")
+            throw error
+        }
     }
 
     /// Decode an enveloped payload, surfacing `{"ok":false}` as a thrown error.
     static func unwrap<T: Decodable>(_ raw: UnsafeMutablePointer<CChar>?) throws -> T {
-        let envelope: TBEnvelope<T> = try decode(raw)
-        guard envelope.ok, let data = envelope.data else {
+        guard let data = takeBytes(raw) else {
+            ffiLog.error("FFI returned NULL for \(String(describing: T.self), privacy: .public)")
+            throw TBCoreError.nullPointer
+        }
+        do {
+            return try decodeEnvelope(data)
+        } catch {
+            ffiLog.error(
+                "FFI \(String(describing: T.self), privacy: .public) failed: \(String(describing: error), privacy: .public)")
+            throw error
+        }
+    }
+
+    /// Pure envelope decode: `{"ok":true,"data":..}` → payload, `{"ok":false}` →
+    /// thrown `TBCoreError.bridge`. Split out from the pointer/free path so the
+    /// error contract is unit-testable (`envelopeContractChecks`) without a real
+    /// FFI allocation — feeding a synthetic pointer to `decode` would be unsound,
+    /// since `tb_free` must only ever release a Rust-allocated pointer.
+    static func decodeEnvelope<T: Decodable>(_ data: Data) throws -> T {
+        let envelope = try JSONDecoder().decode(TBEnvelope<T>.self, from: data)
+        guard envelope.ok, let payload = envelope.data else {
             throw TBCoreError.bridge(envelope.err ?? "unknown")
         }
-        return data
+        return payload
     }
 
     /// Pass an optional year filter across the boundary (nil = all time).
@@ -95,5 +140,52 @@ public enum TBCore {
     /// per-provider failures are reported in each snapshot's `error`.
     public static func agentUsage() throws -> AgentUsagePayload {
         try unwrap(tb_agent_usage())
+    }
+
+    /// Hermetic checks for the FFI envelope/error contract, surfaced to the
+    /// `--selftest` runner (which lives in the TokenBar module and can't reach
+    /// these internal symbols). Exercises the error paths `--smoke` never hits on
+    /// live data: an `{"ok":false}` must throw `bridge`, a malformed body must
+    /// throw rather than crash. Returns `(label, passed)` pairs.
+    public static func envelopeContractChecks() -> [(String, Bool)] {
+        var out: [(String, Bool)] = []
+        func check(_ label: String, _ passed: Bool) { out.append((label, passed)) }
+
+        // ok:true + data → payload returned verbatim.
+        do {
+            let ok: TokensPerMin = try decodeEnvelope(
+                Data(#"{"ok":true,"data":{"tokensPerMin":42.5}}"#.utf8))
+            check("ok:true returns data", ok.tokensPerMin == 42.5)
+        } catch {
+            check("ok:true returns data", false)
+        }
+
+        // ok:false → TBCoreError.bridge carrying the err string.
+        do {
+            let _: TokensPerMin = try decodeEnvelope(Data(#"{"ok":false,"err":"boom"}"#.utf8))
+            check("ok:false throws bridge(boom)", false)
+        } catch let TBCoreError.bridge(msg) {
+            check("ok:false throws bridge(boom)", msg == "boom")
+        } catch {
+            check("ok:false throws bridge(boom)", false)
+        }
+
+        // ok:true but data absent → bridge (contract violation, not a crash).
+        do {
+            let _: TokensPerMin = try decodeEnvelope(Data(#"{"ok":true}"#.utf8))
+            check("ok:true without data throws", false)
+        } catch {
+            check("ok:true without data throws", true)
+        }
+
+        // Malformed JSON → thrown DecodingError, never a trap.
+        do {
+            let _: TokensPerMin = try decodeEnvelope(Data(#"{not json"#.utf8))
+            check("malformed body throws", false)
+        } catch {
+            check("malformed body throws", true)
+        }
+
+        return out
     }
 }

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -368,10 +368,11 @@ static CLAUDE_USAGE_GATE: Mutex<ClaudeUsageGate> = Mutex::new(ClaudeUsageGate {
     last_good: None,
 });
 
-/// Lock the gate, recovering from a poisoned mutex instead of panicking. A
-/// panic in one locked section must not wedge the 429 gate (and take down the
-/// whole `tb_agent_usage` call) for the rest of the process — same stance as
-/// the live-tail lock in lib.rs.
+/// Lock the gate, recovering from a poisoned mutex instead of panicking. Under
+/// the release profile's unwind + FFI-boundary `catch_unwind` (see `guarded` in
+/// lib.rs), a panic caught mid-section poisons this static; `into_inner()` keeps
+/// the 429 gate working for the rest of the process instead of wedging every
+/// later `tb_agent_usage` call — same stance as the live-tail lock in lib.rs.
 fn lock_gate() -> std::sync::MutexGuard<'static, ClaudeUsageGate> {
     CLAUDE_USAGE_GATE
         .lock()

--- a/crates/tb_core_ffi/src/lib.rs
+++ b/crates/tb_core_ffi/src/lib.rs
@@ -61,7 +61,17 @@ static GRAPH_CACHE: LazyLock<Mutex<HashMap<String, GraphCacheEntry>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 static TAILER: LazyLock<UsageTailer> = LazyLock::new(UsageTailer::new);
-static TAIL_LAST_TICK: Mutex<Option<Instant>> = Mutex::new(None);
+/// Live-tail tick bookkeeping. `last` is the completion time of the most recent
+/// successful re-parse; `in_flight` is set while a re-parse is running so a
+/// concurrent poller serves the cached window instead of launching a duplicate.
+struct TickState {
+    last: Option<Instant>,
+    in_flight: bool,
+}
+static TAIL_TICK: Mutex<TickState> = Mutex::new(TickState {
+    last: None,
+    in_flight: false,
+});
 
 fn into_raw_json(json: String) -> *mut c_char {
     // A JSON payload should never contain interior NULs; fall back to an
@@ -88,12 +98,12 @@ fn envelope(result: Result<serde_json::Value, String>) -> *mut c_char {
 /// default panic hook still prints the panic location to stderr before we catch.
 ///
 /// `AssertUnwindSafe` is sound here. State shared across calls is the three
-/// std::sync Mutex statics (GRAPH_CACHE / TAIL_LAST_TICK / CLAUDE_USAGE_GATE),
-/// each recovered from poison on the next lock via `into_inner()`, plus the live
+/// std::sync Mutex statics (GRAPH_CACHE / TAIL_TICK / CLAUDE_USAGE_GATE), each
+/// recovered from poison on the next lock via `into_inner()`, plus the live
 /// tail's parking_lot Mutexes, which never poison and release cleanly on unwind.
 /// A caught panic can leave a cache entry stale or a tail tick un-run, never
-/// torn: the next call re-derives the graph, and `tail_tick_if_stale` rolls its
-/// claim back on a tick panic so the tail re-parses immediately.
+/// torn: the next call re-derives the graph, and `tail_tick_if_stale` clears its
+/// in-flight flag without stamping on a tick panic so the tail re-parses next.
 fn guarded(name: &str, body: impl FnOnce() -> *mut c_char) -> *mut c_char {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {
         Ok(ptr) => ptr,
@@ -165,49 +175,50 @@ fn graph_compute(year: &str) -> Result<serde_json::Value, String> {
     Ok(data)
 }
 
-/// Re-parse the live tail if the last tick is stale (or never happened),
-/// otherwise leave the cached event window in place. The stale check claims the
-/// tick — stamps the clock — *before* releasing the lock, so a second concurrent
-/// poller sees "not stale" and serves the cached window instead of piling a
-/// duplicate re-parse behind this one; the heavy `TAILER.tick()` then runs with
-/// no lock held. Poison recovery is live again now the release profile unwinds:
-/// a panic caught at the FFI boundary while another call held this lock would
-/// poison it, and `into_inner()` keeps the tail ticking instead of wedging it.
-///
-/// `TickClaim` rolls the stamp back if `TAILER.tick()` panics (caught at the FFI
-/// boundary): without it, a single transient tick panic would suppress every
-/// re-parse for the next `TAIL_TICK_SECS`, freezing the live tail on a stale or
-/// empty window — the opposite of the graceful degradation this stance exists
-/// for. On success the claim is committed (`mem::forget`) so the stamp stands.
-fn lock_tick() -> std::sync::MutexGuard<'static, Option<Instant>> {
-    TAIL_LAST_TICK
+fn lock_tick() -> std::sync::MutexGuard<'static, TickState> {
+    TAIL_TICK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
-/// Resets `TAIL_LAST_TICK` to `None` when dropped (i.e. when `TAILER.tick()`
-/// unwinds), so the next poll re-ticks immediately instead of waiting out the
-/// interval on a failed parse. `tail_tick_if_stale` `mem::forget`s it on success.
-struct TickClaim;
-impl Drop for TickClaim {
+/// Clears the in-flight flag when dropped, on both the success and the panic
+/// path (a `TAILER.tick()` that unwinds, caught at the FFI boundary). On panic
+/// `last` is left unstamped, so the next poll re-ticks immediately instead of
+/// suppressing re-parse for the interval.
+struct TickGuard;
+impl Drop for TickGuard {
     fn drop(&mut self) {
-        *lock_tick() = None;
+        lock_tick().in_flight = false;
     }
 }
 
+/// Re-parse the live tail if the last *completed* tick is older than
+/// `TAIL_TICK_SECS`, unless a re-parse is already running. Single-flight: a
+/// second concurrent poller sees `in_flight` (or a fresh `last`) and serves the
+/// cached window immediately — it neither blocks on the lock nor launches a
+/// duplicate parse that could overwrite a newer one (last-writer-wins). The
+/// heavy `TAILER.tick()` runs with no lock held; the stamp is taken only after
+/// it completes, so a slow (> `TAIL_TICK_SECS`) parse can't be seen as stale
+/// mid-flight, and a tick panic leaves `last` unstamped to retry next call.
 fn tail_tick_if_stale() {
-    let should_tick = {
-        let mut last = lock_tick();
-        let stale = last.is_none_or(|at| at.elapsed() >= Duration::from_secs(TAIL_TICK_SECS));
-        if stale {
-            *last = Some(Instant::now());
+    let claimed = {
+        let mut st = lock_tick();
+        if st.in_flight {
+            false
+        } else {
+            let stale = st
+                .last
+                .is_none_or(|at| at.elapsed() >= Duration::from_secs(TAIL_TICK_SECS));
+            if stale {
+                st.in_flight = true;
+            }
+            stale
         }
-        stale
     };
-    if should_tick {
-        let claim = TickClaim;
+    if claimed {
+        let _guard = TickGuard; // clears in_flight on drop (success or panic)
         TAILER.tick();
-        std::mem::forget(claim); // tick completed — keep the stamp
+        lock_tick().last = Some(Instant::now()); // success only — panic skips this
     }
 }
 
@@ -382,13 +393,19 @@ mod tests {
     }
 
     #[test]
-    fn tick_claim_rolls_back_stamp_on_panic() {
-        // A TickClaim dropped during unwind (the tick() panic path) must reset
-        // TAIL_LAST_TICK to None so the next poll re-ticks immediately, instead
-        // of suppressing re-parse for the whole TAIL_TICK_SECS interval.
-        *lock_tick() = Some(Instant::now());
-        drop(TickClaim);
-        assert!(lock_tick().is_none());
+    fn tick_guard_clears_in_flight_without_stamping_on_panic() {
+        // Simulates a panic during TAILER.tick(): the guard, dropped mid-unwind,
+        // must clear in_flight (so a later poll can re-tick) and must NOT stamp
+        // `last` (so the tick is retried rather than suppressed for the interval).
+        {
+            let mut st = lock_tick();
+            st.in_flight = true;
+            st.last = None;
+        }
+        drop(TickGuard);
+        let st = lock_tick();
+        assert!(!st.in_flight);
+        assert!(st.last.is_none()); // unstamped → next poll re-ticks
     }
 
     #[test]

--- a/crates/tb_core_ffi/src/lib.rs
+++ b/crates/tb_core_ffi/src/lib.rs
@@ -79,6 +79,35 @@ fn envelope(result: Result<serde_json::Value, String>) -> *mut c_char {
     into_raw_json(json)
 }
 
+/// Run an FFI entry-point body, converting any panic into an error envelope
+/// instead of letting it unwind across the C ABI. The release profile unwinds
+/// (see the `[profile.release]` note in Cargo.toml): a panic inside one report —
+/// a serde error, a bad slice index in a ported module, an `.expect()` — is
+/// caught here and degrades that single call to `{"ok":false,...}`, leaving the
+/// rest of the menu-bar app running rather than aborting the whole process. The
+/// default panic hook still prints the panic location to stderr before we catch.
+///
+/// `AssertUnwindSafe` is sound here. State shared across calls is the three
+/// std::sync Mutex statics (GRAPH_CACHE / TAIL_LAST_TICK / CLAUDE_USAGE_GATE),
+/// each recovered from poison on the next lock via `into_inner()`, plus the live
+/// tail's parking_lot Mutexes, which never poison and release cleanly on unwind.
+/// A caught panic can leave a cache entry stale or a tail tick un-run, never
+/// torn: the next call re-derives the graph, and `tail_tick_if_stale` rolls its
+/// claim back on a tick panic so the tail re-parses immediately.
+fn guarded(name: &str, body: impl FnOnce() -> *mut c_char) -> *mut c_char {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(body)) {
+        Ok(ptr) => ptr,
+        Err(payload) => {
+            let detail = payload
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("panic");
+            envelope(Err(format!("{} panicked: {}", name, detail)))
+        }
+    }
+}
+
 /// Read an optional year filter from the C side. NULL or empty/whitespace
 /// means "all time" (the report modules' empty-string behavior).
 ///
@@ -95,18 +124,30 @@ unsafe fn year_from(year: *const c_char) -> Result<String, String> {
 }
 
 fn graph_cached(year: &str, max_age: Duration) -> Option<serde_json::Value> {
-    let mut cache = GRAPH_CACHE.lock().ok()?;
-    let (at, token, data) = cache.get_mut(year)?;
-    if at.elapsed() <= max_age {
-        return Some(data.clone());
+    // Read the entry and release the lock before any filesystem I/O — never hold
+    // GRAPH_CACHE across the mtime stat sweep below (mirrors graph_compute, which
+    // probes outside the lock too), so concurrent tb_graph callers don't queue
+    // behind one another's stat.
+    let (fresh_enough, token, data) = {
+        let cache = GRAPH_CACHE.lock().unwrap_or_else(|p| p.into_inner());
+        let (at, token, data) = cache.get(year)?;
+        (at.elapsed() <= max_age, *token, data.clone())
+    };
+    if fresh_enough {
+        return Some(data);
     }
     // Aged out — but if no source file changed since the compute, the graph
-    // cannot have changed either. Re-stamp so the next calls inside the
-    // oneshot window skip the probe entirely.
+    // cannot have changed either. Probe with the lock released, then re-acquire
+    // briefly to re-stamp so the next calls inside the oneshot window skip the
+    // probe entirely. A lost re-stamp (entry evicted/replaced meanwhile) just
+    // degrades to the next call re-probing — benign.
     let fresh = tokscale_core::latest_source_mtime_ms(&Default::default()).ok()?;
-    if fresh == *token {
-        *at = Instant::now();
-        return Some(data.clone());
+    if fresh == token {
+        let mut cache = GRAPH_CACHE.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(entry) = cache.get_mut(year) {
+            entry.0 = Instant::now();
+        }
+        return Some(data);
     }
     None
 }
@@ -117,23 +158,56 @@ fn graph_compute(year: &str) -> Result<serde_json::Value, String> {
     // serving a graph that missed it.
     let token = tokscale_core::latest_source_mtime_ms(&Default::default()).unwrap_or(0);
     let data = usage_graph::run(year)?;
-    if let Ok(mut cache) = GRAPH_CACHE.lock() {
-        cache.insert(year.to_string(), (Instant::now(), token, data.clone()));
-    }
+    GRAPH_CACHE
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert(year.to_string(), (Instant::now(), token, data.clone()));
     Ok(data)
 }
 
 /// Re-parse the live tail if the last tick is stale (or never happened),
-/// otherwise leave the cached event window in place.
+/// otherwise leave the cached event window in place. The stale check claims the
+/// tick — stamps the clock — *before* releasing the lock, so a second concurrent
+/// poller sees "not stale" and serves the cached window instead of piling a
+/// duplicate re-parse behind this one; the heavy `TAILER.tick()` then runs with
+/// no lock held. Poison recovery is live again now the release profile unwinds:
+/// a panic caught at the FFI boundary while another call held this lock would
+/// poison it, and `into_inner()` keeps the tail ticking instead of wedging it.
+///
+/// `TickClaim` rolls the stamp back if `TAILER.tick()` panics (caught at the FFI
+/// boundary): without it, a single transient tick panic would suppress every
+/// re-parse for the next `TAIL_TICK_SECS`, freezing the live tail on a stale or
+/// empty window — the opposite of the graceful degradation this stance exists
+/// for. On success the claim is committed (`mem::forget`) so the stamp stands.
+fn lock_tick() -> std::sync::MutexGuard<'static, Option<Instant>> {
+    TAIL_LAST_TICK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Resets `TAIL_LAST_TICK` to `None` when dropped (i.e. when `TAILER.tick()`
+/// unwinds), so the next poll re-ticks immediately instead of waiting out the
+/// interval on a failed parse. `tail_tick_if_stale` `mem::forget`s it on success.
+struct TickClaim;
+impl Drop for TickClaim {
+    fn drop(&mut self) {
+        *lock_tick() = None;
+    }
+}
+
 fn tail_tick_if_stale() {
-    let mut last = match TAIL_LAST_TICK.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
+    let should_tick = {
+        let mut last = lock_tick();
+        let stale = last.is_none_or(|at| at.elapsed() >= Duration::from_secs(TAIL_TICK_SECS));
+        if stale {
+            *last = Some(Instant::now());
+        }
+        stale
     };
-    let stale = last.is_none_or(|at| at.elapsed() >= Duration::from_secs(TAIL_TICK_SECS));
-    if stale {
+    if should_tick {
+        let claim = TickClaim;
         TAILER.tick();
-        *last = Some(Instant::now());
+        std::mem::forget(claim); // tick completed — keep the stamp
     }
 }
 
@@ -142,12 +216,14 @@ fn tail_tick_if_stale() {
 /// (Legacy Phase 0 shape: `{"ok":true,"messages":N}`, no `data` wrapper.)
 #[no_mangle]
 pub extern "C" fn tb_probe() -> *mut c_char {
-    let opts = tokscale_core::LocalParseOptions::default();
-    let json = match tokscale_core::parse_local_clients(opts) {
-        Ok(pm) => format!(r#"{{"ok":true,"messages":{}}}"#, pm.messages.len()),
-        Err(e) => serde_json::json!({"ok": false, "err": e}).to_string(),
-    };
-    into_raw_json(json)
+    guarded("tb_probe", || {
+        let opts = tokscale_core::LocalParseOptions::default();
+        let json = match tokscale_core::parse_local_clients(opts) {
+            Ok(pm) => format!(r#"{{"ok":true,"messages":{}}}"#, pm.messages.len()),
+            Err(e) => serde_json::json!({"ok": false, "err": e}).to_string(),
+        };
+        into_raw_json(json)
+    })
 }
 
 /// Contribution-graph payload (`UsagePayload` in types.ts) for `year`
@@ -158,12 +234,14 @@ pub extern "C" fn tb_probe() -> *mut c_char {
 /// `year` must be NULL or a valid NUL-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn tb_graph(year: *const c_char) -> *mut c_char {
-    envelope(unsafe { year_from(year) }.and_then(|year| {
-        if let Some(data) = graph_cached(&year, Duration::from_secs(ONESHOT_MAX_AGE_SECS)) {
-            return Ok(data);
-        }
-        graph_compute(&year)
-    }))
+    guarded("tb_graph", || {
+        envelope(unsafe { year_from(year) }.and_then(|year| {
+            if let Some(data) = graph_cached(&year, Duration::from_secs(ONESHOT_MAX_AGE_SECS)) {
+                return Ok(data);
+            }
+            graph_compute(&year)
+        }))
+    })
 }
 
 /// Force-recompute the contribution graph for `year`, bypassing the cache.
@@ -172,7 +250,9 @@ pub unsafe extern "C" fn tb_graph(year: *const c_char) -> *mut c_char {
 /// `year` must be NULL or a valid NUL-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn tb_refresh_graph(year: *const c_char) -> *mut c_char {
-    envelope(unsafe { year_from(year) }.and_then(|year| graph_compute(&year)))
+    guarded("tb_refresh_graph", || {
+        envelope(unsafe { year_from(year) }.and_then(|year| graph_compute(&year)))
+    })
 }
 
 /// Per-model report (`ModelReport` in types.ts) for `year` (NULL/empty = all time).
@@ -181,7 +261,9 @@ pub unsafe extern "C" fn tb_refresh_graph(year: *const c_char) -> *mut c_char {
 /// `year` must be NULL or a valid NUL-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn tb_model_report(year: *const c_char) -> *mut c_char {
-    envelope(unsafe { year_from(year) }.and_then(|year| model_report::run(&year)))
+    guarded("tb_model_report", || {
+        envelope(unsafe { year_from(year) }.and_then(|year| model_report::run(&year)))
+    })
 }
 
 /// Per-hour report (`HourlyReport` in types.ts) for `year` (NULL/empty = all time).
@@ -190,7 +272,9 @@ pub unsafe extern "C" fn tb_model_report(year: *const c_char) -> *mut c_char {
 /// `year` must be NULL or a valid NUL-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn tb_hourly_report(year: *const c_char) -> *mut c_char {
-    envelope(unsafe { year_from(year) }.and_then(|year| hourly_report::run(&year)))
+    guarded("tb_hourly_report", || {
+        envelope(unsafe { year_from(year) }.and_then(|year| hourly_report::run(&year)))
+    })
 }
 
 /// Per-(sub-)agent report (`AgentsReport` in types.ts) for `year`
@@ -200,7 +284,9 @@ pub unsafe extern "C" fn tb_hourly_report(year: *const c_char) -> *mut c_char {
 /// `year` must be NULL or a valid NUL-terminated string.
 #[no_mangle]
 pub unsafe extern "C" fn tb_agents_report(year: *const c_char) -> *mut c_char {
-    envelope(unsafe { year_from(year) }.and_then(|year| agents_report::run(&year)))
+    guarded("tb_agents_report", || {
+        envelope(unsafe { year_from(year) }.and_then(|year| agents_report::run(&year)))
+    })
 }
 
 /// Live per-(client, agent, model) trace buckets over the trailing
@@ -208,21 +294,25 @@ pub unsafe extern "C" fn tb_agents_report(year: *const c_char) -> *mut c_char {
 /// Tauri `TraceBucket` serialization the frontend consumes.
 #[no_mangle]
 pub extern "C" fn tb_usage_trace(window_secs: i64) -> *mut c_char {
-    tail_tick_if_stale();
-    envelope(
-        serde_json::to_value(TAILER.trace(window_secs))
-            .map_err(|e| format!("serialize usage trace: {}", e)),
-    )
+    guarded("tb_usage_trace", || {
+        tail_tick_if_stale();
+        envelope(
+            serde_json::to_value(TAILER.trace(window_secs))
+                .map_err(|e| format!("serialize usage trace: {}", e)),
+        )
+    })
 }
 
 /// Live tokens/min estimate: `{"tokensPerMin": <f32>}`. Same 10-minute-window
 /// rate the Tauri `get_tokens_per_min` command reports.
 #[no_mangle]
 pub extern "C" fn tb_tokens_per_min() -> *mut c_char {
-    tail_tick_if_stale();
-    envelope(Ok(
-        serde_json::json!({"tokensPerMin": TAILER.rate_in_window(600)}),
-    ))
+    guarded("tb_tokens_per_min", || {
+        tail_tick_if_stale();
+        envelope(Ok(
+            serde_json::json!({"tokensPerMin": TAILER.rate_in_window(600)}),
+        ))
+    })
 }
 
 /// OAuth quota cards (`AgentUsagePayload` in agentUsage.ts) for
@@ -231,8 +321,18 @@ pub extern "C" fn tb_tokens_per_min() -> *mut c_char {
 /// snapshot's `error` field; the call itself only fails on serialization.
 #[no_mangle]
 pub extern "C" fn tb_agent_usage() -> *mut c_char {
-    let payload = RUNTIME.block_on(agent_usage::run());
-    envelope(serde_json::to_value(payload).map_err(|e| format!("serialize agent usage: {}", e)))
+    guarded("tb_agent_usage", || {
+        // No outer timeout on purpose: each provider carries its own 30s
+        // per-request reqwest timeout (which covers connect, so nothing hangs
+        // unbounded), and they run concurrently via tokio::join!. A single outer
+        // ceiling would instead collapse the whole payload to one error — losing
+        // the providers that already succeeded — and could cut off the legitimate
+        // expired-token path (sequential refresh + fetch, up to ~60s).
+        let payload = RUNTIME.block_on(agent_usage::run());
+        envelope(
+            serde_json::to_value(payload).map_err(|e| format!("serialize agent usage: {}", e)),
+        )
+    })
 }
 
 /// Release a string returned by any tb_* entry point.
@@ -245,5 +345,59 @@ pub unsafe extern "C" fn tb_free(p: *mut c_char) {
         unsafe {
             let _ = CString::from_raw(p);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use usage_tail::UsageTailer;
+
+    /// Read a heap JSON pointer into an owned String and free it — the test-side
+    /// equivalent of Swift's `decode`/`tb_free`.
+    unsafe fn take(p: *mut c_char) -> String {
+        let s = unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned();
+        unsafe { tb_free(p) };
+        s
+    }
+
+    #[test]
+    fn guarded_passes_success_through() {
+        let p = guarded("tb_test", || envelope(Ok(serde_json::json!({"v": 1}))));
+        let s = unsafe { take(p) };
+        assert!(s.contains(r#""ok":true"#), "got: {s}");
+        assert!(s.contains(r#""v":1"#), "got: {s}");
+    }
+
+    #[test]
+    fn guarded_converts_panic_to_error_envelope() {
+        // The whole point of the unwind + catch_unwind stance: a panic inside an
+        // entry-point body must NOT unwind across the C ABI (which would abort the
+        // process). It is caught and returned as {"ok":false,...} so one card
+        // fails while the rest of the app keeps running.
+        let p = guarded("tb_test", || panic!("boom"));
+        let s = unsafe { take(p) };
+        assert!(s.contains(r#""ok":false"#), "got: {s}");
+        assert!(s.contains("tb_test panicked: boom"), "got: {s}");
+    }
+
+    #[test]
+    fn tick_claim_rolls_back_stamp_on_panic() {
+        // A TickClaim dropped during unwind (the tick() panic path) must reset
+        // TAIL_LAST_TICK to None so the next poll re-ticks immediately, instead
+        // of suppressing re-parse for the whole TAIL_TICK_SECS interval.
+        *lock_tick() = Some(Instant::now());
+        drop(TickClaim);
+        assert!(lock_tick().is_none());
+    }
+
+    #[test]
+    fn trace_rejects_nonpositive_window() {
+        // window_secs <= 0 yields no buckets instead of an overflowed cutoff.
+        let tail = UsageTailer::new();
+        assert!(tail.trace(0).is_empty());
+        assert!(tail.trace(-5).is_empty());
+        // A pathological window must saturate, not panic/overflow.
+        assert!(tail.trace(i64::MAX).is_empty());
     }
 }

--- a/crates/tb_core_ffi/src/usage_tail.rs
+++ b/crates/tb_core_ffi/src/usage_tail.rs
@@ -140,7 +140,8 @@ impl UsageTailer {
     }
 
     fn window_total(&self, secs: i64) -> i64 {
-        let cutoff = now_ms() - secs * 1000;
+        // saturating so a pathological `secs` can't overflow the cutoff.
+        let cutoff = now_ms().saturating_sub(secs.saturating_mul(1000));
         let events = self.events.lock();
         events
             .iter()
@@ -153,7 +154,14 @@ impl UsageTailer {
     /// decides whether to collapse rows by client based on the user's
     /// "detailed trace" setting.
     pub fn trace(&self, window_secs: i64) -> Vec<TraceBucket> {
-        let cutoff = now_ms() - window_secs * 1000;
+        // Mirror rate_in_window's contract: a non-positive window has no events.
+        // saturating_* so a garbage window_secs from the C side can't overflow
+        // the cutoff; window_secs itself is left intact for the window_min
+        // divisor below, so the per-minute rate is never distorted by a clamp.
+        if window_secs <= 0 {
+            return Vec::new();
+        }
+        let cutoff = now_ms().saturating_sub(window_secs.saturating_mul(1000));
         let events = self.events.lock();
         let mut groups: HashMap<(String, String, String), (i64, u32)> = HashMap::new();
         for e in events.iter() {


### PR DESCRIPTION
## What & why

A two-agent review (an adversarial design review, then an `xhigh` self-review of the implementation) of the FFI seam between the Rust `tb_core_ffi` staticlib and the Swift app. The headline change is the **panic stance**: the shipping build used `panic = "abort"`, so any panic anywhere in the Rust core — a serde error, a bad index in a ported report module, an `.expect()` — aborts the **whole menu-bar app**. One malformed session file could turn that into an unrecoverable launch-crash loop (parse on launch → panic → abort → relaunch → …).

The Swift side is already built for per-card failure (`try?` keeps the last good numbers on any one card's error). This PR makes the Rust side match that contract.

## Changes

**`fix(ffi)` — Rust seam**
- Remove `panic = "abort"` → unwind, and wrap **every** FFI entry point in a `guarded()` `catch_unwind`. A panic now returns `{"ok":false,"err":"<name> panicked: …"}` and degrades that one card; the process survives.
- Unwinding makes Mutex poison-recovery meaningful again (a Mutex only poisons on unwind). `GRAPH_CACHE` / `TAIL_LAST_TICK` / `CLAUDE_USAGE_GATE` now **all** recover via `into_inner()` (previously `GRAPH_CACHE` silently went cache-dead on poison); the doc spells out which locks poison vs the `parking_lot` ones that don't.
- `usage_tail::trace`: reject non-positive `window_secs` (mirrors `rate_in_window`) and use **saturating** arithmetic on the cutoff so a garbage window can't overflow — `window_secs` itself is left intact so the per-minute divisor isn't distorted (a `clamp` would have been wrong here).
- `graph_cached` / `tail_tick_if_stale`: stop holding the cache/tick lock across filesystem I/O and the heavy re-parse, so concurrent pollers don't serialize. `tail_tick_if_stale` claims the tick before releasing the lock (dedup concurrent re-parses), and a `TickClaim` drop-guard **rolls the claim back if the tick panics**, so a transient tick panic doesn't suppress re-parse for a full interval.

**`fix(swift)` — bridge observability + tests**
- Add an `os.Logger` at the two boundary chokepoints (`decode`/`unwrap`) so FFI errors swallowed by `try?` are no longer invisible. Logs the entry-point type + error string only — never a payload body (agent usage carries emails).
- Split the pure envelope decode into `decodeEnvelope(Data)` (unit-testable without a real FFI allocation) and centralize `tb_free` in `takeBytes` as the single legal pointer consumer.
- Hermetic `--selftest` checks for the `ok:false → bridge`, missing-data, and malformed-body paths that `--smoke` never exercises on live data.

## Deliberately NOT done
- **No outer timeout on `tb_agent_usage`.** The self-review found an earlier 35s `tokio::time::timeout` was harmful: when it fired it collapsed the whole payload to one error (losing the providers that already succeeded), and it could cut off the legitimate expired-token path (sequential refresh + fetch ≈ 60s). Each provider already carries its own 30s reqwest timeout (which covers connect), so nothing hangs unbounded — the outer cap was dropped.
- Left as known/low-risk: `agent_usage` single-flight, an agentUsage staleness badge, the 429 gate's cross-error stale-serve.

## Test plan
- `cargo test --workspace` (27 ffi + 842 tokscale-core) — includes new tests that prove a guarded panic becomes an error envelope (process survives), the window guard rejects non-positive/overflowing input, and the tick claim rolls back on the panic path.
- `cargo clippy --workspace --all-targets`, `cargo build --release`, `swift build`, `swift run TokenBar --selftest`, `swift run TokenBar --smoke` — all green; every FFI entry point exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TQpBXVDajv8w5jEZxazYm
