### PR TITLE
fix(perf): cache dashboard snapshot to eliminate popover reopen flash

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -11,19 +11,56 @@ enum AppView: String, CaseIterable {
     var label: String { rawValue.prefix(1).uppercased() + rawValue.dropFirst() }
 }
 
+/// Snapshot of the model's essential state, captured on each successful
+/// load so a fresh DashboardModel can start in `.ready` state instead of
+/// flashing "Loading usage…" every time the popover reopens.
+private struct DashboardSnapshot {
+    let payload: UsagePayload
+    let stats: UsageStats
+    let modelReport: ModelReport?
+    let colors: ModelColorMap
+    let knownYears: [String]
+    let year: String?
+    let hourly: HourlyReport?
+    let agents: AgentsReport?
+    let agentUsage: AgentUsagePayload?
+    let trace: [TraceBucket]
+}
+
 /// Shared dashboard data for every lens. Base data (graph + model report)
 /// loads when the popover opens; the hourly/agents reports load lazily the
 /// first time their lens becomes active, mirroring the Tauri app's
 /// empty-year short-circuit hooks.
 @MainActor @Observable final class DashboardModel {
+    /// Survives the model's deallocation so the next PopoverView starts
+    /// with cached data instead of `.loading`.
+    private static var lastSnapshot: DashboardSnapshot?
     enum Phase {
         case loading
         case ready
         case failed(String)
     }
 
-    private(set) var phase: Phase = .loading
+    private(set) var phase: Phase
     private static let yearKey = "tokenbar.dashboard.year"
+
+    init() {
+        if let snap = Self.lastSnapshot {
+            payload = snap.payload
+            stats = snap.stats
+            modelReport = snap.modelReport
+            colors = snap.colors
+            knownYears = snap.knownYears
+            year = snap.year
+            hourly = snap.hourly
+            agents = snap.agents
+            agentUsage = snap.agentUsage
+            trace = snap.trace
+            phase = .ready
+        } else {
+            phase = .loading
+        }
+    }
 
     /// Year filter for every lens (HeaderBar's year select in the Tauri app);
     /// nil = all time. Persisted so the selection survives the popover's
@@ -139,6 +176,11 @@ enum AppView: String, CaseIterable {
         colors = ModelColorMap(report: report)
         knownYears = Set(knownYears + payload.years.map(\.year)).sorted(by: >)
         phase = .ready
+        Self.lastSnapshot = DashboardSnapshot(
+            payload: payload, stats: stats!, modelReport: report,
+            colors: colors, knownYears: knownYears, year: year,
+            hourly: hourly, agents: agents, agentUsage: agentUsage,
+            trace: trace)
     }
 
     /// Periodically re-derive every loaded lens so the popover advances while


### PR DESCRIPTION
## Problem

Phase B CPU optimization (4eac28e) swaps PopoverView for a static `Color.clear` placeholder when the popover closes, then reinstalls a fresh `PopoverView()` on reopen. This stops background `.task` polling loops from running indefinitely.

But every reopen creates a brand new `DashboardModel()` that starts in `.loading` → flashes "Loading usage…" until the FFI fetch completes.

## Fix

Cache the model's essential state in a `static DashboardSnapshot` on each successful `apply()`, and restore it in `init()`:

- **First open** (cold): `lastSnapshot` is nil → `.loading` → shows loading briefly (expected)
- **Subsequent opens** (warm): `lastSnapshot` exists → `.ready` with cached data → no flash
- `.task { await model.load() }` still runs in background to refresh

## Scope

- Only `Sources/TokenBar/DashboardModel.swift` changed (44 lines)
- Phase B CPU optimization fully preserved — no changes to StatusItemController or PopoverView

## Verification

- [x] `make` (cargo + swift build) — clean
- [x] `--selftest` (67 assertions) — all pass
- [x] `--smoke` (7 FFI entry points) — all pass
- [x] LSP diagnostics — clean
- [x] Code review — 5-agent parallel review, all PASS