### PR TITLE
fix(core): sync upstream codex fork-replay token de-duplication (M2)

### DIFF
--- a/vendor/README.md
+++ b/vendor/README.md
@@ -16,16 +16,17 @@
 
 ## Cherry-picked upstream commits (ahead of baseline)
 
-Specific later upstream fixes pulled in à la carte (we do **not** re-vendor
-wholesale — that would clobber the streaming/dedup/cowork patches below). The
+Specific later upstream fixes pulled in selectively (we do **not** re-vendor
+wholesale, which would clobber the streaming/dedup/cowork patches below). The
 next sync should treat these as already-present and not re-apply them.
 
 | Commit | What | Files |
 |---|---|---|
-| `#614` (1a305f0f) → `#658` (5c1fe659) → `#634` (aebe4ea8) | Modern-Claude pricing: parse `claude-{family}-{major}-{minor}` from the id instead of a hardcoded opus-4.7/4.6/4.5 chain, never-degrade veto on the resolve path, and skip-unusable exact entries. Fixes ~3x overcharge on newer minors (e.g. `opus-4-8`). **models.dev (`#665`) deliberately excluded.** | `src/pricing/lookup.rs` |
+| `#614` (1a305f0f), `#658` (5c1fe659), `#634` (aebe4ea8) | Modern-Claude pricing: parse `claude-{family}-{major}-{minor}` from the id instead of a hardcoded opus-4.7/4.6/4.5 chain, never-degrade veto on the resolve path, and skip-unusable exact entries. Fixes ~3x overcharge on newer minors (e.g. `opus-4-8`). **models.dev (`#665`) deliberately excluded.** | `src/pricing/lookup.rs` |
 | `#707` (5017eefb), *blocklist hunk only* | `FUZZY_BLOCKLIST` += `claude`/`anthropic`/`model`/`router`; `strips_claude_numeric_minor` hardened via new `is_version_segment`. Stops retired `claude-2.x` eroding to a bare brand token and fuzzy-matching an opus-fast key. The pass-reorder / `prefers_model_part_key` / models.dev parts of #707 were **not** taken. | `src/pricing/lookup.rs` |
 | `#659` (7500b303) | cc-mirror `tool_result` keeps its variant client id + provider hint (was hardcoded to `claude`); dedup_key namespaced by client. | `src/sessions/claudecode.rs` |
 | `#723` (cbbd0dff) | Copilot CLI OTEL underscore-format cache token attributes (`gen_ai.usage.cache_read_input_tokens`) read as fallbacks (were 0). | `src/sessions/copilot.rs` |
+| `#649` (44055841), `#651` (2d90f41d), `#681` (b43dc5f8), `#719` (3a68cf52) | Codex fork-replay correctness: skip replayed parent `token_count` rows in fork/subagent logs, scope the dedup key to the fork parent so sibling replays collapse, and keep user-fork own-turns after a repeated child `session_meta`. Fixes codex token over-counting (nested-parent + sibling forks) and under-counting (user forks). `CACHE_SCHEMA_VERSION` bumped to 19 to reparse stale entries. `lib.rs` change is the ported upstream integration tests (plus a streaming-path regression); production logic is in `codex.rs`. `#646` (turn detection) was already vendored. | `src/sessions/codex.rs`, `src/message_cache.rs`, `src/lib.rs` (tests) |
 
 ## Local patches (diverged from upstream)
 

--- a/vendor/tokscale-core/src/lib.rs
+++ b/vendor/tokscale-core/src/lib.rs
@@ -4279,6 +4279,56 @@ mod tests {
         }
     }
 
