### PR TITLE
fix(perf): correct the dashboard-snapshot cache (Codex + self-review of #17)

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -14,6 +14,14 @@ enum AppView: String, CaseIterable {
 /// Snapshot of the model's essential state, captured on each successful
 /// load so a fresh DashboardModel can start in `.ready` state instead of
 /// flashing "Loading usage…" every time the popover reopens.
+///
+/// Only `hourly`/`agents` are excluded: they are the lazy lenses that
+/// `ensureData(for:)` refetches *solely when nil*, so restoring stale non-nil
+/// values would strand them on a previous year's slice (Codex P2-1/P2-3)
+/// until the 60s pollGraph tick. `agentUsage`/`trace` are NOT lazy lenses —
+/// their pollers (`pollAgentUsage`/`pollTrace`) fetch-first and overwrite
+/// unconditionally — so caching them is staleness-free and keeps the Overview
+/// tab's live/quota cards populated on reopen instead of flashing placeholders.
 private struct DashboardSnapshot {
     let payload: UsagePayload
     let stats: UsageStats
@@ -21,8 +29,6 @@ private struct DashboardSnapshot {
     let colors: ModelColorMap
     let knownYears: [String]
     let year: String?
-    let hourly: HourlyReport?
-    let agents: AgentsReport?
     let agentUsage: AgentUsagePayload?
     let trace: [TraceBucket]
 }
@@ -32,9 +38,22 @@ private struct DashboardSnapshot {
 /// first time their lens becomes active, mirroring the Tauri app's
 /// empty-year short-circuit hooks.
 @MainActor @Observable final class DashboardModel {
-    /// Survives the model's deallocation so the next PopoverView starts
-    /// with cached data instead of `.loading`.
+    /// Survives the model's deallocation so the next PopoverView starts with
+    /// cached data instead of `.loading`. A deliberate process-lifetime cache
+    /// (one COW-shared value snapshot, never invalidated). Every model may
+    /// *read* it on init, but only the popover's model *writes* it (gated by
+    /// `cachesSnapshot`): SettingsWindowView's independent DashboardModel runs
+    /// the same poll loops on a year frozen at its own init, so letting it
+    /// write here would clobber the snapshot with the settings model's stale
+    /// year and re-introduce the reopen flash. TODO: the cleaner end-state is
+    /// StatusItemController owning one long-lived DashboardModel injected via
+    /// `.environment`, with the poll loops started/stopped explicitly on
+    /// popover open/close — that deletes this static, DashboardSnapshot, and
+    /// the year guard while preserving the Phase B CPU win.
     private static var lastSnapshot: DashboardSnapshot?
+    /// Whether this model owns the shared `lastSnapshot` (true only for the
+    /// popover's model, whose teardown/rebuild is what the cache speeds up).
+    private let cachesSnapshot: Bool
     enum Phase {
         case loading
         case ready
@@ -44,16 +63,37 @@ private struct DashboardSnapshot {
     private(set) var phase: Phase
     private static let yearKey = "tokenbar.dashboard.year"
 
-    init() {
-        if let snap = Self.lastSnapshot {
+    /// Resolve the active year filter: the `--year=` debug flag wins, else the
+    /// persisted selection. Shared by `init()`'s snapshot guard and the `year`
+    /// property initializer so the two can never drift (the guard MUST compute
+    /// the same value the property does, or it would mis-classify a consistent
+    /// snapshot as stale). nil = all time.
+    private static func resolveYear() -> String? {
+        CommandLine.arguments
+            .first(where: { $0.hasPrefix("--year=") })
+            .map { String($0.dropFirst("--year=".count)) }
+            ?? UserDefaults.standard.string(forKey: yearKey)
+    }
+
+    /// `cachesSnapshot` = true only for the popover's model (PopoverView), the
+    /// one whose per-open teardown/rebuild the cache exists to speed up; the
+    /// settings window passes false so it never writes the shared snapshot.
+    init(cachesSnapshot: Bool = false) {
+        self.cachesSnapshot = cachesSnapshot
+        // Guard snapshot restore on year-consistency: if the user changed the
+        // year filter after the snapshot was written (e.g. setYear() persisted
+        // the new year but reload() failed before apply() ran), the cached
+        // payload is for the wrong slice — fall through to .loading so load()
+        // fetches fresh. resolveYear() is a static (no `self`); @Observable
+        // turns `year` into a computed accessor that touches self, so it is not
+        // readable here until `phase` is set — hence the shared static helper,
+        // which mirrors the `year` property initializer exactly.
+        if let snap = Self.lastSnapshot, snap.year == Self.resolveYear() {
             payload = snap.payload
             stats = snap.stats
             modelReport = snap.modelReport
             colors = snap.colors
             knownYears = snap.knownYears
-            year = snap.year
-            hourly = snap.hourly
-            agents = snap.agents
             agentUsage = snap.agentUsage
             trace = snap.trace
             phase = .ready
@@ -66,11 +106,7 @@ private struct DashboardSnapshot {
     /// nil = all time. Persisted so the selection survives the popover's
     /// rootView teardown/rebuild cycle.
     /// `--year=<yyyy>` preselects a year (debug/screenshot aid).
-    private(set) var year: String? =
-        CommandLine.arguments
-            .first(where: { $0.hasPrefix("--year=") })
-            .map { String($0.dropFirst("--year=".count)) }
-        ?? UserDefaults.standard.string(forKey: yearKey)
+    private(set) var year: String? = DashboardModel.resolveYear()
     /// Union of `payload.years` across loads — a year-filtered payload only
     /// reports the selected year, so remember the rest for the picker.
     private(set) var knownYears: [String] = []
@@ -95,6 +131,11 @@ private struct DashboardSnapshot {
             }.value
             let payload = try await payloadTask
             let report = await reportTask
+            // The year may have changed while we were off-actor (the user can
+            // open the year menu during the initial load); drop a stale slice
+            // so apply() never tags the new year — and the static snapshot —
+            // with the old year's payload. Mirrors reload()/pollGraph().
+            guard self.year == year else { return }
             apply(payload: payload, report: report)
         } catch {
             // Keep showing stale data over an error screen when a previous
@@ -176,11 +217,37 @@ private struct DashboardSnapshot {
         colors = ModelColorMap(report: report)
         knownYears = Set(knownYears + payload.years.map(\.year)).sorted(by: >)
         phase = .ready
+        cacheSnapshot()
+    }
+
+    /// Capture the full restore cache from the current state. Called ONLY from
+    /// apply(), where the year-scoped payload/stats and `year` are set together
+    /// and `year` has been validated against the payload — so the snapshot's
+    /// `year` always matches the slice its `payload` holds. No-op unless this
+    /// model owns the cache and a base payload has loaded.
+    private func cacheSnapshot() {
+        guard cachesSnapshot, let payload, let stats else { return }
         Self.lastSnapshot = DashboardSnapshot(
-            payload: payload, stats: stats!, modelReport: report,
+            payload: payload, stats: stats, modelReport: modelReport,
             colors: colors, knownYears: knownYears, year: year,
-            hourly: hourly, agents: agents, agentUsage: agentUsage,
-            trace: trace)
+            agentUsage: agentUsage, trace: trace)
+    }
+
+    /// Refresh only the live, year-independent fields (agentUsage/trace) of the
+    /// existing snapshot from their pollers, keeping the payload/year pair that
+    /// apply() last wrote. The pollers run outside apply() and must NOT
+    /// re-capture payload/year: self.year can momentarily disagree with
+    /// self.payload mid year-switch (setYear flips year before reload's apply
+    /// lands) or after the empty-year auto-clear, and writing that pair would
+    /// mis-tag a stale payload with a changed year that the init guard can't
+    /// catch. Preserving snap.payload/snap.year keeps the cache consistent.
+    /// No-op until apply() has written a base snapshot.
+    private func refreshSnapshotLiveData() {
+        guard cachesSnapshot, let snap = Self.lastSnapshot else { return }
+        Self.lastSnapshot = DashboardSnapshot(
+            payload: snap.payload, stats: snap.stats, modelReport: snap.modelReport,
+            colors: snap.colors, knownYears: snap.knownYears, year: snap.year,
+            agentUsage: agentUsage, trace: trace)
     }
 
     /// Periodically re-derive every loaded lens so the popover advances while
@@ -239,7 +306,10 @@ private struct DashboardSnapshot {
                 try TBCore.agentUsage()
             }.value
             if Task.isCancelled { break }
-            if let payload { agentUsage = payload }
+            if let payload {
+                agentUsage = payload
+                refreshSnapshotLiveData() // keep the reopen cache's quota cards current
+            }
             try? await Task.sleep(for: .seconds(60))
         }
     }
@@ -253,23 +323,36 @@ private struct DashboardSnapshot {
                 try TBCore.usageTrace(windowSecs: 600)
             }.value
             if Task.isCancelled { break }
-            if let buckets { trace = buckets }
+            if let buckets {
+                trace = buckets
+                refreshSnapshotLiveData() // keep the reopen cache's live trace current
+            }
             try? await Task.sleep(for: .seconds(10))
         }
     }
 
-    /// Fetch the lazy per-lens reports on first activation.
+    /// Fetch the lazy per-lens reports on first activation — and, because
+    /// PopoverView's `.task` is keyed on the year too, again for the active
+    /// lens after a year switch. Re-checks the year after the off-actor fetch
+    /// (mirrors load()/reload()/pollGraph()): a year change mid-fetch drops the
+    /// stale slice instead of stranding the previous year's report on the lens,
+    /// and the keyed `.task` re-fires to fetch the new year while the report is
+    /// still nil (reload()'s lazy re-fetch only covers an already-loaded lens).
     func ensureData(for view: AppView) async {
         let year = self.year
         switch view {
         case .hourly where hourly == nil:
-            hourly = await Task.detached(priority: .userInitiated) {
+            let report = await Task.detached(priority: .userInitiated) {
                 try? TBCore.hourlyReport(year: year)
             }.value
+            guard self.year == year else { return }
+            hourly = report
         case .agents where agents == nil:
-            agents = await Task.detached(priority: .userInitiated) {
+            let report = await Task.detached(priority: .userInitiated) {
                 try? TBCore.agentsReport(year: year)
             }.value
+            guard self.year == year else { return }
+            agents = report
         default:
             break
         }

--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -10,7 +10,9 @@ struct PopoverView: View {
     /// Height at the start of the active resize drag (global-space gesture).
     @State private var dragBase: CGFloat?
 
-    @State private var model = DashboardModel()
+    // The popover's model owns the shared restore snapshot — its per-open
+    // teardown/rebuild is exactly what the cache exists to speed up.
+    @State private var model = DashboardModel(cachesSnapshot: true)
     @State private var tokensPerMin: Double?
     /// True while Cmd has been held alone for a beat — shows shortcut pins.
     @State private var cmdHeld = false
@@ -68,7 +70,12 @@ struct PopoverView: View {
         .background(PopoverBackdrop().ignoresSafeArea())
         .overlay(alignment: .bottom) { resizeHandle }
         .task { await model.load() }
-        .task(id: activeViewRaw) {
+        // Keyed on the year too: a year switch must re-fetch the active lazy
+        // lens (Hourly/Agents) for the new slice. Without the year in the key,
+        // switching years while parked on Hourly/Agents would keep showing the
+        // old year (reload()'s lazy re-fetch only refreshes an already-loaded
+        // lens, so a lens still nil from the reopen would never reload).
+        .task(id: "\(activeViewRaw)|\(model.year ?? "")") {
             await model.ensureData(for: activeView.wrappedValue)
         }
         .task { await pollTokensPerMin() }

--- a/Sources/TokenBar/Views/SettingsWindowView.swift
+++ b/Sources/TokenBar/Views/SettingsWindowView.swift
@@ -8,6 +8,9 @@ import TokenBarCore
 /// changes reflect instantly without touching the popover's transient
 /// behavior.
 struct SettingsWindowView: View {
+    // Default cachesSnapshot: false — this window's model must never write the
+    // popover's restore snapshot (its `year` is frozen at init; clobbering the
+    // cache with it would re-introduce the reopen flash).
     @State private var model = DashboardModel()
     @State private var tokensPerMin: Double?
 


### PR DESCRIPTION
## Why

Follow-up to #17. The merged snapshot cache (which makes the popover reopen in `.ready` instead of flashing "Loading usage..." while the FFI fetch runs) had three real P2 issues, all flagged by Codex on #17 and confirmed here. Reviewing them surfaced three further bugs: a pre-existing `load()` race, a cross-window cache writer, and a `payload`/`year` decoupling.

Single substantive file (`DashboardModel.swift`); two one-line call-site changes.

## Findings and fixes

### Codex findings on #17 (all real against the merged code)

| # | Bug | Fix |
|---|-----|-----|
| P2-1 | `apply()` snapshotted `hourly`/`agents` **before** `reload()` refetched them for a new year, so a reopen could restore the previous year's lazy-lens data. `ensureData(for:)` only refetches when `nil`, and `pollGraph` sleeps 60s. | Strip `hourly`/`agents` from the snapshot so they start `nil` on reopen and refetch on first activation. |
| P2-2 | `init()` overwrote the persisted / `--year=` year with `snap.year`, so a `setYear()` that persisted a new year but whose `reload()` failed before `apply()` would restore the stale year and keep fetching the wrong slice. | Restore the snapshot only when `snap.year == resolveYear()`; otherwise fall through to `.loading` and let `load()` fetch the correct slice. |
| P2-3 | Restored non-`nil` `hourly`/`agents` made `ensureData` skip its refetch, so the lens was stale for up to 60s on reopen. | Same as P2-1 (lenses start `nil`, refetch on activation). |

### Found during self-review (`/code-review`)

| Severity | Bug | Fix |
|----------|-----|-----|
| P2 | `SettingsWindowView` runs a second `DashboardModel` whose `year` is frozen at init (no year picker). Its `pollGraph` wrote the **same** static snapshot, so leaving Settings open across a popover year change clobbered the cache with the settings model's stale year and the reopen flash returned. | Gate the snapshot **write** on a `cachesSnapshot` flag (`true` only for the popover's model). Settings reads the cache but never writes it. |
| P3 | `agentUsage`/`trace` were frozen at the last `apply()` rather than the pollers that actually populate them, so a cold-start-then-reopen showed empty Overview live/quota cards. | The pollers now refresh the snapshot's live fields (see split below). Keep `agentUsage`/`trace` cached: their pollers fetch-first and overwrite unconditionally, so caching them is staleness-free. |
| P3 (introduced while fixing the above, caught before merge) | Pollers rebuilding the whole snapshot read `self.year` + `self.payload` independently, so a year switch or empty-year clear could write `{payload: old-year, year: new-year}` that the `init` guard cannot catch. | Split the writer (below). |
| P1 (pre-existing) | `load()` applied an off-actor fetch without re-checking `self.year`, unlike `reload()`/`pollGraph()`. A year switch during the initial load could tag the new year, and the static snapshot, with the old year's payload. | Add `guard self.year == year else { return }` before `apply()` in `load()`. |

### The snapshot writer split

```
cacheSnapshot()            // apply() only: payload + year set together and
                           // validated, so the snapshot's year always matches
                           // the slice its payload holds
refreshSnapshotLiveData()  // pollers only: preserves the existing snapshot's
                           // payload/year, updates ONLY agentUsage/trace, so a
                           // poller can never mis-tag a stale payload
```

## Deliberately not changed

> These were evaluated and judged acceptable for this fix.

- Reopening directly onto the Hourly/Agents lens shows a brief in-card "Loading..." (those two lazy lenses are intentionally not cached, to avoid the cross-year staleness above). Documented in the snapshot doc comment.
- `--year=<empty year>` debug flag flashes on every reopen (debug/screenshot path only).
- Deleting logs while the popover is closed (All-years filter) shows one stale frame, self-healed by the immediate `load()`. Pre-existing from #17, inherent to the cache.
- A `TODO` at the static notes the clean end-state: a controller-owned long-lived `DashboardModel` with explicit poll start/stop, which deletes the static, the snapshot, and the year guard while keeping the Phase B CPU win.

## Verification

`cargo build --release` + `swift build` + `swift run TokenBar --selftest` (67 assertions) + `--smoke` (7 FFI entry points), all green.

The cross-year / poller races are timing-dependent and the app-layer `DashboardModel` is not in the `--selftest` (TokenBarCore) scope, so verification here is the build/test gate plus the source-traced review reasoning above (same reason #17 itself shipped without a unit test).

The Phase B CPU optimization is preserved byte-for-byte: the snapshot is inert value-type data on a static, with no `Task`/`Timer`/observer. The popover's model is still `@State`, still torn down to `Color.clear` on close, and its five `.task` loops still cancel on teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHAWZmQAPEie23q4z9r7VA
