### PR TITLE
fix(release): maintain a multi-item appcast via generate_appcast

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           umask 077
           printf '%s' "$SPARKLE_PRIVATE_KEY" > /tmp/sparkle_ed.key
-          scripts/make_appcast.sh "TokenBar.app.tar.gz" "$VERSION" "$BUILD" "$GITHUB_REF_NAME" /tmp/sparkle_ed.key release-notes.txt
+          scripts/make_appcast.sh "TokenBar.app.tar.gz" "$VERSION" "$GITHUB_REF_NAME" /tmp/sparkle_ed.key release-notes.txt
           rm -f /tmp/sparkle_ed.key
 
       # Tauri migration manifest: the old Tauri app's updater endpoint

--- a/appcast.xml
+++ b/appcast.xml
@@ -30,5 +30,36 @@
         length="7047740"
         type="application/octet-stream"/>
     </item>
+    <item>
+      <title>1.1.0</title>
+      <pubDate>Sun, 21 Jun 2026 18:15:56 +0000</pubDate>
+      <sparkle:version>151</sparkle:version>
+      <sparkle:shortVersionString>1.1.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+
+      <link>https://github.com/Nanako0129/TokenBar/releases/tag/v1.1.0</link>
+      <description><![CDATA[
+<b>New:</b>
+<ul>
+<li>Tracks five more local AI coding tools: Cline, Antigravity CLI, jcode, MiMo Code, and gjc.</li>
+</ul>
+<b>Improved:</b>
+<ul>
+<li>More accurate cost and per-tool attribution across AI token usage.</li>
+<li>Corrected Codex usage counts for forked and sub-agent sessions.</li>
+<li>Antigravity CLI usage is now dated per turn, so the live view and daily totals reflect when each turn actually happened.</li>
+</ul>
+<b>Fixes:</b>
+<ul>
+<li>The app no longer crashes if the usage parser hits an unexpected error.</li>
+<li>More reliable live usage updates, including for the newly added tools.</li>
+</ul>
+      ]]></description>
+      <enclosure
+        url="https://github.com/Nanako0129/TokenBar/releases/download/v1.1.0/TokenBar.app.tar.gz"
+        sparkle:edSignature="8AmcpkHvF9b7d7hR2Wk7xHMvxPtYvhKmqAYleU/9HSBQassIVVwZ2G+3JoF8OPXSzz1r144CszEOKJRL+lOpDA=="
+        length="6894840"
+        type="application/octet-stream"/>
+    </item>
   </channel>
 </rss>

--- a/scripts/make_appcast.sh
+++ b/scripts/make_appcast.sh
@@ -1,43 +1,48 @@
 #!/bin/bash
-# Emit appcast.xml for a release archive.
+# Maintain a multi-item appcast.xml for a release archive.
 #
-#   scripts/make_appcast.sh <archive.tar.gz> <version> <build> <tag> <ed-key-file> [notes.txt]
+#   scripts/make_appcast.sh <archive.tar.gz> <version> <tag> <ed-key-file> [notes.txt]
 #
-# Signs the archive with sign_update (Sparkle SPM artifact) and writes
-# appcast.xml beside it. Single-item feed: the latest release is the feed.
+# Delegates to Sparkle's own generate_appcast (shipped in the SPM artifact, the
+# same place as sign_update) so the feed is a proper MULTI-item appcast instead
+# of a single item overwritten on every release. generate_appcast reads the
+# existing appcast.xml back in, preserves prior items verbatim (their URLs,
+# EdDSA signatures and release notes survive without the old archives being
+# present), appends the new item, signs it, and prunes to --maximum-versions
+# per branch. Keeping the latest stable item always present is what stops a
+# future prerelease (a channel-tagged item) from hiding stable from everyone.
+#
+# generate_appcast authors item fields from the bundle's Info.plist, so the one
+# thing it does not produce is our DeepSeek release notes; we render them to an
+# HTML sidecar named after the archive (TokenBar.app.html) and pass
+# --embed-release-notes so they land in the item's <description> CDATA.
 set -euo pipefail
 
-ARCHIVE="$1"
+ARCHIVE="$1"        # freshly built TokenBar.app.tar.gz
 VERSION="$2"
-BUILD="$3"
-TAG="$4"
-KEY_FILE="$5"
-NOTES_FILE="${6:-}"
+TAG="$3"            # git tag, e.g. v1.1.2 — used for the per-release download URL
+KEY_FILE="$4"
+NOTES_FILE="${5:-}"
 
-SIGN_UPDATE=".build/artifacts/sparkle/Sparkle/bin/sign_update"
-SIGNATURE_LINE=$("$SIGN_UPDATE" -f "$KEY_FILE" "$ARCHIVE")
-# sign_update prints: sparkle:edSignature="…" length="…"
-ED_SIGNATURE=$(echo "$SIGNATURE_LINE" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
-LENGTH=$(echo "$SIGNATURE_LINE" | sed -n 's/.*length="\([^"]*\)".*/\1/p')
-[ -n "$ED_SIGNATURE" ] && [ -n "$LENGTH" ] || { echo "failed to parse sign_update output" >&2; exit 1; }
+GENERATE_APPCAST=".build/artifacts/sparkle/Sparkle/bin/generate_appcast"
+REPO_APPCAST="appcast.xml"
+ARCHIVE_BASENAME=$(basename "$ARCHIVE")                  # TokenBar.app.tar.gz
+NOTES_BASENAME="${ARCHIVE_BASENAME%.tar.gz}.html"        # TokenBar.app.html
 
-ASSET_NAME=$(basename "$ARCHIVE")
-URL="https://github.com/Nanako0129/TokenBar/releases/download/$TAG/$ASSET_NAME"
-PUB_DATE=$(LC_ALL=en_US.UTF-8 date -u "+%a, %d %b %Y %H:%M:%S +0000")
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
 
-# Prerelease versions ride the Sparkle "beta" channel: only installs that
-# opted in (Settings → "Receive beta updates") see them. Stable versions
-# carry no channel tag and reach everyone — including old beta-app installs.
-CHANNEL_TAG=""
-case "$VERSION" in
-  *-*) CHANNEL_TAG="      <sparkle:channel>beta</sparkle:channel>";;
-esac
+# Seed generate_appcast with the currently published feed so it preserves the
+# prior items (read back from this file — the old archives are not needed).
+[ -f "$REPO_APPCAST" ] && cp "$REPO_APPCAST" "$WORK/appcast.xml"
+
+cp "$ARCHIVE" "$WORK/$ARCHIVE_BASENAME"
 
 # Render the plain-text notes (restricted format: "New:"/"Fixes:" headings,
-# "- " bullets) into simple HTML for the Sparkle update dialog.
-DESCRIPTION=""
+# "- " bullets) into simple HTML beside the archive; generate_appcast embeds a
+# same-base-name HTML sidecar as this item's <description>.
 if [[ -n "$NOTES_FILE" && -s "$NOTES_FILE" ]]; then
-  HTML=$(awk '
+  awk '
     function esc(t) { gsub(/&/, "\&amp;", t); gsub(/</, "\&lt;", t); return t }
     /^- / {
       if (!inlist) { print "<ul>"; inlist = 1 }
@@ -52,33 +57,29 @@ if [[ -n "$NOTES_FILE" && -s "$NOTES_FILE" ]]; then
       else print "<p>" t "</p>"
     }
     END { if (inlist) print "</ul>" }
-  ' "$NOTES_FILE")
-  DESCRIPTION="      <description><![CDATA[
-$HTML
-      ]]></description>"
+  ' "$NOTES_FILE" > "$WORK/$NOTES_BASENAME"
 fi
 