+    // M2 (codex fork-replay): the parser-level fork dedup (#649/#681) must also
+    // collapse replayed parent token_count rows through OUR streaming report
+    // path (scan_messages_streaming), not just the materialized
+    // parse_all_messages_with_pricing path the upstream tests exercise. Without
+    // the fork-parent-scoped dedup key, each fork's replayed parent rows survive
+    // per child and inflate codex totals.
+    #[test]
+    #[serial_test::serial]
+    fn test_streaming_codex_collapses_parent_replay_across_forks() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_codex_parent_replay_fixture(source_home.path());
+
+            let mut input_sum = 0i64;
+            let mut output_sum = 0i64;
+            let mut count = 0usize;
+            scan_messages_streaming(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+                false,
+                &scanner::ScannerSettings::default(),
+                &|_m: &UnifiedMessage| true,
+                &mut |m: &UnifiedMessage| {
+                    input_sum += m.tokens.input;
+                    output_sum += m.tokens.output;
+                    count += 1;
+                },
+            );
+
+            // Same collapse as the materialized
+            // test_parse_all_messages_with_pricing_codex_deduplicates_parent_replay_across_forks:
+            // the parent's two turns plus the single own-turn shared (by identical
+            // cumulative total) across the two forks. Without #649/#681 the
+            // replayed parent rows would survive per fork and inflate this.
+            assert_eq!(count, 3, "replayed parent rows must collapse to 3 messages");
+            assert_eq!(input_sum, 140);
+            assert_eq!(output_sum, 14);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
     // Issue #6: the agents report must dedup the simple_lane! clients
     // (copilot/codebuff/kimi/…) like the model/graph/hourly reports. Here
     // codebuff emits the SAME upstream message id "DUP" in two different
@@ -5094,6 +5144,113 @@ mod tests {
         .unwrap();
     }
 
+    fn write_codex_parent_replay_fixture(source_home: &std::path::Path) {
+        let codex_dir = source_home.join(".codex/sessions");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(
+            codex_dir.join("parent.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-05-24T20:00:00Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-05-24T20:00:01Z","type":"turn_context","payload":{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-05-24T20:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":10,"total_tokens":110},"last_token_usage":{"input_tokens":100,"output_tokens":10,"total_tokens":110}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-05-24T20:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":130,"output_tokens":13,"total_tokens":143},"last_token_usage":{"input_tokens":30,"output_tokens":3,"total_tokens":33}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        for (filename, child_id, child_turn_id, timestamp) in [
+            (
+                "child-a.jsonl",
+                "019e5c03-1e99-7000-8000-000000000001",
+                "019e5c03-6425-7000-8000-000000000001",
+                "2026-05-24T21:00:00Z",
+            ),
+            (
+                "child-b.jsonl",
+                "019e5c04-1e99-7000-8000-000000000001",
+                "019e5c04-6425-7000-8000-000000000001",
+                "2026-05-24T22:00:00Z",
+            ),
+        ] {
+            std::fs::write(
+                codex_dir.join(filename),
+                format!(
+                    concat!(
+                        r#"{{"timestamp":"{timestamp}","type":"session_meta","payload":{{"id":"{child_id}","forked_from_id":"019e5b00-0000-7000-8000-000000000001","source":{{"subagent":{{"thread_spawn":{{"parent_thread_id":"019e5b00-0000-7000-8000-000000000001","depth":1}}}}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"session_meta","payload":{{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"turn_context","payload":{{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":100,"output_tokens":10,"total_tokens":110}},"last_token_usage":{{"input_tokens":100,"output_tokens":10,"total_tokens":110}}}}}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":130,"output_tokens":13,"total_tokens":143}},"last_token_usage":{{"input_tokens":30,"output_tokens":3,"total_tokens":33}}}}}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"task_started","turn_id":"{child_turn_id}"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"turn_context","payload":{{"turn_id":"{child_turn_id}","model":"gpt-5.5","cwd":"/repo"}}}}"#,
+                        "\n",
+                        r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":140,"output_tokens":14,"total_tokens":154}},"last_token_usage":{{"input_tokens":10,"output_tokens":1,"total_tokens":11}}}}}}}}"#,
+                        "\n",
+                    ),
+                    timestamp = timestamp,
+                    child_id = child_id,
+                    child_turn_id = child_turn_id,
+                ),
+            )
+            .unwrap();
+        }
+    }
+
+    fn write_codex_user_fork_replay_fixture(source_home: &std::path::Path) {
+        let sessions_dir = source_home.join(".codex/sessions/2026/01/02");
+        let archived_dir = source_home.join(".codex/archived_sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&archived_dir).unwrap();
+
+        std::fs::write(
+            archived_dir.join("rollout-2026-01-02T03-04-05-11111111-1111-7111-8111-111111111111.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-01-02T03:04:05Z","type":"session_meta","payload":{"id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:04:06Z","type":"turn_context","payload":{"turn_id":"11111111-3333-7333-8333-333333333333","model":"gpt-5.5","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:04:07Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:04:08Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1200,"cached_input_tokens":450,"output_tokens":120,"total_tokens":1320},"last_token_usage":{"input_tokens":200,"cached_input_tokens":50,"output_tokens":20,"total_tokens":220}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        std::fs::write(
+            sessions_dir.join("rollout-2026-01-02T03-10-00-22222222-2222-7222-8222-222222222222.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-01-02T03:10:00Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:10:00Z","type":"session_meta","payload":{"id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:10:00Z","type":"turn_context","payload":{"turn_id":"11111111-3333-7333-8333-333333333333","model":"gpt-5.5","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:10:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:10:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1200,"cached_input_tokens":450,"output_tokens":120,"total_tokens":1320},"last_token_usage":{"input_tokens":200,"cached_input_tokens":50,"output_tokens":20,"total_tokens":220}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:10:30Z","type":"turn_context","payload":{"turn_id":"22222222-4444-7444-8444-444444444444","model":"gpt-5.5","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:10:30Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-02T03:10:53Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":500,"output_tokens":150,"total_tokens":1650},"last_token_usage":{"input_tokens":300,"cached_input_tokens":50,"output_tokens":30,"total_tokens":330}}}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_parse_all_messages_with_pricing_codex_deduplicates_forked_history() {
@@ -5141,12 +5298,84 @@ mod tests {
         }
     }
 
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_codex_keeps_user_fork_own_turn() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_codex_user_fork_replay_fixture(source_home.path());
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            let session_ids: HashSet<_> = messages
+                .iter()
+                .map(|message| message.session_id.as_str())
+                .collect();
+            assert!(session_ids.contains(
+                "rollout-2026-01-02T03-10-00-22222222-2222-7222-8222-222222222222"
+            ));
+            assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 1000);
+            assert_eq!(messages.iter().map(|m| m.tokens.cache_read).sum::<i64>(), 500);
+            assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 150);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_parse_all_messages_with_pricing_codex_deduplicates_parent_replay_across_forks() {
+        let cache_home = tempfile::TempDir::new().unwrap();
+        let source_home = tempfile::TempDir::new().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", cache_home.path());
+
+        {
+            write_codex_parent_replay_fixture(source_home.path());
+
+            let messages = parse_all_messages_with_pricing(
+                source_home.path().to_str().unwrap(),
+                &["codex".to_string()],
+                None,
+            );
+
+            // Parent contributes its two turns. The two forks each replay the
+            // parent history (skipped) and then emit one own turn that lands on
+            // the identical cumulative total (140/14). Sibling forks sharing a
+            // cumulative total is the signature of a replayed row, so the
+            // fork-parent-scoped dedup key collapses them into one. Real fork
+            // fan-out replays the same upstream totals into 10-100+ siblings;
+            // two distinct turns reaching a byte-identical cumulative vector by
+            // chance does not happen in practice because the cumulative encodes
+            // each fork's divergent context size.
+            assert_eq!(messages.len(), 3);
+            assert_eq!(messages.iter().map(|m| m.tokens.input).sum::<i64>(), 140);
+            assert_eq!(messages.iter().map(|m| m.tokens.output).sum::<i64>(), 14);
+        }
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
     fn write_codex_twin_token_count_fixture(source_home: &std::path::Path) {
         // Single session with two turns whose `last_token_usage` deltas are
         // byte-identical but emitted at different timestamps. The fork-dedup
-        // key includes timestamp, so both turns must survive — collapsing
-        // them would erase legitimate usage when a user happens to send two
-        // turns producing the same per-turn delta.
+        // key includes the cumulative total, so both turns must survive even
+        // when a user happens to send two turns producing the same per-turn
+        // delta.
         let codex_dir = source_home.join(".codex/sessions");
         std::fs::create_dir_all(&codex_dir).unwrap();
         std::fs::write(

--- a/vendor/tokscale-core/src/message_cache.rs
+++ b/vendor/tokscale-core/src/message_cache.rs
@@ -11,7 +11,11 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 16;
+// 19: Codex fork-replay parsing now skips replayed parent usage, scopes the
+// token_count dedup key to the fork parent, and keeps user-fork turns after
+// repeated child session_meta rows. Cached messages store their dedup_key and
+// older entries can be empty, so they must be reparsed.
+const CACHE_SCHEMA_VERSION: u32 = 19;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/vendor/tokscale-core/src/sessions/codex.rs
+++ b/vendor/tokscale-core/src/sessions/codex.rs
@@ -32,6 +32,7 @@ pub struct CodexPayload {
     pub model_name: Option<String>,
     pub model_info: Option<CodexModelInfo>,
     pub info: Option<CodexInfo>,
+    pub turn_id: Option<String>,
     pub source: Option<Value>,
     /// Current working directory from session_meta.
     pub cwd: Option<String>,
@@ -171,6 +172,8 @@ pub(crate) struct CodexParseState {
     pub session_is_headless: bool,
     pub session_id_from_meta: Option<String>,
     pub session_forked_from_id: Option<String>,
+    pub forked_child_session_id: Option<String>,
+    pub forked_child_replay_session_id: Option<String>,
     pub session_provider: Option<String>,
     pub session_agent: Option<String>,
     pub session_workspace_key: Option<String>,
@@ -285,11 +288,33 @@ fn parse_codex_reader<R: BufRead>(
                 let event_model = payload_model.clone().or(info_model.clone());
 
                 if state.forked_child_waiting_for_turn_context {
-                    if entry.entry_type == "turn_context" {
+                    if entry.entry_type == "turn_context"
+                        && forked_child_turn_starts_own_session(&state, payload.turn_id.as_deref())
+                    {
                         state.forked_child_waiting_for_turn_context = false;
+                        state.forked_child_replay_session_id = None;
+                        if let Some(ref id) = state.forked_child_session_id {
+                            state.session_id_from_meta = Some(id.clone());
+                        }
                         state.current_model = payload_model.clone();
                         handled = true;
                     } else {
+                        if entry.entry_type == "session_meta" {
+                            if let Some(ref id) = payload.id {
+                                if state
+                                    .forked_child_session_id
+                                    .as_deref()
+                                    .is_some_and(|child_id| child_id != id)
+                                {
+                                    // Newer Codex fork logs can embed the
+                                    // parent session metadata before replaying
+                                    // parent token_count history. Keep
+                                    // skipping while that copied upstream
+                                    // transcript is active.
+                                    state.forked_child_replay_session_id = Some(id.clone());
+                                }
+                            }
+                        }
                         if is_token_count {
                             if let Some(info) = payload.info.as_ref() {
                                 remember_forked_child_inherited_baseline(&mut state, info);
@@ -325,10 +350,18 @@ fn parse_codex_reader<R: BufRead>(
                         .filter(|id| !id.is_empty())
                         .or_else(|| forked_from_id_from_source(payload.source.as_ref()));
                     if let Some(forked_from_id) = forked_from_id {
+                        let repeated_active_child_meta = !state
+                            .forked_child_waiting_for_turn_context
+                            && payload.id.as_deref().is_some()
+                            && state.forked_child_session_id.as_deref() == payload.id.as_deref();
                         state.session_forked_from_id = Some(forked_from_id.to_string());
-                        state.forked_child_waiting_for_turn_context = true;
-                        state.forked_child_inherited_baseline = None;
-                        state.forked_child_inherited_reported_total = None;
+                        state.forked_child_session_id = payload.id.clone();
+                        if !repeated_active_child_meta {
+                            state.forked_child_waiting_for_turn_context = true;
+                            state.forked_child_replay_session_id = None;
+                            state.forked_child_inherited_baseline = None;
+                            state.forked_child_inherited_reported_total = None;
+                        }
                     }
                     if let Some(ref provider) = payload.model_provider {
                         state.session_provider = Some(provider.clone());
@@ -504,10 +537,26 @@ fn parse_codex_reader<R: BufRead>(
                         message.is_turn_start = true;
                         state.pending_turn_start = false;
                     }
-                    if parsed_timestamp.is_some() {
-                        if let Some(model) = model.as_deref() {
-                            set_codex_dedup_key(&mut message, model);
-                        }
+                    if parsed_timestamp.is_some() || total_usage.is_some() {
+                        // Fork/subagent children replay the same upstream
+                        // token_count history into many sibling files. Those
+                        // replays carry identical cumulative totals but a
+                        // distinct per-file session id, so a session-scoped key
+                        // never collapses them and the totals get counted once
+                        // per sibling. Scope the key to the fork parent instead
+                        // so sibling replays share one key. Unrelated sessions
+                        // keep their own id and never merge.
+                        let dedup_scope_id = state
+                            .session_forked_from_id
+                            .as_deref()
+                            .or(state.session_id_from_meta.as_deref())
+                            .unwrap_or(session_id);
+                        set_codex_dedup_key(
+                            &mut message,
+                            model.as_deref().unwrap_or("unknown"),
+                            dedup_scope_id,
+                            total_usage,
+                        );
                     }
                     message.set_workspace(
                         state.session_workspace_key.clone(),
@@ -618,6 +667,52 @@ fn forked_from_id_from_source(source: Option<&Value>) -> Option<&str> {
         .filter(|id| !id.is_empty())
 }
 
+fn forked_child_turn_starts_own_session(state: &CodexParseState, turn_id: Option<&str>) -> bool {
+    if state.forked_child_replay_session_id.is_none() {
+        return true;
+    }
+
+    let Some(child_session_id) = state.forked_child_session_id.as_deref() else {
+        return true;
+    };
+
+    match (turn_id, codex_uuid_v7_order_key(child_session_id)) {
+        (Some(turn_id), Some(child_key)) => {
+            codex_uuid_v7_order_key(turn_id).is_none_or(|turn_key| turn_key >= child_key)
+        }
+        _ => true,
+    }
+}
+
+fn codex_uuid_v7_order_key(id: &str) -> Option<String> {
+    let mut parts = id.split('-');
+    let first = parts.next()?;
+    let second = parts.next()?;
+    let third = parts.next()?;
+    let fourth = parts.next()?;
+    let fifth = parts.next()?;
+
+    if parts.next().is_some()
+        || first.len() != 8
+        || second.len() != 4
+        || third.len() != 4
+        || fourth.len() != 4
+        || fifth.len() != 12
+        || !third.starts_with('7')
+    {
+        return None;
+    }
+
+    let mut key = String::with_capacity(32);
+    for part in [first, second, third, fourth, fifth] {
+        if !part.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return None;
+        }
+        key.push_str(&part.to_ascii_lowercase());
+    }
+    Some(key)
+}
+
 fn parse_codex_entry_timestamp(timestamp: Option<&str>) -> Option<i64> {
     timestamp
         .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
@@ -629,7 +724,29 @@ fn duration_between_ms(start_ms: Option<i64>, end_ms: Option<i64>) -> Option<i64
     (duration > 0).then_some(duration)
 }
 
-fn codex_token_count_dedup_key(message: &UnifiedMessage, model: &str) -> String {
+fn codex_token_count_dedup_key(
+    message: &UnifiedMessage,
+    model: &str,
+    upstream_session_id: &str,
+    total_usage: Option<CodexTotals>,
+) -> String {
+    if let Some(total) = total_usage {
+        // Codex fork/subagent logs can replay the same upstream token_count
+        // history into many child files with child-local timestamps. The
+        // cumulative total is the stable upstream identity; timestamp is only
+        // a fallback when older rows do not carry totals.
+        return format!(
+            "codex:token_count-total:{}:{}:{}:{}:{}:{}:{}",
+            upstream_session_id,
+            message.provider_id,
+            model,
+            total.input,
+            total.output,
+            total.cached,
+            total.reasoning
+        );
+    }
+
     format!(
         "codex:token_count:{}:{}:{}:{}:{}:{}:{}:{}",
         message.timestamp,
@@ -643,9 +760,19 @@ fn codex_token_count_dedup_key(message: &UnifiedMessage, model: &str) -> String 
     )
 }
 
-fn set_codex_dedup_key(message: &mut UnifiedMessage, model: &str) {
+fn set_codex_dedup_key(
+    message: &mut UnifiedMessage,
+    model: &str,
+    upstream_session_id: &str,
+    total_usage: Option<CodexTotals>,
+) {
     if message.dedup_key.is_none() {
-        message.dedup_key = Some(codex_token_count_dedup_key(message, model));
+        message.dedup_key = Some(codex_token_count_dedup_key(
+            message,
+            model,
+            upstream_session_id,
+            total_usage,
+        ));
     }
 }
 
@@ -657,7 +784,8 @@ fn flush_pending_model_messages(
 ) {
     for (mut message, used_fallback_timestamp) in pending_model_messages.drain(..) {
         if !used_fallback_timestamp {
-            set_codex_dedup_key(&mut message, model);
+            let upstream_session_id = message.session_id.clone();
+            set_codex_dedup_key(&mut message, model, &upstream_session_id, None);
         }
         message.model_id = model.to_string();
         messages.push(message);
@@ -1653,6 +1781,33 @@ mod tests {
     }
 
     #[test]
+    fn test_forked_child_submit_cap_regression_skips_large_inherited_cache_replays() {
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","forked_from_id":"parent-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1,"agent_role":"architect"}}},"model_provider":"openai","agent_nickname":"architect","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:57.994Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1200000000,"cached_input_tokens":1180000000,"output_tokens":1000000,"reasoning_output_tokens":100000,"total_tokens":1201100000},"last_token_usage":{"input_tokens":750000000,"cached_input_tokens":740000000,"output_tokens":500000,"reasoning_output_tokens":50000,"total_tokens":750550000}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.947Z","type":"turn_context","payload":{"model":"gpt-5.5","cwd":"/repo-child"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.948Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1180000000,"cached_input_tokens":1160000000,"output_tokens":900000,"reasoning_output_tokens":90000,"total_tokens":1180990000},"last_token_usage":{"input_tokens":20000000,"cached_input_tokens":20000000,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":20000000}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.949Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1200000000,"cached_input_tokens":1180000000,"output_tokens":1000000,"reasoning_output_tokens":100000,"total_tokens":1201100000},"last_token_usage":{"input_tokens":20000000,"cached_input_tokens":20000000,"output_tokens":100000,"reasoning_output_tokens":10000,"total_tokens":20110000}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:59.253Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1200001500,"cached_input_tokens":1180001000,"output_tokens":1000200,"reasoning_output_tokens":100050,"total_tokens":1201101750},"last_token_usage":{"input_tokens":1500,"cached_input_tokens":1000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":1750}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "gpt-5.5");
+        assert_eq!(messages[0].tokens.input, 500);
+        assert_eq!(messages[0].tokens.cache_read, 1000);
+        assert_eq!(messages[0].tokens.output, 200);
+        assert_eq!(messages[0].tokens.reasoning, 50);
+    }
+
+    #[test]
     fn test_forked_child_detects_thread_spawn_source_without_top_level_fork_id() {
         let file = create_test_file(concat!(
             r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"child-session","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-session","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo-child"}}"#,
@@ -1673,6 +1828,70 @@ mod tests {
         assert_eq!(messages[0].model_id, "gpt-5.5");
         assert_eq!(messages[0].tokens.input, 10);
         assert_eq!(messages[0].tokens.output, 2);
+    }
+
+    #[test]
+    fn test_user_forked_child_counts_own_turn_after_parent_replay() {
+        let file = create_test_file(concat!(
+            r#"{"timestamp":"2026-01-02T03:10:00.000Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.001Z","type":"session_meta","payload":{"id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.100Z","type":"turn_context","payload":{"turn_id":"11111111-3333-7333-8333-333333333333","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:00.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":100,"total_tokens":1100}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:30.100Z","type":"turn_context","payload":{"turn_id":"22222222-4444-7444-8444-444444444444","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:30.200Z","type":"session_meta","payload":{"id":"22222222-2222-7222-8222-222222222222","forked_from_id":"11111111-1111-7111-8111-111111111111","source":"vscode","thread_source":"user","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-01-02T03:10:31.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1250,"cached_input_tokens":450,"output_tokens":120,"total_tokens":1370},"last_token_usage":{"input_tokens":250,"cached_input_tokens":50,"output_tokens":20,"total_tokens":270}}}}"#,
+            "\n"
+        ));
+
+        let messages = parse_codex_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 200);
+        assert_eq!(messages[0].tokens.cache_read, 50);
+        assert_eq!(messages[0].tokens.output, 20);
+    }
+
+    #[test]
+    fn test_forked_child_skips_nested_parent_replay_until_own_turn() {
+        let parent = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:51:57.991Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.000Z","type":"turn_context","payload":{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:51:58.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330}}}}"#,
+            "\n"
+        ));
+        let child = create_test_file(concat!(
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5c03-1e99-7000-8000-000000000001","forked_from_id":"019e5b00-0000-7000-8000-000000000001","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019e5b00-0000-7000-8000-000000000001","depth":1}}},"model_provider":"openai","agent_nickname":"worker","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.000Z","type":"session_meta","payload":{"id":"019e5b00-0000-7000-8000-000000000001","source":"vscode","model_provider":"openai","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.100Z","type":"turn_context","payload":{"turn_id":"019e5b00-0001-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:10.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330},"last_token_usage":{"input_tokens":300,"output_tokens":30,"total_tokens":330}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"019e5c03-6425-7000-8000-000000000001"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.100Z","type":"turn_context","payload":{"turn_id":"019e5c03-6425-7000-8000-000000000001","model":"gpt-5.5","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-05-05T21:52:20.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":320,"output_tokens":32,"total_tokens":352},"last_token_usage":{"input_tokens":20,"output_tokens":2,"total_tokens":22}}}}"#,
+            "\n"
+        ));
+
+        let parent_messages = parse_codex_file(parent.path());
+        let child_messages = parse_codex_file(child.path());
+
+        assert_eq!(parent_messages.len(), 1);
+        assert_eq!(child_messages.len(), 1);
+        assert_ne!(parent_messages[0].dedup_key, child_messages[0].dedup_key);
+        assert_eq!(child_messages[0].tokens.input, 20);
+        assert_eq!(child_messages[0].tokens.output, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Milestone 2 of the staged sync of `vendor/tokscale-core` toward upstream [junhoyeo/tokscale](https://github.com/junhoyeo/tokscale). This pulls in the upstream **Codex fork/subagent replay correctness stack** (`#649`, `#651`, `#681`, `#719`).

Method (same as M1): replay the commits on a scratch branch off our baseline, validate with upstream's 75 codex tests, then 3-way merge the result onto our patched files (`git merge-file`, **0 conflicts**). `#646` (turn detection) was already vendored.

> **Why this matters:** before M2, Codex fork/subagent logs that replay the parent's `token_count` history were **over-counted** (every replayed parent row was billed, and sibling forks each counted a copy). On real data the smoke total dropped from 4499B to 4468B tokens ($3012 to $2996) with *more* messages parsed, confirming the de-duplication.

## What changed

| File | Change |
|---|---|
| `src/sessions/codex.rs` | Production fork-replay parser: skip replayed parent `token_count` rows, scope the dedup key to the fork parent (`session_forked_from_id`) so sibling replays collapse, and keep a user fork's own turn after a repeated child `session_meta`. |
| `src/message_cache.rs` | `CACHE_SCHEMA_VERSION` 16 -> 19 to force a one-time reparse of cached `UnifiedMessage`s (they store their `dedup_key`). PR#2 `HASH_MEMO`/`STORE_MEMO`/mtime-prune code untouched. |
| `src/lib.rs` | Test-only: ports the upstream integration tests plus a new streaming-path regression `test_streaming_codex_collapses_parent_replay_across_forks`. |
| `vendor/README.md` | Records the cherry-pick. |

> **Compatible with our streaming dedup:** Codex already dedups against a single per-client `codex_seen` set in `scan_messages_streaming`, which is exactly the cross-file set `#681` needs to collapse siblings. The new streaming-path test proves the collapse flows through `scan_messages_streaming` (the path the app actually uses), not just the materialized `parse_all_messages_with_pricing` path the upstream tests exercise.

## Test plan

| Check | Result |
|---|---|
| `cargo test -p tokscale-core` | 870 passed |
| `cargo test -p tb_core_ffi` | 27 passed |
| `cargo clippy --workspace --all-targets` | clean |
| `cargo build --release` + `swift build` | ok |
| `--selftest` / `--smoke` | green; smoke shows reduced codex totals |
| PR#3 cross-client dedup test | still green (streaming patch intact) |

## Local review (`/code-review high`)

**No merge mis-stitches**: every finding is upstream's own logic faithfully cherry-picked (verified byte-identical to `#719`), and the new streaming regression test was verified to fail when the fix is neutered. The merge combined our local divergence with the upstream stack cleanly.

The review did surface known limitations **inherent to upstream's fork-replay heuristic** (not introduced here). We are shipping the faithful port (a large net improvement over the prior over-counting) and will file an upstream issue:

| Limitation | Effect | Trigger |
|---|---|---|
| Same-millisecond fork ordering (`forked_child_turn_starts_own_session`) uses UUID v7 lexicographic order as a tiebreak | A forked child's own single turn can be dropped (~50% of cases) | Nested-parent-meta fork where the child `session_meta` and the child's own first `turn_context` are minted in the same millisecond, single-turn subagent |
| Fork-parent-scoped dedup key carries no turn discriminator | Two genuinely-distinct sibling turns that reach a byte-identical cumulative token vector collapse to one | Deterministic / near-empty subagent fan-out (upstream notes this "does not happen in practice") |
| Model-less `token_count` before any `turn_context` keys on model `unknown` | Two distinct unresolved-model turns on the same cumulative vector collapse | Multiple `token_count` rows before the first `turn_context` (rare; `turn_context` normally precedes) |

These are narrow tails and were over-counted (worse) before M2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQquLvuARJkiTvDgACujQF
