### PR TITLE
fix(core): sync upstream pricing + client-attribution correctness (M1)

### DIFF
--- a/vendor/README.md
+++ b/vendor/README.md
@@ -9,6 +9,24 @@
 > archived, this repo now owns the vendored copy; future syncs come straight
 > from junhoyeo/tokscale and must re-apply the local patches below.
 
+> **Baseline:** this vendor's true upstream baseline is ≈ junhoyeo/tokscale
+> `0c820a5d` (cc-mirror #618) — **not** the `version = "3.0.0"` in `Cargo.toml`,
+> which is stale. It sits between upstream v3.0.0 and v3.1.x, plus the local
+> patches below, plus the cherry-picked upstream commits listed next.
+
+## Cherry-picked upstream commits (ahead of baseline)
+
+Specific later upstream fixes pulled in à la carte (we do **not** re-vendor
+wholesale — that would clobber the streaming/dedup/cowork patches below). The
+next sync should treat these as already-present and not re-apply them.
+
+| Commit | What | Files |
+|---|---|---|
+| `#614` (1a305f0f) → `#658` (5c1fe659) → `#634` (aebe4ea8) | Modern-Claude pricing: parse `claude-{family}-{major}-{minor}` from the id instead of a hardcoded opus-4.7/4.6/4.5 chain, never-degrade veto on the resolve path, and skip-unusable exact entries. Fixes ~3x overcharge on newer minors (e.g. `opus-4-8`). **models.dev (`#665`) deliberately excluded.** | `src/pricing/lookup.rs` |
+| `#707` (5017eefb), *blocklist hunk only* | `FUZZY_BLOCKLIST` += `claude`/`anthropic`/`model`/`router`; `strips_claude_numeric_minor` hardened via new `is_version_segment`. Stops retired `claude-2.x` eroding to a bare brand token and fuzzy-matching an opus-fast key. The pass-reorder / `prefers_model_part_key` / models.dev parts of #707 were **not** taken. | `src/pricing/lookup.rs` |
+| `#659` (7500b303) | cc-mirror `tool_result` keeps its variant client id + provider hint (was hardcoded to `claude`); dedup_key namespaced by client. | `src/sessions/claudecode.rs` |
+| `#723` (cbbd0dff) | Copilot CLI OTEL underscore-format cache token attributes (`gen_ai.usage.cache_read_input_tokens`) read as fallbacks (were 0). | `src/sessions/copilot.rs` |
+
 ## Local patches (diverged from upstream)
 
 | Patch | Files | Status upstream |
@@ -17,3 +35,5 @@
 | PR #3 (perf): streaming per-file aggregation replaces materialize-then-aggregate for the graph/model/monthly/hourly reports — `StreamingAggregator` + `SessionizeAccumulator` folded by `scan_messages_streaming` in one cache-aware pass (no full-history `Vec`). Each client lane owns its dedup set (follow-up `0752e35`: prevents cross-client `dedup_key` collisions). | `src/aggregator.rs`, `src/lib.rs`, `src/sessionize.rs`, `tests/streaming_snapshot.rs` | not yet forwarded to junhoyeo/tokscale |
 | #6 (fix): the **agents report** now folds over `scan_messages_streaming` too — new `get_agents_report` (mirrors `get_model_report`, `resolve_report_clients` + a single streaming pass into `AgentAccumulator`), so it shares the one deduped/per-client-gated/priced stream as every other report (resolves the issue #6 divergence: agents no longer over-counts copilot/codebuff/kimi/cursor/warp/… duplicate `dedup_key`s, and scans the same client set). `parse_local_unified_messages` survives as public API only (footgun-documented, no in-repo callers). `crates/tb_core_ffi/src/agents_report.rs` is now a thin mapper like `model_report.rs` (no longer byte-identical to the archived Tauri original — accepted). | `src/lib.rs`, `crates/tb_core_ffi/src/agents_report.rs` | not yet forwarded to junhoyeo/tokscale |
 | #5 (feat): discover Claude desktop "Cowork" (local-agent-mode) transcripts. `discover_cowork_project_roots()` recurses `~/Library/Application Support/Claude/local-agent-mode-sessions/**/.claude/projects` and feeds the roots into `built_in_extra_scan_paths_for` as `ClientId::Claude`. Returns the per-session `projects` roots only, so the sibling `audit.jsonl` (a mirror of the same `usage` records) is never scanned — scanning it would double-count. | `src/scanner.rs` | not yet forwarded to junhoyeo/tokscale |
+| pricing (fix): **cache-rate backfill** — `choose_best_source_result` is wrapped so the chosen pricing source has any missing cache read/write rates grafted from the runner-up source (`backfill_cache_costs` + `prefer_litellm_over_openrouter`). Without it, a provider-hint that selects an entry lacking cache rates (e.g. an OpenRouter row) bills cache reads at $0 (fable-5 showed $11.50 instead of $45). Upstream `#658`/`#707` do **not** subsume this: `has_any_usable_pricing` is an `.any()` gate, so a row that prices everything *except* cache still passes through unfilled — the root cause stays ours to fix. | `src/pricing/lookup.rs` | not yet forwarded to junhoyeo/tokscale |
+| pricing (perf): **in-memory auto-refresh** — `PRICING_SERVICE` is a `RwLock<Option<CachedService>>` with `IN_MEMORY_TTL = 3600s` (was a never-refreshing `OnceCell`), so prices re-read the file cache / network roughly hourly instead of being frozen for the process lifetime; adds `pricing_cached_at()` (Models card "Prices updated …"). Spans `mod.rs` + the additive `litellm::cached_at` / `cache::cache_timestamp` helpers. | `src/pricing/mod.rs`, `src/pricing/litellm.rs`, `src/pricing/cache.rs` | not yet forwarded to junhoyeo/tokscale |

--- a/vendor/tokscale-core/src/pricing/lookup.rs
+++ b/vendor/tokscale-core/src/pricing/lookup.rs
@@ -46,7 +46,27 @@ const RESELLER_PROVIDER_PREFIXES: &[&str] = &[
     "openrouter/",
 ];
 
-const FUZZY_BLOCKLIST: &[&str] = &["auto", "mini", "chat", "base"];
+// Bare brand tokens ("claude", "anthropic") are blocked because they contain
+// no model information: a fuzzy hit from them can land on any model of the
+// brand (e.g. retired `claude-2.1` eroding to `claude` and billing at an
+// opus-fast key), so such a match is never trustworthy.
+//
+// Generic English words ("model", "router") are blocked for the same reason:
+// they carry no model identity, yet substring-match real priced keys
+// (`azure_ai/model_router`, `kilo/switchpoint/router`). Without this guard an
+// id whose only fuzzy-eligible remnant after suffix stripping is the word
+// `model` (e.g. `model-zero-usage-v1` -> stripped `model`) misprices at the
+// router key's rate. See `fuzzy_match_does_not_resolve_generic_model_token`.
+const FUZZY_BLOCKLIST: &[&str] = &[
+    "auto",
+    "mini",
+    "chat",
+    "base",
+    "claude",
+    "anthropic",
+    "model",
+    "router",
+];
 
 const MAX_LOOKUP_CACHE_ENTRIES: usize = 512;
 const TIERED_PRICING_THRESHOLD_128K_TOKENS: f64 = 128_000.0;
@@ -269,9 +289,25 @@ impl PricingLookup {
             Some("openrouter") => self.lookup_openrouter_only(id, provider_id),
             _ => self.lookup_auto(id, provider_id),
         };
+        let requested_family = claude_family(lower_ref);
+        let requested_version = requested_claude_version(lower_ref);
+        let unparsed_modern_version = requested_family.is_some()
+            && requested_version.is_none()
+            && contains_delimited_modern_major_minor(lower_ref);
+        let unsafe_claude_resolution = |result: &LookupResult| {
+            resolves_unsafe_claude_version(
+                requested_family,
+                requested_version.as_deref(),
+                unparsed_modern_version,
+                result,
+            )
+        };
 
         // 1. Try direct lookup
         if let Some(result) = do_lookup(lower_ref) {
+            if unsafe_claude_resolution(&result) {
+                return None;
+            }
             return Some(result);
         }
 
@@ -279,14 +315,18 @@ impl PricingLookup {
             return None;
         }
 
+        let guarded_lookup = |candidate: &str| {
+            do_lookup(candidate).filter(|result| !unsafe_claude_resolution(result))
+        };
+
         // 2. Try stripping unknown suffixes (e.g., -thinking, -high, -codex)
-        if let Some(result) = try_strip_unknown_suffix(lower_ref, do_lookup) {
+        if let Some(result) = try_strip_unknown_suffix(lower_ref, guarded_lookup) {
             return Some(result);
         }
 
         // 3. Try stripping unknown prefixes (e.g., antigravity-, myplugin-)
         //    For each prefix candidate, also try suffix stripping
-        if let Some(result) = try_strip_unknown_prefix(lower_ref, do_lookup) {
+        if let Some(result) = try_strip_unknown_prefix(lower_ref, guarded_lookup) {
             return Some(result);
         }
 
@@ -576,11 +616,9 @@ impl PricingLookup {
             let key = format!("{}{}", prefix, model_id);
             if let Some(litellm_key) = self.litellm_lower.get(&key) {
                 if let Some(pricing) = self.litellm.get(litellm_key) {
-                    return Some(LookupResult {
-                        pricing: pricing.clone(),
-                        source: "LiteLLM".into(),
-                        matched_key: litellm_key.clone(),
-                    });
+                    if let Some(result) = lookup_result_if_usable(pricing, "LiteLLM", litellm_key) {
+                        return Some(result);
+                    }
                 }
             }
         }
@@ -646,30 +684,18 @@ impl PricingLookup {
     fn exact_match_litellm(&self, model_id: &str) -> Option<LookupResult> {
         let key = self.litellm_lower.get(model_id)?;
         let pricing = self.litellm.get(key)?;
-        Some(LookupResult {
-            pricing: pricing.clone(),
-            source: "LiteLLM".into(),
-            matched_key: key.clone(),
-        })
+        lookup_result_if_usable(pricing, "LiteLLM", key)
     }
 
     fn exact_match_openrouter(&self, model_id: &str) -> Option<LookupResult> {
         if let Some(key) = self.openrouter_lower.get(model_id) {
             if let Some(pricing) = self.openrouter.get(key) {
-                return Some(LookupResult {
-                    pricing: pricing.clone(),
-                    source: "OpenRouter".into(),
-                    matched_key: key.clone(),
-                });
+                return lookup_result_if_usable(pricing, "OpenRouter", key);
             }
         }
         if let Some(key) = self.openrouter_model_part.get(model_id) {
             if let Some(pricing) = self.openrouter.get(key) {
-                return Some(LookupResult {
-                    pricing: pricing.clone(),
-                    source: "OpenRouter".into(),
-                    matched_key: key.clone(),
-                });
+                return lookup_result_if_usable(pricing, "OpenRouter", key);
             }
         }
         None
@@ -677,20 +703,12 @@ impl PricingLookup {
 
     fn exact_match_cursor(&self, model_id: &str) -> Option<LookupResult> {
         if let Some(key) = self.cursor_lower.get(model_id) {
-            return Some(LookupResult {
-                pricing: self.cursor.get(key).unwrap().clone(),
-                source: "Cursor".into(),
-                matched_key: key.clone(),
-            });
+            return lookup_result_if_usable(self.cursor.get(key).unwrap(), "Cursor", key);
         }
         if let Some(model_part) = model_id.split('/').next_back() {
             if model_part != model_id {
                 if let Some(key) = self.cursor_lower.get(model_part) {
-                    return Some(LookupResult {
-                        pricing: self.cursor.get(key).unwrap().clone(),
-                        source: "Cursor".into(),
-                        matched_key: key.clone(),
-                    });
+                    return lookup_result_if_usable(self.cursor.get(key).unwrap(), "Cursor", key);
                 }
             }
         }
@@ -710,11 +728,9 @@ impl PricingLookup {
             let key = format!("{}{}", prefix, model_id);
             if let Some(litellm_key) = self.litellm_lower.get(&key) {
                 if let Some(pricing) = self.litellm.get(litellm_key) {
-                    return Some(LookupResult {
-                        pricing: pricing.clone(),
-                        source: "LiteLLM".into(),
-                        matched_key: litellm_key.clone(),
-                    });
+                    if let Some(result) = lookup_result_if_usable(pricing, "LiteLLM", litellm_key) {
+                        return Some(result);
+                    }
                 }
             }
         }
@@ -734,11 +750,9 @@ impl PricingLookup {
             let key = format!("{}{}", prefix, model_id);
             if let Some(or_key) = self.openrouter_lower.get(&key) {
                 if let Some(pricing) = self.openrouter.get(or_key) {
-                    return Some(LookupResult {
-                        pricing: pricing.clone(),
-                        source: "OpenRouter".into(),
-                        matched_key: or_key.clone(),
-                    });
+                    if let Some(result) = lookup_result_if_usable(pricing, "OpenRouter", or_key) {
+                        return Some(result);
+                    }
                 }
             }
         }
@@ -1062,51 +1076,200 @@ fn contains_model_id(key: &str, model_id: &str) -> bool {
 
 fn normalize_model_name(model_id: &str) -> Option<String> {
     let lower = model_id.to_lowercase();
+    let family = claude_family(&lower)?;
 
-    if lower.contains("opus") {
-        if contains_delimited_fragment(&lower, "4.7") || contains_delimited_fragment(&lower, "4-7")
-        {
-            return Some("claude-opus-4-7".into());
-        } else if contains_delimited_fragment(&lower, "4.6")
-            || contains_delimited_fragment(&lower, "4-6")
-        {
-            return Some("claude-opus-4-6".into());
-        } else if contains_delimited_fragment(&lower, "4.5")
-            || contains_delimited_fragment(&lower, "4-5")
-        {
-            return Some("claude-opus-4-5".into());
-        } else if contains_delimited_fragment(&lower, "4") {
-            return Some("claude-opus-4".into());
-        }
+    // Modern Claude line (major >= 4): explicit single-digit minor parsed
+    // straight from the id, in either order (claude-sonnet-4-6, opus-4.8,
+    // claude-4-6-sonnet). New minor releases need no code change.
+    if let Some(model) = normalize_claude_family_minor(&lower) {
+        return Some(model);
     }
-    if lower.contains("sonnet") {
-        if contains_delimited_fragment(&lower, "4.5") || contains_delimited_fragment(&lower, "4-5")
-        {
-            return Some("claude-sonnet-4-5".into());
-        } else if contains_delimited_fragment(&lower, "4") {
-            return Some("claude-sonnet-4".into());
-        } else if contains_delimited_fragment(&lower, "3.7")
-            || contains_delimited_fragment(&lower, "3-7")
-        {
-            return Some("claude-3-7-sonnet".into());
-        } else if contains_delimited_fragment(&lower, "3.5")
-            || contains_delimited_fragment(&lower, "3-5")
-        {
-            return Some("claude-3.5-sonnet".into());
-        }
+
+    // Never degrade: a delimited `major(-|.)minor` version whose minor was
+    // not recognized above (4-60, 4-0, 5-0, dated 4-20250514) must stay
+    // unresolved rather than fall through to a coarser or older key.
+    if contains_delimited_modern_major_minor(&lower) {
+        return None;
     }
-    if lower.contains("haiku") {
-        if contains_delimited_fragment(&lower, "4.5") || contains_delimited_fragment(&lower, "4-5")
+
+    // Bare modern major adjacent to the family token (claude-sonnet-5,
+    // opus-5, 4-opus). Resolves only via an exact dataset hit downstream.
+    if let Some(model) = normalize_claude_family_bare_major(&lower) {
+        return Some(model);
+    }
+
+    // Catch-alls preserved from the hardcoded matcher: a delimited `4`
+    // anywhere still maps opus/sonnet to the bare 4.0 key, and the legacy
+    // 3.x line uses irregular naming (family after the version, dotted 3.5).
+    match family {
+        "opus" if contains_delimited_fragment(&lower, "4") => Some("claude-opus-4".into()),
+        "sonnet" => {
+            if contains_delimited_fragment(&lower, "4") {
+                Some("claude-sonnet-4".into())
+            } else if contains_delimited_fragment(&lower, "3.7")
+                || contains_delimited_fragment(&lower, "3-7")
+            {
+                Some("claude-3-7-sonnet".into())
+            } else if contains_delimited_fragment(&lower, "3.5")
+                || contains_delimited_fragment(&lower, "3-5")
+            {
+                Some("claude-3.5-sonnet".into())
+            } else {
+                None
+            }
+        }
+        "haiku" => {
+            if contains_delimited_fragment(&lower, "3.5")
+                || contains_delimited_fragment(&lower, "3-5")
+            {
+                Some("claude-3.5-haiku".into())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Family tokens of the modern Claude model line.
+const CLAUDE_FAMILY_TOKENS: &[&str] = &["opus", "sonnet", "haiku", "fable"];
+
+/// The Claude family token contained in `lower`, if any.
+fn claude_family(lower: &str) -> Option<&'static str> {
+    CLAUDE_FAMILY_TOKENS
+        .iter()
+        .copied()
+        .find(|family| lower.contains(family))
+}
+
+/// Modern Claude majors are single digits >= 4. The 3.x line uses irregular
+/// naming and is matched explicitly by the legacy branches.
+fn is_modern_claude_major(value: &str) -> bool {
+    value.len() == 1 && value.as_bytes()[0].is_ascii_digit() && value.as_bytes()[0] >= b'4'
+}
+
+/// Canonical `claude-{family}-{major}-{minor}` key parsed from an id carrying
+/// an explicit single-digit minor for a modern major (>= 4), in either
+/// `family-major-minor` (claude-sonnet-4-6, opus-4.8) or reversed
+/// `major-minor-family` (claude-4-6-sonnet, 4-8-opus) order. Generalization
+/// of the former opus-only `normalize_claude_opus_4_minor` across families.
+fn normalize_claude_family_minor(lower: &str) -> Option<String> {
+    let parts: Vec<&str> = lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .collect();
+
+    for window in parts.windows(3) {
+        if CLAUDE_FAMILY_TOKENS.contains(&window[0])
+            && is_modern_claude_major(window[1])
+            && is_single_digit_minor(window[2])
         {
-            return Some("claude-haiku-4-5".into());
-        } else if contains_delimited_fragment(&lower, "3.5")
-            || contains_delimited_fragment(&lower, "3-5")
+            return Some(format!("claude-{}-{}-{}", window[0], window[1], window[2]));
+        }
+        if is_modern_claude_major(window[0])
+            && is_single_digit_minor(window[1])
+            && CLAUDE_FAMILY_TOKENS.contains(&window[2])
         {
-            return Some("claude-3.5-haiku".into());
+            return Some(format!("claude-{}-{}-{}", window[2], window[0], window[1]));
         }
     }
 
     None
+}
+
+/// Canonical `claude-{family}-{major}` key for an id naming a modern major
+/// (>= 4) without a minor (claude-sonnet-5, opus-5, 4-opus). The major must
+/// be adjacent to the family token; in forward order it must not be followed
+/// by another digit run (dated `4-20250514` shapes are version-like, not
+/// bare), and in reversed order it must not itself be the minor of a
+/// preceding legacy major (claude-3-5-sonnet).
+fn normalize_claude_family_bare_major(lower: &str) -> Option<String> {
+    let parts: Vec<&str> = lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .collect();
+    let all_digits = |part: &str| part.bytes().all(|b| b.is_ascii_digit());
+
+    for (idx, part) in parts.iter().enumerate() {
+        if !CLAUDE_FAMILY_TOKENS.contains(part) {
+            continue;
+        }
+        if let Some(major) = parts
+            .get(idx + 1)
+            .copied()
+            .filter(|p| is_modern_claude_major(p))
+        {
+            if parts.get(idx + 2).is_none_or(|next| !all_digits(next)) {
+                return Some(format!("claude-{part}-{major}"));
+            }
+        }
+        if idx >= 1
+            && is_modern_claude_major(parts[idx - 1])
+            && (idx < 2 || !all_digits(parts[idx - 2]))
+        {
+            return Some(format!("claude-{part}-{}", parts[idx - 1]));
+        }
+    }
+
+    None
+}
+
+/// True if the id carries a delimited modern `major(-|.)minor` version
+/// (4-6, 4.8, 5-0, 4-60, 4-20250514). Generalizes the former
+/// `contains_delimited_major_minor(lower, '4')` checks across all modern
+/// majors so the never-degrade contract also covers major 5 and up.
+fn contains_delimited_modern_major_minor(haystack: &str) -> bool {
+    ('4'..='9').any(|major| contains_delimited_major_minor(haystack, major))
+}
+
+/// The version-pinned canonical key a Claude id requests, used to veto
+/// fuzzy/stripped resolutions that would land on a different version.
+///
+/// - An explicit single-digit minor (claude-sonnet-4-7) always pins; this is
+///   main's opus-only minor guard generalized across families.
+/// - A bare major pins from major 5 up (claude-opus-5 must never bill as any
+///   opus 4.x key). Bare major 4 is deliberately left unpinned to preserve
+///   the long-standing behavior of e.g. `claude-opus-4` resolving to a
+///   dated or regional 4.x dataset key.
+fn requested_claude_version(lower: &str) -> Option<String> {
+    if let Some(model) = normalize_claude_family_minor(lower) {
+        return Some(model);
+    }
+    normalize_claude_family_bare_major(lower).filter(|model| !model.ends_with("-4"))
+}
+
+/// Veto for resolutions that violate the never-degrade contract:
+/// cross-family (a sonnet id billed at an opus key), cross-version (a 4-7 id
+/// billed at a 4-6 key, a major-5 id billed at a 4.x key), or any
+/// modern-Claude resolution for an id whose `major-minor` version could not
+/// be parsed (4-60, 5-0, dated forms). Exact dataset hits stay allowed: they
+/// either normalize back to the requested version or, for unparseable
+/// versions, do not normalize at all. Generalization of the former
+/// `resolves_different_claude_opus_4_minor`.
+fn resolves_unsafe_claude_version(
+    requested_family: Option<&'static str>,
+    requested_version: Option<&str>,
+    unparsed_modern_version: bool,
+    result: &LookupResult,
+) -> bool {
+    let Some(requested_family) = requested_family else {
+        return false;
+    };
+    let matched_lower = result.matched_key.to_lowercase();
+
+    if claude_family(&matched_lower).is_some_and(|family| family != requested_family) {
+        return true;
+    }
+
+    let resolved = normalize_model_name(&matched_lower);
+    if let Some(requested_version) = requested_version {
+        return resolved.is_some_and(|resolved| resolved != requested_version);
+    }
+    unparsed_modern_version && resolved.is_some()
+}
+
+fn is_single_digit_minor(value: &str) -> bool {
+    value.len() == 1 && value.as_bytes()[0].is_ascii_digit() && value.as_bytes()[0] != b'0'
 }
 
 fn normalize_version_separator(model_id: &str) -> Option<String> {
@@ -1182,6 +1345,18 @@ fn has_any_usable_pricing(pricing: &ModelPricing) -> bool {
     ]
     .into_iter()
     .any(|opt| opt.is_some_and(is_valid_price_value))
+}
+
+fn lookup_result_if_usable(
+    pricing: &ModelPricing,
+    source: &str,
+    matched_key: &str,
+) -> Option<LookupResult> {
+    has_any_usable_pricing(pricing).then(|| LookupResult {
+        pricing: pricing.clone(),
+        source: source.into(),
+        matched_key: matched_key.into(),
+    })
 }
 
 fn has_any_valid_above_tier_value(pricing: &ModelPricing) -> bool {
@@ -1268,6 +1443,26 @@ fn contains_delimited_fragment(haystack: &str, fragment: &str) -> bool {
     false
 }
 
+fn contains_delimited_major_minor(haystack: &str, major: char) -> bool {
+    for (pos, _) in haystack.match_indices(major) {
+        let before_ok = pos == 0 || !haystack[..pos].chars().last().unwrap().is_alphanumeric();
+        let after_pos = pos + major.len_utf8();
+        let mut after = haystack[after_pos..].chars();
+        let Some(separator) = after.next() else {
+            continue;
+        };
+        let Some(minor_start) = after.next() else {
+            continue;
+        };
+
+        if before_ok && matches!(separator, '.' | '-') && minor_start.is_ascii_digit() {
+            return true;
+        }
+    }
+
+    false
+}
+
 fn is_fuzzy_eligible(model_id: &str) -> bool {
     if model_id.len() < MIN_FUZZY_MATCH_LEN {
         return false;
@@ -1282,6 +1477,10 @@ fn try_strip_unknown_suffix<F>(model_id: &str, do_lookup: F) -> Option<LookupRes
 where
     F: Fn(&str) -> Option<LookupResult>,
 {
+    if has_unrecognized_claude_four_minor(model_id) {
+        return None;
+    }
+
     let parts: Vec<&str> = model_id.split('-').collect();
 
     if parts.len() < 2 {
@@ -1294,6 +1493,10 @@ where
         let candidate: String = parts[..parts.len() - strip].join("-");
 
         if candidate.len() >= MIN_MODEL_NAME_LEN {
+            if strips_claude_numeric_minor(&candidate, parts[parts.len() - strip]) {
+                continue;
+            }
+
             if let Some(result) = do_lookup(&candidate) {
                 return Some(result);
             }
@@ -1301,6 +1504,58 @@ where
     }
 
     None
+}
+
+fn strips_claude_numeric_minor(candidate: &str, first_stripped_segment: &str) -> bool {
+    if !is_version_segment(first_stripped_segment) {
+        return false;
+    }
+    let claude_branded = candidate.contains("claude")
+        || candidate.contains("opus")
+        || candidate.contains("sonnet")
+        || candidate.contains("haiku");
+    if !claude_branded {
+        return false;
+    }
+    // Refuse to strip a version segment when it would either peel a minor off
+    // a still-versioned claude-4 candidate (claude-sonnet-4-5 -> claude-sonnet-4)
+    // or erode the id's only version, leaving a bare brand token
+    // (claude-2.1 -> claude). Both candidates would resolve to a different
+    // model's price. Dated forms (claude-3-5-sonnet-20241022) keep stripping:
+    // their candidate retains a version, so neither arm fires.
+    contains_delimited_fragment(candidate, "4") || !candidate.bytes().any(|b| b.is_ascii_digit())
+}
+
+/// True for a bare version segment produced by splitting an id on `-`:
+/// digits with at most one interior dot (`4`, `6`, `2.1`, `20241022`).
+fn is_version_segment(segment: &str) -> bool {
+    let bytes = segment.as_bytes();
+    if bytes.is_empty() || !bytes[0].is_ascii_digit() || !bytes[bytes.len() - 1].is_ascii_digit() {
+        return false;
+    }
+    let mut seen_dot = false;
+    for &byte in bytes {
+        match byte {
+            b'0'..=b'9' => {}
+            b'.' if !seen_dot => seen_dot = true,
+            _ => return false,
+        }
+    }
+    true
+}
+
+fn has_unrecognized_claude_four_minor(model_id: &str) -> bool {
+    (model_id.contains("claude")
+        || model_id.contains("opus")
+        || model_id.contains("sonnet")
+        || model_id.contains("haiku"))
+        && contains_delimited_major_minor(model_id, '4')
+        && !contains_delimited_fragment(model_id, "4.5")
+        && !contains_delimited_fragment(model_id, "4-5")
+        && !contains_delimited_fragment(model_id, "4.6")
+        && !contains_delimited_fragment(model_id, "4-6")
+        && !contains_delimited_fragment(model_id, "4.7")
+        && !contains_delimited_fragment(model_id, "4-7")
 }
 
 /// Attempts to find a model by progressively stripping leading segments.
@@ -2826,7 +3081,7 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_opus_4_60_does_not_map_to_4_6() {
+    fn test_normalize_opus_4_60_does_not_degrade_to_opus_4() {
         let mut litellm = HashMap::new();
         litellm.insert(
             "claude-opus-4".into(),
@@ -2846,9 +3101,7 @@ mod tests {
         );
 
         let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
-        let result = lookup.lookup("opus-4-60").unwrap();
-        assert_eq!(result.matched_key, "claude-opus-4");
-        assert_ne!(result.matched_key, "claude-opus-4-6");
+        assert!(lookup.lookup("opus-4-60").is_none());
     }
 
     #[test]
@@ -2955,6 +3208,24 @@ mod tests {
     }
 
     #[test]
+    fn test_unknown_future_opus_minor_does_not_degrade_to_opus_4() {
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000015),
+                output_cost_per_token: Some(0.000075),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(HashMap::new(), openrouter, HashMap::new());
+
+        assert!(lookup.lookup("claude-opus-4-8").is_none());
+        assert!(lookup.lookup("aws.claude-opus-4-8").is_none());
+    }
+
+    #[test]
     fn test_normalize_opus_14_6_does_not_map_to_4_6() {
         let mut litellm = HashMap::new();
         litellm.insert(
@@ -2978,6 +3249,375 @@ mod tests {
     #[test]
     fn test_normalize_haiku_14_5_does_not_map_to_4_5() {
         assert_eq!(normalize_model_name("haiku-14-5"), None);
+    }
+
+    // =========================================================================
+    // Generalized Claude family/major/minor normalization (PR #634 rework)
+    // =========================================================================
+
+    /// Synthetic dataset mirroring real LiteLLM/OpenRouter key shapes, with
+    /// deliberately adversarial gaps: bedrock-style `us.anthropic.` keys exist
+    /// for opus but not sonnet, and OpenRouter carries a pricier opus `-fast`
+    /// variant that the old fallbacks degraded other families onto.
+    fn claude_family_fixture() -> PricingLookup {
+        fn p(input: f64, output: f64) -> ModelPricing {
+            ModelPricing {
+                input_cost_per_token: Some(input),
+                output_cost_per_token: Some(output),
+                ..Default::default()
+            }
+        }
+
+        let mut litellm = HashMap::new();
+        litellm.insert("claude-opus-4".to_string(), p(15e-6, 75e-6));
+        litellm.insert("claude-opus-4-1".to_string(), p(15e-6, 75e-6));
+        litellm.insert("claude-opus-4-5".to_string(), p(5e-6, 25e-6));
+        litellm.insert("claude-opus-4-6".to_string(), p(5e-6, 25e-6));
+        litellm.insert("claude-opus-4-7".to_string(), p(5e-6, 25e-6));
+        litellm.insert("claude-opus-4-8".to_string(), p(5e-6, 25e-6));
+        litellm.insert("claude-sonnet-4".to_string(), p(3e-6, 15e-6));
+        litellm.insert("claude-sonnet-4-5".to_string(), p(3e-6, 15e-6));
+        litellm.insert("claude-sonnet-4-6".to_string(), p(3e-6, 15e-6));
+        litellm.insert("claude-haiku-4-5".to_string(), p(1e-6, 5e-6));
+        litellm.insert("us.anthropic.claude-opus-4-8".to_string(), p(5e-6, 25e-6));
+        litellm.insert("vertex_ai/claude-sonnet-4-6".to_string(), p(3e-6, 15e-6));
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert("anthropic/claude-opus-4".to_string(), p(15e-6, 75e-6));
+        openrouter.insert("anthropic/claude-opus-4.8".to_string(), p(5e-6, 25e-6));
+        openrouter.insert("anthropic/claude-opus-4.8-fast".to_string(), p(7e-6, 30e-6));
+        openrouter.insert("anthropic/claude-sonnet-4.6".to_string(), p(3e-6, 15e-6));
+        openrouter.insert("anthropic/claude-haiku-4.5".to_string(), p(1e-6, 5e-6));
+        openrouter.insert("anthropic/claude-fable-5".to_string(), p(5e-6, 25e-6));
+
+        PricingLookup::new(litellm, openrouter, HashMap::new())
+    }
+
+    #[test]
+    fn test_normalize_minor_generalizes_across_families() {
+        assert_eq!(
+            normalize_model_name("claude-sonnet-4-7"),
+            Some("claude-sonnet-4-7".into())
+        );
+        assert_eq!(
+            normalize_model_name("sonnet-4.7"),
+            Some("claude-sonnet-4-7".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-haiku-4-6"),
+            Some("claude-haiku-4-6".into())
+        );
+        assert_eq!(
+            normalize_model_name("haiku-4.6"),
+            Some("claude-haiku-4-6".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-opus-4-9"),
+            Some("claude-opus-4-9".into())
+        );
+        assert_eq!(
+            normalize_model_name("opus-4.9"),
+            Some("claude-opus-4-9".into())
+        );
+        assert_eq!(
+            normalize_model_name("opus-5-2"),
+            Some("claude-opus-5-2".into())
+        );
+    }
+
+    #[test]
+    fn test_normalize_reversed_order_all_families() {
+        assert_eq!(
+            normalize_model_name("claude-4-8-opus"),
+            Some("claude-opus-4-8".into())
+        );
+        assert_eq!(
+            normalize_model_name("4-8-opus"),
+            Some("claude-opus-4-8".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-4-6-sonnet"),
+            Some("claude-sonnet-4-6".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-4-5-haiku"),
+            Some("claude-haiku-4-5".into())
+        );
+    }
+
+    #[test]
+    fn test_normalize_bare_modern_major() {
+        assert_eq!(
+            normalize_model_name("claude-sonnet-5"),
+            Some("claude-sonnet-5".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-opus-5"),
+            Some("claude-opus-5".into())
+        );
+        assert_eq!(
+            normalize_model_name("fable-5"),
+            Some("claude-fable-5".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-fable-5[1m]"),
+            Some("claude-fable-5".into())
+        );
+    }
+
+    /// Boundary contract preserved from main's hardcoded matcher: two-digit
+    /// minors and majors, zero minors, undelimited versions, and dated forms
+    /// must not normalize to a coarser key. (PR #634's original parser
+    /// degraded `opus-4-60` to `claude-opus-4`; main's contract is None.)
+    #[test]
+    fn test_normalize_modern_claude_boundaries() {
+        assert_eq!(normalize_model_name("opus-4-60"), None);
+        assert_eq!(normalize_model_name("sonnet-4-60"), None);
+        assert_eq!(normalize_model_name("opus-14-6"), None);
+        assert_eq!(normalize_model_name("opus4"), None);
+        assert_eq!(normalize_model_name("opus-4x"), None);
+        assert_eq!(normalize_model_name("opus-3"), None);
+        assert_eq!(normalize_model_name("claude-sonnet-5-0"), None);
+        assert_eq!(normalize_model_name("claude-opus-4-20250514"), None);
+    }
+
+    /// Legacy 3.x ids keep their irregular canonical keys; the reversed-order
+    /// and bare-major parsing must not hijack the digit pairs in them.
+    #[test]
+    fn test_normalize_legacy_line_not_hijacked_by_modern_parser() {
+        assert_eq!(
+            normalize_model_name("claude-3-5-sonnet"),
+            Some("claude-3.5-sonnet".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-3-7-sonnet-20250219"),
+            Some("claude-3-7-sonnet".into())
+        );
+        assert_eq!(
+            normalize_model_name("claude-3-5-haiku-20241022"),
+            Some("claude-3.5-haiku".into())
+        );
+    }
+
+    /// Regression (B1): a bedrock-style sonnet id must never be billed at an
+    /// opus key. Before the family guard, `us.anthropic.claude-sonnet-4-6-v1:0`
+    /// suffix-stripped down to `us.anthropic.claude` and fuzzy-matched the
+    /// dataset's `us.anthropic.claude-opus-4-8` entry ($5/M instead of $3/M).
+    #[test]
+    fn test_bedrock_sonnet_never_billed_as_opus() {
+        let lookup = claude_family_fixture();
+        let result = lookup
+            .lookup("us.anthropic.claude-sonnet-4-6-v1:0")
+            .unwrap();
+        assert_eq!(result.matched_key, "claude-sonnet-4-6");
+        assert_eq!(result.pricing.input_cost_per_token, Some(3e-6));
+    }
+
+    /// Regression (B2): reversed-order sonnet ids must resolve to the sonnet
+    /// key, not cross-family. Before reversed-order parsing was generalized
+    /// beyond opus, `claude-4-6-sonnet` stripped down to `claude` and
+    /// fuzzy-matched `anthropic/claude-opus-4.8-fast`.
+    #[test]
+    fn test_reversed_sonnet_resolves_canonical_not_cross_family() {
+        let lookup = claude_family_fixture();
+        for id in ["claude-4-6-sonnet", "4-6-sonnet"] {
+            let result = lookup.lookup(id).unwrap();
+            assert_eq!(result.matched_key, "claude-sonnet-4-6", "id: {id}");
+        }
+        let result = lookup.lookup("claude-4-5-haiku").unwrap();
+        assert_eq!(result.matched_key, "claude-haiku-4-5");
+    }
+
+    /// Regression (B3): the never-degrade contract that
+    /// `test_unknown_future_opus_minor_does_not_degrade_to_opus_4` pins for
+    /// opus now holds for sonnet and haiku too. Unknown minors previously
+    /// degraded: `sonnet-4-7` -> claude-sonnet-4.6, `haiku-4-6` ->
+    /// claude-haiku-4.5 (and with real data even claude-3.5-haiku).
+    #[test]
+    fn test_unknown_sonnet_haiku_minor_does_not_degrade() {
+        let lookup = claude_family_fixture();
+        for id in [
+            "sonnet-4-7",
+            "claude-sonnet-4-7",
+            "sonnet-4-60",
+            "haiku-4-6",
+            "claude-haiku-4-6",
+        ] {
+            assert!(lookup.lookup(id).is_none(), "id {id} must not degrade");
+        }
+    }
+
+    /// Regression (B4): major >= 5 ids resolve to a dataset-known exact id
+    /// when one exists, else None — never to a different major. Previously
+    /// `claude-opus-5` resolved to `anthropic/claude-opus-4.8-fast` and
+    /// `sonnet-5`/`claude-sonnet-5-0` to sonnet 4.6, while bare `opus-5`
+    /// happened to return None only because of a fuzzy length cutoff.
+    #[test]
+    fn test_major_five_never_resolves_to_different_major() {
+        let lookup = claude_family_fixture();
+        for id in [
+            "claude-opus-5",
+            "opus-5",
+            "opus-5-2",
+            "sonnet-5",
+            "claude-sonnet-5-0",
+        ] {
+            assert!(
+                lookup.lookup(id).is_none(),
+                "id {id} must not resolve to a 4.x key"
+            );
+        }
+
+        // fable-5 is dataset-known (OpenRouter) and resolves in all forms.
+        for id in [
+            "claude-fable-5",
+            "fable-5",
+            "claude-fable-5[1m]",
+            "anthropic/claude-fable-5",
+        ] {
+            let result = lookup.lookup(id).unwrap();
+            assert_eq!(result.matched_key, "anthropic/claude-fable-5", "id: {id}");
+        }
+    }
+
+    /// When the dataset later gains a major-5 key, the same ids resolve to it
+    /// with no code change — the "known version" decision is dataset-driven.
+    #[test]
+    fn test_major_five_resolves_once_dataset_knows_it() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "claude-opus-5".to_string(),
+            ModelPricing {
+                input_cost_per_token: Some(0.00001),
+                output_cost_per_token: Some(0.00005),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        for id in ["claude-opus-5", "opus-5", "aws.claude-opus-5-thinking"] {
+            let result = lookup.lookup(id).unwrap();
+            assert_eq!(result.matched_key, "claude-opus-5", "id: {id}");
+        }
+    }
+
+    /// Known minors keep resolving across the id shapes seen in the wild:
+    /// dotted versions, vendor prefixes, tier/feature suffixes.
+    #[test]
+    fn test_known_minor_shapes_resolve_per_family() {
+        let lookup = claude_family_fixture();
+        let cases = [
+            ("opus-4-8", "claude-opus-4-8"),
+            ("opus-4.8", "claude-opus-4-8"),
+            ("aws.claude-opus-4-8", "claude-opus-4-8"),
+            ("claude-opus-4-8-thinking", "claude-opus-4-8"),
+            ("claude-sonnet-4-6", "claude-sonnet-4-6"),
+            ("claude-sonnet-4.6", "claude-sonnet-4-6"),
+            ("sonnet-4-6", "claude-sonnet-4-6"),
+            ("sonnet-4.6", "claude-sonnet-4-6"),
+            ("aws.claude-sonnet-4-6-v1", "claude-sonnet-4-6"),
+            ("claude-sonnet-4-6-thinking", "claude-sonnet-4-6"),
+            ("haiku-4-5", "claude-haiku-4-5"),
+            ("haiku-4.5", "claude-haiku-4-5"),
+            ("vertex_ai/claude-sonnet-4-6", "vertex_ai/claude-sonnet-4-6"),
+        ];
+        for (id, expected) in cases {
+            let result = lookup.lookup(id).unwrap();
+            assert_eq!(result.matched_key, expected, "id: {id}");
+        }
+    }
+
+    /// Ported from PR #634: the next opus minor must prefer its own key over
+    /// the bare `claude-opus-4` catch-all, in dashed and dotted forms.
+    #[test]
+    fn test_normalize_opus_4_8_prefers_4_8_over_4() {
+        let lookup = claude_family_fixture();
+        for id in ["opus-4-8", "opus-4.8"] {
+            let result = lookup.lookup(id).unwrap();
+            assert_eq!(result.matched_key, "claude-opus-4-8", "id: {id}");
+            assert_eq!(result.source, "LiteLLM");
+        }
+    }
+
+    /// Ported from PR #634: `aws.claude-opus-4-8` must not degrade to
+    /// OpenRouter's legacy `anthropic/claude-opus-4` (~3x overcharge).
+    #[test]
+    fn test_aws_opus_4_8_does_not_degrade_to_opus_4() {
+        let lookup = claude_family_fixture();
+        let result = lookup.lookup("aws.claude-opus-4-8").unwrap();
+        assert_eq!(result.matched_key, "claude-opus-4-8");
+
+        // 8.4M input + 873K output at opus-4-8 rates is ~$64, not ~$191
+        // (legacy opus 4 at $15/$75 per M).
+        let cost = lookup.calculate_cost("aws.claude-opus-4-8", 8_400_000, 873_000, 0, 0, 0);
+        assert!(
+            (60.0..=70.0).contains(&cost),
+            "expected opus-4-8 priced cost around $64, got ${cost:.2}"
+        );
+    }
+
+    /// Ported behavior from PR #707: a bare brand token carries no model
+    /// identity, so a retired `claude-2.1` that erodes to `claude` (or the bare
+    /// `claude`/`anthropic` tokens themselves) must stay unpriced rather than
+    /// fuzzy-match an opus key. Without the FUZZY_BLOCKLIST additions these
+    /// would land on `anthropic/claude-opus-4.8-fast` / legacy `claude-opus-4`.
+    #[test]
+    fn test_bare_brand_token_does_not_fuzzy_match_opus() {
+        let lookup = claude_family_fixture();
+        assert!(
+            lookup.lookup("claude").is_none(),
+            "bare 'claude' must not resolve to any opus key"
+        );
+        assert!(
+            lookup.lookup("anthropic").is_none(),
+            "bare 'anthropic' must not resolve to any opus key"
+        );
+        assert!(
+            lookup.lookup("claude-2.1").is_none(),
+            "retired claude-2.1 must not erode to 'claude' and fuzzy-match opus-fast"
+        );
+    }
+
+    /// Ported from PR #707 (the blocklist hunk's referenced test): the generic
+    /// tokens `model`/`router` carry no model identity and must never fuzzy-match
+    /// a real priced key (`azure_ai/model_router`), while an EXACT key match for a
+    /// genuine `model-router` id is still honored.
+    #[test]
+    fn fuzzy_match_does_not_resolve_generic_model_token() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "azure_ai/model_router".into(),
+            ModelPricing {
+                input_cost_per_token: Some(1.4e-7),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+
+        // The bare token must not resolve.
+        assert!(lookup.lookup("model").is_none());
+        // Ids that strip down to the bare `model` token must not misresolve.
+        assert!(lookup.lookup("model-zero-usage-v1").is_none());
+        assert!(lookup.lookup("model-nonzero-usage-v1").is_none());
+        assert!(lookup.lookup("test-model").is_none());
+
+        // But an EXACT key match is still honored — `model-router` is a real
+        // model id, not a fuzzy remnant.
+        let mut litellm2 = HashMap::new();
+        litellm2.insert(
+            "azure/model-router".into(),
+            ModelPricing {
+                input_cost_per_token: Some(1.4e-7),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+        let lookup2 = PricingLookup::new(litellm2, HashMap::new(), HashMap::new());
+        assert_eq!(
+            lookup2.lookup("model-router").unwrap().matched_key,
+            "azure/model-router"
+        );
     }
 
     #[test]
@@ -3173,7 +3813,10 @@ mod tests {
         assert!(!is_fuzzy_eligible("base"));
         assert!(!is_fuzzy_eligible("abc"));
         assert!(is_fuzzy_eligible("gpt-4o"));
-        assert!(is_fuzzy_eligible("claude"));
+        // Bare brand tokens carry no model information: a fuzzy hit from them
+        // can land on any model of the brand, so they are blocklisted.
+        assert!(!is_fuzzy_eligible("claude"));
+        assert!(!is_fuzzy_eligible("anthropic"));
     }
 
     // =========================================================================
@@ -3899,6 +4542,79 @@ mod tests {
         assert_eq!(result.matched_key, "claude-opus-4-6-20250301");
         assert_eq!(result.source, "LiteLLM");
         assert!(result.pricing.input_cost_per_token.is_some());
+    }
+
+    #[test]
+    fn test_none_pricing_exact_litellm_does_not_shadow_openrouter_model_part() {
+        let mut litellm = HashMap::new();
+        litellm.insert("claude-opus-4-6".into(), ModelPricing::default());
+
+        let mut openrouter = HashMap::new();
+        openrouter.insert(
+            "anthropic/claude-opus-4-6".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000005),
+                output_cost_per_token: Some(0.000025),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, openrouter, HashMap::new());
+        let result = lookup.lookup("claude-opus-4-6").unwrap();
+
+        assert_eq!(result.source, "OpenRouter");
+        assert_eq!(result.matched_key, "anthropic/claude-opus-4-6");
+
+        let cost = lookup.calculate_cost("claude-opus-4-6", 100, 20, 0, 0, 0);
+        assert!(cost > 0.0, "cost should use priced fallback, got {cost}");
+    }
+
+    #[test]
+    fn test_none_pricing_provider_exact_does_not_shadow_stripped_priced_entry() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "anthropic/claude-sonnet-4-5".into(),
+            ModelPricing::default(),
+        );
+        litellm.insert(
+            "claude-sonnet-4-5".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.000003),
+                output_cost_per_token: Some(0.000015),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("anthropic/claude-sonnet-4-5").unwrap();
+
+        assert_eq!(result.source, "LiteLLM");
+        assert_eq!(result.matched_key, "claude-sonnet-4-5");
+
+        let cost = lookup.calculate_cost("anthropic/claude-sonnet-4-5", 100, 20, 0, 0, 0);
+        assert!(
+            cost > 0.0,
+            "cost should use stripped priced entry, got {cost}"
+        );
+    }
+
+    #[test]
+    fn test_zero_pricing_exact_entry_is_usable() {
+        let mut litellm = HashMap::new();
+        litellm.insert(
+            "free-model".into(),
+            ModelPricing {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(0.0),
+                ..Default::default()
+            },
+        );
+
+        let lookup = PricingLookup::new(litellm, HashMap::new(), HashMap::new());
+        let result = lookup.lookup("free-model").unwrap();
+
+        assert_eq!(result.matched_key, "free-model");
+        assert_eq!(lookup.calculate_cost("free-model", 100, 20, 0, 0, 0), 0.0);
     }
 
     #[test]

--- a/vendor/tokscale-core/src/sessions/claudecode.rs
+++ b/vendor/tokscale-core/src/sessions/claudecode.rs
@@ -426,6 +426,8 @@ pub fn parse_claude_file_with_cache_and_home(
                         entry: &entry,
                         last_model: last_model.as_deref(),
                         last_provider_hint: last_provider_hint.as_deref(),
+                        client_id: &client_id,
+                        default_provider_hint: metadata_provider_hint,
                         session_id: &session_id,
                         fallback_timestamp,
                         workspace_key: workspace_key.clone(),
@@ -813,6 +815,8 @@ struct ClaudeToolResultContext<'a> {
     entry: &'a ClaudeEntry,
     last_model: Option<&'a str>,
     last_provider_hint: Option<&'a str>,
+    client_id: &'a str,
+    default_provider_hint: Option<&'a str>,
     session_id: &'a str,
     fallback_timestamp: i64,
     workspace_key: Option<String>,
@@ -846,7 +850,8 @@ fn extract_claude_tool_result_message(
                 .and_then(|message| message.provider_id.clone())
         })
         .or_else(|| context.entry.provider_id.clone())
-        .or_else(|| context.last_provider_hint.map(str::to_string));
+        .or_else(|| context.last_provider_hint.map(str::to_string))
+        .or_else(|| context.default_provider_hint.map(str::to_string));
 
     let provider_choice = claude_provider_choice(&raw_model, provider_hint.as_deref());
     let model = canonicalize_claude_model(&raw_model);
@@ -855,7 +860,7 @@ fn extract_claude_tool_result_message(
         .unwrap_or(context.fallback_timestamp);
 
     let mut message = UnifiedMessage::new_with_dedup(
-        "claude",
+        context.client_id,
         model,
         provider_choice.id,
         context.session_id.to_string(),
@@ -868,9 +873,12 @@ fn extract_claude_tool_result_message(
             reasoning: 0,
         },
         0.0,
-        usage
-            .dedup_key
-            .map(|key| format!("claude:tool_result:{}:{key}", context.session_id)),
+        usage.dedup_key.map(|key| {
+            format!(
+                "{}:tool_result:{}:{key}",
+                context.client_id, context.session_id
+            )
+        }),
     );
     message.message_count = 0;
     message.agent = context.sidechain_agent;
@@ -1922,6 +1930,27 @@ mod tests {
             messages[0].dedup_key.as_deref(),
             Some(expected_dedup_key.as_str())
         );
+        assert_eq!(messages[0].message_count, 0);
+    }
+
+    #[test]
+    fn test_cc_mirror_tool_result_keeps_variant_client_and_provider() {
+        let content = r#"{"type":"user","timestamp":"2026-05-27T10:00:00.000Z","message":{"model":"sonnet","content":[{"type":"tool_result","tool_use_id":"toolu_cc_mirror","tool_output":{"input_tokens":7,"output":"tool output"}}]}}"#;
+
+        let (_temp_dir, path) = create_cc_mirror_project_file(
+            content,
+            "zai-worker",
+            "zai",
+            "project-one",
+            "session.jsonl",
+        );
+        let messages = parse_claude_file(&path);
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, "cc-mirror/zai-worker");
+        assert_eq!(messages[0].provider_id, "zai");
+        assert_eq!(messages[0].model_id, "sonnet");
+        assert_eq!(messages[0].tokens.input, 7);
         assert_eq!(messages[0].message_count, 0);
     }
 

--- a/vendor/tokscale-core/src/sessions/copilot.rs
+++ b/vendor/tokscale-core/src/sessions/copilot.rs
@@ -233,12 +233,20 @@ fn candidate_from_attributes(
 ) -> Option<CopilotUsageCandidate> {
     let input = attr_i64_first(attributes, &["gen_ai.usage.input_tokens"]);
     let output = attr_i64_first(attributes, &["gen_ai.usage.output_tokens"]);
-    let cache_read = attr_i64_first(attributes, &["gen_ai.usage.cache_read.input_tokens"]);
+    let cache_read = attr_i64_first(
+        attributes,
+        &[
+            "gen_ai.usage.cache_read.input_tokens",
+            "gen_ai.usage.cache_read_input_tokens",
+        ],
+    );
     let cache_write = attr_i64_first(
         attributes,
         &[
             "gen_ai.usage.cache_write.input_tokens",
             "gen_ai.usage.cache_creation.input_tokens",
+            "gen_ai.usage.cache_write_input_tokens",
+            "gen_ai.usage.cache_creation_input_tokens",
         ],
     );
     let reasoning = attr_i64_first(
@@ -789,6 +797,32 @@ mod tests {
         assert_eq!(messages[0].tokens.input, 0);
         assert_eq!(messages[0].tokens.cache_read, 50);
         assert_eq!(messages[0].tokens.cache_write, 0);
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_underscore_cache_attributes() {
+        // Copilot CLI OTEL emits cache fields with underscores instead of dots:
+        // gen_ai.usage.cache_read_input_tokens / gen_ai.usage.cache_creation_input_tokens
+        let content = r#"{"type":"span","traceId":"trace-cli","spanId":"span-cli","name":"chat claude-sonnet-4.6","endTime":[1775934264,967317833],"resource":{"attributes":{"service.name":"github-copilot","service.version":"1.0.62"}},"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.usage.input_tokens":21884,"gen_ai.usage.output_tokens":80,"gen_ai.usage.cache_creation_input_tokens":21881}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.cache_write, 21881);
+        assert_eq!(messages[0].tokens.cache_read, 0);
+    }
+
+    #[test]
+    fn test_parse_copilot_cli_underscore_cache_read_and_creation() {
+        let content = r#"{"type":"span","traceId":"trace-cli2","spanId":"span-cli2","name":"chat claude-sonnet-4.6","endTime":[1775934264,967317833],"resource":{"attributes":{"service.name":"github-copilot"}},"attributes":{"gen_ai.operation.name":"chat","gen_ai.provider.name":"github","gen_ai.request.model":"claude-sonnet-4.6","gen_ai.usage.input_tokens":23000,"gen_ai.usage.output_tokens":120,"gen_ai.usage.cache_read_input_tokens":21881,"gen_ai.usage.cache_creation_input_tokens":1397}}"#;
+        let file = create_test_file(content);
+
+        let messages = parse_copilot_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.cache_read, 21881);
+        assert_eq!(messages[0].tokens.cache_write, 1397);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is **M1 of a four-part sync** of `vendor/tokscale-core` toward upstream [junhoyeo/tokscale](https://github.com/junhoyeo/tokscale) **v3.1.3**. Our vendored copy sits at roughly upstream `0c820a5d` (#618) and is about 31 crate commits behind. Rather than re-vendoring the whole crate, each milestone cherry-picks a focused set of upstream commits onto our patched copy.

> **Why cherry-pick instead of re-vendor:** upstream never adopted our local streaming-aggregation, per-client-dedup, agents-report, or Cowork-discovery patches. A wholesale re-vendor of `lib.rs` / `aggregator.rs` / `scanner.rs` / `message_cache.rs` would silently overwrite them. We keep those patches intact and graft only the specific upstream fixes we want.

M1 is **Tier 0**: the cheap, high-value correctness fixes that surface automatically through the existing FFI report path. No Swift, FFI, or registry changes.

### Roadmap (for context)

| Milestone | Scope | Status |
|---|---|---|
| **M1** | Pricing + client-attribution correctness | **this PR** |
| M2 | Codex fork-replay token de-duplication | planned |
| M3 | New clients: Cline, Antigravity CLI | planned |
| M4 | New clients: gjc, MiMo Code, Jcode | planned |

## Pricing (`src/pricing/lookup.rs`)

Brought in as a **zero-conflict three-way merge** of the upstream chain `#614 -> #658 -> #634`, validated by cherry-picking those commits onto a scratch branch off our baseline (skipping #665 models.dev), running upstream's own 222 pricing tests green, then merging the result onto our patched file. The `#707` blocklist hunk was applied separately.

| Upstream | Change | Why it matters |
|---|---|---|
| `#634` / `#658` / `#614` | Parse `claude-{family}-{major}-{minor}` from the model id instead of a hardcoded `opus-4.7/4.6/4.5` chain; never-degrade veto on the resolve path; skip all-`None` exact entries | A newer minor (e.g. the currently-running `opus-4-8`) no longer degrades to legacy `claude-opus-4`, fixing an ~3x overcharge ($15/$75 vs $5/$25). Future minors price with no code change. |
| `#707` (blocklist only) | `FUZZY_BLOCKLIST` gains `claude` / `anthropic` / `model` / `router`; `strips_claude_numeric_minor` hardened via a new `is_version_segment` | Retired `claude-2.x` no longer erodes to a bare brand token and fuzzy-matches an opus-fast key |

> **Deliberately excluded:** models.dev (#665) and the rest of #707 (pass reorder, `prefers_model_part_key`). Our local cache-rate backfill (`backfill_cache_costs`) is preserved on top: #658/#707 do not subsume it, since their `.any()` "usable" gate still lets a row that prices everything except cache through unfilled.

## Client attribution

| Upstream | File | Change |
|---|---|---|
| `#659` | `sessions/claudecode.rs` | cc-mirror `tool_result` keeps its variant client id and provider hint (was hardcoded `"claude"`); `dedup_key` namespaced by client |
| `#723` | `sessions/copilot.rs` | Copilot CLI OTEL underscore-format cache token attributes read as fallbacks (were silently `0`) |

## Docs (`vendor/README.md`)

Records the true ~#618 baseline, the cherry-picked upstream commits, and the two previously-undocumented local pricing patches (cache-rate backfill, in-memory auto-refresh TTL) so a future sync cannot silently drop them.

## Test plan

| Check | Result |
|---|---|
| `cargo test -p tokscale-core` | 864 passed |
| `cargo test -p tb_core_ffi` | 27 passed |
| `cargo clippy --workspace --all-targets` | clean (crate is `#![deny(clippy::all)]`) |
| `cargo build --release` + `swift build` | ok |
| `swift run TokenBar --selftest` / `--smoke` | green; smoke shows `top=claude-opus-4-8` priced correctly |

New regression coverage: the upstream #634 `opus-4-8` suite, #707 `fuzzy_match_does_not_resolve_generic_model_token`, the #723 underscore tests, the #659 cc-mirror test, plus a new bare-brand-token blocklist test.

## Local review (`/code-review high`)

**0 confirmed bugs.** Four low-severity PLAUSIBLE findings:

| Finding | Disposition |
|---|---|
| `FUZZY_BLOCKLIST` comment referenced a test that wasn't ported; `model`/`router` had no coverage | **Fixed**: ported the upstream #707 generic-token test |
| `has_unrecognized_claude_four_minor` redundant with the #634 veto | Left as-is: faithful to upstream HEAD, no live bug |
| `requested_claude_version` computed eagerly on non-Claude ids | Left as-is: upstream HEAD code, cache-bounded micro-cost |
| Three overlapping never-degrade guards | Left as-is: all faithful to upstream, no live bug |

The three "left as-is" items are kept to preserve diffability against upstream.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQquLvuARJkiTvDgACujQF
