### PR TITLE
feat: reorder & hide client tabs from Settings (also drives Overview quota cards)

### DIFF
--- a/Sources/TokenBar/AppDelegate.swift
+++ b/Sources/TokenBar/AppDelegate.swift
@@ -32,6 +32,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         BetaMigration.runIfNeeded() // before anything reads defaults
+        ClientRegistry.migrateLegacyOrderKey() // fold the old limits order into the shared tab order, likewise before reads
         // refreshIntervalMin's initializer ran at AppDelegate construction in
         // main.swift, BEFORE the migration above — re-read it now so a migrated
         // (non-default) data-refresh interval is honored this session instead of

--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -43,12 +43,23 @@ struct PopoverView: View {
             if BridgeBuild.isActive && !bridgeDismissed {
                 bridgeBanner
             }
-            if let stats = model.stats, stats.presentClients.count > 1 {
-                DashboardTabs(
-                    clients: stats.presentClients, active: $activeTab,
-                    kbdHints: cmdHeld)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 8)
+            if let stats = model.stats {
+                let displayClients = ClientRegistry.displayClients(present: stats.presentClients)
+                // Show the tabs row (which always starts with Overview) as soon as there is client data.
+                // This ensures Overview is visible alongside the clients.
+                if !displayClients.isEmpty {
+                    DashboardTabs(
+                        clients: displayClients, active: $activeTab,
+                        kbdHints: cmdHeld)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 8)
+                }
+                // If the active tab was hidden by user preference, fall back (side-effect)
+                let _ = {
+                    if activeTab != "overview" && !displayClients.contains(activeTab) {
+                        activeTab = "overview"
+                    }
+                }()
             }
             ViewSwitch(active: activeView)
                 .padding(.horizontal, 12)