-cat > appcast.xml <<XML
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-  <channel>
-    <title>TokenBar updates</title>
-    <item>
-      <title>$VERSION</title>
-      <pubDate>$PUB_DATE</pubDate>
-      <sparkle:version>$BUILD</sparkle:version>
-      <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-$CHANNEL_TAG
-      <link>https://github.com/Nanako0129/TokenBar/releases/tag/$TAG</link>
-$DESCRIPTION
-      <enclosure
-        url="$URL"
-        sparkle:edSignature="$ED_SIGNATURE"
-        length="$LENGTH"
-        type="application/octet-stream"/>
-    </item>
-  </channel>
-</rss>
-XML
-echo "appcast.xml written ($VERSION build $BUILD)"
+# Stable releases stay channel-less (served to everyone, so the latest stable is
+# always visible). Prereleases (1.2.0-beta.1) go on the "beta" channel, so only
+# hosts that opted in (allowedChannels -> ["beta"]) see them and stable users are
+# never offered a beta. Because stable items remain channel-less in the same
+# multi-item feed, a beta opt-in still sees stable and graduates to it
+# automatically once a higher stable build ships. (Empty for stable; left
+# unquoted on purpose so no flag is passed — safe, the value never has spaces.)
+CHANNEL_ARG=""
+case "$VERSION" in
+  *-*) CHANNEL_ARG="--channel beta" ;;
+esac
+
+"$GENERATE_APPCAST" \
+  --ed-key-file "$KEY_FILE" \
+  --download-url-prefix "https://github.com/Nanako0129/TokenBar/releases/download/$TAG/" \
+  --link "https://github.com/Nanako0129/TokenBar/releases/tag/$TAG" \
+  --embed-release-notes \
+  --maximum-versions 5 \
+  $CHANNEL_ARG \
+  "$WORK"
+
+cp "$WORK/appcast.xml" "$REPO_APPCAST"
+echo "appcast.xml updated ($VERSION) -> $(grep -c '<item>' "$REPO_APPCAST") item(s)"


### PR DESCRIPTION
## Problem

`make_appcast.sh` regenerated `appcast.xml` from scratch on every tag (a single `<item>`) and overwrote `main` with it. A channel-less stable item is served to every host, so a single item is fine for stable. But the moment a prerelease shipped, its `<sparkle:channel>beta</sparkle:channel>` item replaced the whole feed and hid the latest stable from every default-channel user until the next stable release -- the same class of bug that leaked betas to stable users in Transmission #7308.

## Fix

Switch to Sparkle's own `generate_appcast` (already shipped in the SPM artifact, next to `sign_update`), which maintains a multi-item feed:

| Aspect | Behavior |
|---|---|
| Prior items | Read back from the existing `appcast.xml` and preserved verbatim -- URLs, EdDSA signatures and release notes survive without the old archives being present |
| New item | Freshly signed and appended; feed pruned to `--maximum-versions 5` per branch |
| Stable | Channel-less, so it is always visible to everyone -- a release can never hide stable again |
| Prerelease (`*-*`) | Passed `--channel beta`, so only opt-in hosts see it; stable stays visible, so a beta install graduates to stable automatically once a higher stable ships |
| Release notes | DeepSeek notes rendered to an HTML sidecar (`TokenBar.app.html`) that `generate_appcast` embeds as the item's `<description>`; the awk->HTML renderer is kept |

`release.yml` drops the now-unused `$BUILD` argument (`generate_appcast` reads the build number from the bundle's `Info.plist`).

`appcast.xml` is seeded with the real `v1.1.0` item appended below the live `v1.1.1` item (purely additive -- `v1.1.1` is untouched; both are the actual published items) so the feed is multi-item immediately. CI maintains it from the next release onward.

## Verification (hermetic, local)

- `generate_appcast` merges the real `v1.1.0` feed + a new `v1.1.1` archive into a 2-item channel-less feed; the old item is preserved byte-for-byte.
- Both EdDSA signatures validate against the embedded public key (independent `cryptography` Ed25519 verify).
- Notes render into `<description>`; `<link>` present; each item's enclosure URL carries its own tag.
- A prerelease version gets `<sparkle:channel>beta</sparkle:channel>` while stable stays channel-less.
- Re-runs are idempotent; output is well-formed XML.

No Rust/Swift source changed, so build/selftest/smoke are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP7GQqy4psrGBZ2ininc7X