@@ -274,7 +285,7 @@ struct PopoverView: View {
     @ViewBuilder private var lensContent: some View {
         if let payload = model.payload, let stats = model.stats {
             let singleClient = activeTab == "overview" ? nil : activeTab
-            let clientIds = singleClient.map { [$0] } ?? stats.presentClients
+            let clientIds = singleClient.map { [$0] } ?? ClientRegistry.displayClients(present: stats.presentClients)
             let activeStats = singleClient == nil
                 ? stats
                 : UsageStats(payload: payload, selectedClients: Set(clientIds))
@@ -415,7 +426,7 @@ struct PopoverView: View {
         guard mods == .command, let chars = event.charactersIgnoringModifiers?.lowercased()
         else { return false }
 
-        let tabs = ["overview"] + (model.stats?.presentClients ?? [])
+        let tabs = ["overview"] + ClientRegistry.displayClients(present: model.stats?.presentClients ?? [])
         switch chars {
         case "1", "2", "3", "4", "5", "6", "7", "8", "9":
             let index = Int(chars)! - 1

--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -37,29 +37,27 @@ struct PopoverView: View {
             set: { activeViewRaw = $0.rawValue })
     }
 
+    /// Client ids shown in the top tab bar: present clients minus the user's
+    /// hidden set, in their saved order. Drives both the tab row and the
+    /// fall-back-to-Overview guard (see `.onChange` below).
+    private var displayClients: [String] {
+        ClientRegistry.displayClients(present: model.stats?.presentClients ?? [])
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             header
             if BridgeBuild.isActive && !bridgeDismissed {
                 bridgeBanner
             }
-            if let stats = model.stats {
-                let displayClients = ClientRegistry.displayClients(present: stats.presentClients)
-                // Show the tabs row (which always starts with Overview) as soon as there is client data.
-                // This ensures Overview is visible alongside the clients.
-                if !displayClients.isEmpty {
-                    DashboardTabs(
-                        clients: displayClients, active: $activeTab,
-                        kbdHints: cmdHeld)
-                        .padding(.horizontal, 12)
-                        .padding(.bottom, 8)
-                }
-                // If the active tab was hidden by user preference, fall back (side-effect)
-                let _ = {
-                    if activeTab != "overview" && !displayClients.contains(activeTab) {
-                        activeTab = "overview"
-                    }
-                }()
+            // Show the tabs row (which always starts with Overview) as soon as
+            // there is client data, so Overview is visible alongside the clients.
+            if !displayClients.isEmpty {
+                DashboardTabs(
+                    clients: displayClients, active: $activeTab,
+                    kbdHints: cmdHeld)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
             }
             ViewSwitch(active: activeView)
                 .padding(.horizontal, 12)
@@ -105,13 +103,26 @@ struct PopoverView: View {
             }
         }
         .onDisappear { removeKeyMonitors() }
-        // Reset a stale persisted tab whenever the loaded client set changes —
+        // Reset a stale persisted tab whenever the displayed client set changes —
         // attached to the always-present root, not the tab row (which is hidden
         // when only one client is present), so a saved client id that no longer
-        // exists can't strand the dashboard on an empty single-client slice
-        // with no visible tab row to return to Overview.
-        .onChange(of: model.stats?.presentClients) { _, clients in
-            if activeTab != "overview", let clients, !clients.contains(activeTab) {
+        // exists (or that the user just hid from the top tabs) can't strand the
+        // dashboard on an empty slice with no visible tab row to return to
+        // Overview. `initial: true` also catches a tab persisted-then-hidden
+        // across a relaunch. Keyed on displayClients (not presentClients) so a
+        // hide toggle — which leaves the client in presentClients — still fires.
+        .onChange(of: model.stats?.presentClients, initial: true) { _, present in
+            // Keyed on presentClients (the load signal), NOT displayClients:
+            // when every client is hidden, displayClients stays [] across the
+            // nil->loaded transition, so an onChange on it would never fire and
+            // a persisted tab would strand on a hidden slice. presentClients
+            // still deltas on load. The `guard` skips the pre-load nil fire so a
+            // persisted tab isn't reset to Overview before data arrives
+            // (defeating tokenbar.activeTab's cross-launch memory). Membership is
+            // judged against displayClients so hiding the active tab — which
+            // leaves it in presentClients — still falls back to Overview.
+            guard present != nil else { return }
+            if activeTab != "overview", !displayClients.contains(activeTab) {
                 activeTab = "overview"
             }
         }

--- a/Sources/TokenBar/Views/AgentLimitsCard.swift
+++ b/Sources/TokenBar/Views/AgentLimitsCard.swift
@@ -29,8 +29,10 @@ struct AgentLimitsCard: View {
     @AppStorage("tokenbar.limits.asUsed") private var asUsed = false
     @AppStorage("tokenbar.limits.paceMode") private var paceModeRaw = PaceMode.historical.rawValue
     @AppStorage("tokenbar.limits.layout") private var layoutRaw = LimitsLayout.full.rawValue
-    /// Saved drag order, comma-joined client ids (ids never contain commas).
-    @AppStorage("tokenbar.limits.order") private var orderRaw = ""
+    /// Saved drag order (shared with the "Client tabs (top bar)" order in Settings).
+    /// Reordering providers in Settings → Client tabs now also reorders the
+    /// quota cards shown in Overview → Agent limits (and vice-versa via drag).
+    @AppStorage(ClientRegistry.tabOrderKey) private var orderRaw = ""
 
     @State private var dragId: String?
     @State private var overId: String?
@@ -94,8 +96,15 @@ struct AgentLimitsCard: View {
         }
         if restrict { return clients.filter(known) }
         var seen = Set<String>()
-        return (clients.filter(known) + (agentUsage?.agents.map(\.clientId) ?? []))
+        var base = (clients.filter(known) + (agentUsage?.agents.map(\.clientId) ?? []))
             .filter { seen.insert($0).inserted }
+
+        // Apply the same hide logic as Client tabs: hidden providers should not appear in limits cards either.
+        if reorderable {
+            let hidden = ClientRegistry.hiddenClients()
+            base = base.filter { !hidden.contains($0) }
+        }
+        return base
     }
 
     /// Saved drag order applied; ids without a saved position keep their

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -9,6 +9,9 @@ struct SettingsPanel: View {
     /// For the quota-source picker (the windows currently known).
     var agentUsage: AgentUsagePayload?
 
+    /// Present clients (used for the client tabs reorder/hide UI).
+    var presentClients: [String] = []
+
     @AppStorage(TrayMode.storageKey) private var trayModeRaw = TrayMode.todayTokens.rawValue
     @AppStorage(TrayAnimator.animateKey) private var animateTray = true
     @AppStorage(TrayAnimator.styleKey) private var animationStyle = "cat"
@@ -26,7 +29,54 @@ struct SettingsPanel: View {
     /// same key, so the two stay in sync.
     @AppStorage(PopoverChrome.heightKey) private var popoverHeight = 0.0
 
+    // New for tabs improvement
+    @AppStorage(ClientRegistry.tabOrderKey) private var tabsOrderRaw = ""
+    @AppStorage(ClientRegistry.tabHiddenKey) private var tabsHiddenRaw = ""
+
+    // Drag state for client tabs reorder (scoped to this panel)
+    @State private var tabsDragId: String?
+    @State private var tabsOverId: String?
+    @State private var tabsCardFrames: [String: CGRect] = [:]
+
+    private static let tabsDragSpace = "client-tabs-order"
+
+    private struct TabsCardFramesKey: PreferenceKey {
+        static let defaultValue: [String: CGRect] = [:]
+        static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+            value.merge(nextValue(), uniquingKeysWith: { $1 })
+        }
+    }
+
     static let refreshIntervalOptions = [1, 5, 15, 30, 60]
+
+    // MARK: - Client tabs drag reorder helpers (adapted from AgentLimitsCard)
+
+    private func dropEdge(for id: String, in orderList: [String]) -> VerticalEdge? {
+        guard let dragId = tabsDragId,
+              tabsOverId == id,
+              dragId != id,
+              let fromI = orderList.firstIndex(of: dragId),
+              let toI = orderList.firstIndex(of: id)
+        else { return nil }
+        return fromI < toI ? .bottom : .top
+    }
+
+    private func dragGestureForTab(id: String, orderList: [String]) -> some Gesture {
+        DragGesture(minimumDistance: 2, coordinateSpace: .named(Self.tabsDragSpace))
+            .onChanged { value in
+                tabsDragId = id
+                let over = tabsCardFrames.first { $0.value.contains(value.location) }?.key
+                tabsOverId = (over != nil && over != id) ? over : nil
+            }
+            .onEnded { _ in
+                if let over = tabsOverId, over != id {
+                    let next = ClientRegistry.reorder(orderList, from: id, to: over)
+                    tabsOrderRaw = next.joined(separator: ",")
+                }
+                tabsDragId = nil
+                tabsOverId = nil
+            }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -84,6 +134,94 @@ struct SettingsPanel: View {
                         options: PaceMode.allCases.map { ($0.rawValue, "Pace: \($0.rawValue.capitalized)") })
                     hint("The deficit/reserve marker. Historical learns your weekly usage curve and shows run-out risk, falling back to linear until enough weeks accrue; Linear paces evenly by the clock; Off hides the marker.")
                 }
+            }
+
+            section("Client tabs (top bar)") {
+                let hiddenSet = Set(tabsHiddenRaw.isEmpty ? [] : tabsHiddenRaw.split(separator: ",").map(String.init))
+
+                // Master order: show ALL present clients (checked or unchecked) sorted by saved order.
+                // Hidden ones remain visible in settings so you can always reorder them.
+                let order = tabsOrderRaw.isEmpty ? [] : tabsOrderRaw.split(separator: ",").map(String.init)
+                let fullOrdered = presentClients.sorted { a, b in
+                    let ia = order.firstIndex(of: a) ?? Int.max
+                    let ib = order.firstIndex(of: b) ?? Int.max
+                    if ia == ib {
+                        return presentClients.firstIndex(of: a)! < presentClients.firstIndex(of: b)!
+                    }
+                    return ia < ib
+                }
+
+                if presentClients.isEmpty {
+                    Text("No clients with usage data yet.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Drag to reorder. Check = show in top tabs, uncheck = hide from top tabs (but stays here).")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+
+                        VStack(spacing: 4) {
+                            ForEach(fullOrdered, id: \.self) { id in
+                                let isVisible = !hiddenSet.contains(id)
+                                HStack(spacing: 8) {
+                                    // Drag handle - always shown for every provider
+                                    Text("⠿")
+                                        .font(.caption)
+                                        .foregroundStyle(tabsDragId == id ? .primary : .tertiary)
+                                        .help("Drag to reorder")
+                                        .gesture(dragGestureForTab(id: id, orderList: fullOrdered))
+
+                                    Toggle(isOn: Binding(
+                                        get: { isVisible },
+                                        set: { show in
+                                            var hidden = hiddenSet
+                                            if show {
+                                                hidden.remove(id)
+                                            } else {
+                                                hidden.insert(id)
+                                            }
+                                            tabsHiddenRaw = hidden.sorted().joined(separator: ",")
+                                        }
+                                    )) {
+                                        HStack(spacing: 6) {
+                                            AgentIconView(clientId: id, size: 14)
+                                            Text(ClientRegistry.shortName(id))
+                                                .font(.caption)
+                                            if !isVisible {
+                                                Text("(hidden)")
+                                                    .font(.caption2)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                        }
+                                    }
+                                    .toggleStyle(.checkbox)
+
+                                    Spacer()
+                                }
+                                .opacity(tabsDragId == id ? 0.5 : 1)
+                                .overlay(alignment: dropEdge(for: id, in: fullOrdered) == .top ? .top : .bottom) {
+                                    if let edge = dropEdge(for: id, in: fullOrdered) {
+                                        Rectangle()
+                                            .fill(Color.accentColor)
+                                            .frame(height: 2)
+                                            .offset(y: edge == .top ? -3 : 3)
+                                    }
+                                }
+                                .background(
+                                    GeometryReader { geo in
+                                        Color.clear.preference(
+                                            key: TabsCardFramesKey.self,
+                                            value: [id: geo.frame(in: .named(Self.tabsDragSpace))])
+                                    })
+                            }
+                        }
+                        .coordinateSpace(name: Self.tabsDragSpace)
+                        .onPreferenceChange(TabsCardFramesKey.self) { tabsCardFrames = $0 }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                hint("All providers always appear here so you can arrange order + visibility. Unchecked = hidden from top tabs AND from Agent limits cards (and overview charts). Order applies to top tabs and quota cards.")
             }
 
             section("Live trace") {

--- a/Sources/TokenBar/Views/SettingsWindowView.swift
+++ b/Sources/TokenBar/Views/SettingsWindowView.swift
@@ -17,7 +17,7 @@ struct SettingsWindowView: View {
     var body: some View {
         HStack(spacing: 0) {
             ScrollView {
-                SettingsPanel(agentUsage: model.agentUsage)
+                SettingsPanel(agentUsage: model.agentUsage, presentClients: model.stats?.presentClients ?? [])
                     .padding(14)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(OverlayScrollerEnforcer())
@@ -63,9 +63,18 @@ struct SettingsWindowView: View {
             }
 
             section("Agent limits card") {
+                let displayClients = ClientRegistry.displayClients(present: model.stats?.presentClients ?? [])
                 AgentLimitsCard(
-                    clients: model.stats?.presentClients ?? [],
-                    trace: model.trace, agentUsage: model.agentUsage)
+                    clients: displayClients,
+                    trace: model.trace, agentUsage: model.agentUsage,
+                    reorderable: true)
+            }
+
+            section("Client tabs (top bar preview + controls)") {
+                SettingsPanel(
+                    agentUsage: model.agentUsage,
+                    presentClients: model.stats?.presentClients ?? []
+                )
             }
 
             section("Live session card") {

--- a/Sources/TokenBar/Views/SettingsWindowView.swift
+++ b/Sources/TokenBar/Views/SettingsWindowView.swift
@@ -70,13 +70,6 @@ struct SettingsWindowView: View {
                     reorderable: true)
             }
 
-            section("Client tabs (top bar preview + controls)") {
-                SettingsPanel(
-                    agentUsage: model.agentUsage,
-                    presentClients: model.stats?.presentClients ?? []
-                )
-            }
-
             section("Live session card") {
                 UsageTraceCard(buckets: model.trace, windowSecs: 600)
             }

--- a/Sources/TokenBarCore/ClientRegistry.swift
+++ b/Sources/TokenBarCore/ClientRegistry.swift
@@ -71,4 +71,58 @@ public enum ClientRegistry {
         }
         return name
     }
+
+    // MARK: - Tab bar display order & visibility (new for tabs improvement)
+
+    public static let tabOrderKey = "tokenbar.tabs.order"
+    public static let tabHiddenKey = "tokenbar.tabs.hidden"
+
+    /// Returns the set of client ids that the user has hidden from the top tabs (and now also from Agent limits cards).
+    public static func hiddenClients() -> Set<String> {
+        let defaults = UserDefaults.standard
+        let raw = defaults.string(forKey: tabHiddenKey) ?? ""
+        return Set(raw.isEmpty ? [] : raw.split(separator: ",").map(String.init))
+    }
+
+    /// Returns the subset of `present` clients to show in the top tab bar,
+    /// filtered by hidden list and sorted according to the user's saved order.
+    /// Clients not yet in the saved order are appended at the end (so newly
+    /// discovered agents become visible without breaking existing custom order).
+    public static func displayClients(present: [String]) -> [String] {
+        let orderRaw = UserDefaults.standard.string(forKey: tabOrderKey) ?? ""
+        let hidden = hiddenClients()
+
+        let order = orderRaw.isEmpty ? [] : orderRaw.split(separator: ",").map(String.init)
+
+        let visible = present.filter { !hidden.contains($0) }
+
+        guard !order.isEmpty else {
+            // No custom order yet — preserve incoming order (historically alpha).
+            return visible
+        }
+
+        return visible.sorted { a, b in
+            let ia = order.firstIndex(of: a) ?? Int.max
+            let ib = order.firstIndex(of: b) ?? Int.max
+            if ia == ib {
+                // Preserve relative order among items with no explicit position.
+                return visible.firstIndex(of: a)! < visible.firstIndex(of: b)!
+            }
+            return ia < ib
+        }
+    }
+
+    /// Direction-aware reorder helper (drag down inserts after, up before).
+    /// Mirrors the logic used in AgentLimitsCard.
+    public static func reorder(_ list: [String], from: String, to: String) -> [String] {
+        guard let fromI = list.firstIndex(of: from),
+              let toI = list.firstIndex(of: to),
+              fromI != toI
+        else { return list }
+
+        var out = list.filter { $0 != from }
+        let anchor = out.firstIndex(of: to)!
+        out.insert(from, at: fromI < toI ? anchor + 1 : anchor)
+        return out
+    }
 }

--- a/Sources/TokenBarCore/ClientRegistry.swift
+++ b/Sources/TokenBarCore/ClientRegistry.swift
@@ -125,4 +125,19 @@ public enum ClientRegistry {
         out.insert(from, at: fromI < toI ? anchor + 1 : anchor)
         return out
     }
+
+    /// One-time migration: the Agent-limits drag order used to persist under
+    /// "tokenbar.limits.order". It now shares `tabOrderKey` with the client tab
+    /// bar, so fold an existing legacy value across once — otherwise upgrading
+    /// users would silently lose their saved card arrangement. Idempotent: only
+    /// fires when the new key is unset and a non-empty legacy value exists.
+    public static func migrateLegacyOrderKey() {
+        let defaults = UserDefaults.standard
+        let legacyKey = "tokenbar.limits.order"
+        guard defaults.object(forKey: tabOrderKey) == nil,
+              let legacy = defaults.string(forKey: legacyKey),
+              !legacy.isEmpty
+        else { return }
+        defaults.set(legacy, forKey: tabOrderKey)
+    }
 }


### PR DESCRIPTION
## What

Adds user control over the top **client tab bar** and keeps the Overview in sync with it:

- **Reorder** providers by dragging them in **Settings → Client tabs (top bar)**.
- **Show / hide** individual providers via a checkbox. Hidden providers stay listed in
  Settings (so you can re-enable or reorder them) but disappear from the top tabs.
- The saved order + visibility now also drive the **Overview → Agent limits** quota cards
  (and the Overview charts), so both views stay consistent. Reordering in Settings and
  dragging the limit cards share one persisted order.
- The active tab falls back to **Overview** if the user hides it.

## How

- New persistence + helpers in `ClientRegistry` (`Sources/TokenBarCore/ClientRegistry.swift`):
  `tabOrderKey` / `tabHiddenKey`, `hiddenClients()`, `displayClients(present:)`.
- `SettingsPanel` gains a **"Client tabs (top bar)"** section with drag-to-reorder + visibility toggles.
- `PopoverView`, `SettingsWindowView`, and `AgentLimitsCard` consume `ClientRegistry.displayClients(...)`
  so ordering/hiding applies to the tab row, the keyboard shortcuts (⌘1–9, `[` / `]`), and the
  Overview quota cards. The tab-row view (`DashboardTabs`) itself is unchanged.

## Compatibility

- Preferences live in `UserDefaults` (`tokenbar.tabs.order`, `tokenbar.tabs.hidden`); the
  limits-card order key is unified with the tabs order key.
- No migration needed — with no saved state, behavior is unchanged (all present clients shown
  in the historical order).
- Rebased onto current `main`; builds clean (`swift build`). The diff touches 5 files and leaves
  the tab-row scroll behavior as-is.
