### PR TITLE
feat(settings): Add per-client and master toggles to hide Agent limits

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -182,6 +182,48 @@ enum SelfTest {
         expect(AgentLimitsCard.reorder(order, from: "a", to: "a") == order, "reorder onto itself is a no-op")
         expect(AgentLimitsCard.reorder(order, from: "x", to: "b") == order, "reorder unknown id is a no-op")
 
+        // mergeReorder: dragging within a visible SUBSET must not drop the
+        // off-screen ids from the shared tab-order key. Non-visible ids keep
+        // their exact slots; the visible slots refill in the new order.
+        expect(
+            ClientRegistry.mergeReorder(
+                full: ["g", "a", "c", "x"], visible: ["c", "x"], from: "x", to: "c")
+                == ["g", "a", "x", "c"],
+            "mergeReorder keeps non-visible ids in place")
+        // A visible id not yet in the saved order appends at the end.
+        expect(
+            ClientRegistry.mergeReorder(
+                full: ["a"], visible: ["a", "z"], from: "a", to: "a")
+                == ["a", "z"],
+            "mergeReorder appends visible ids absent from full")
+        // A no-op drag leaves the full order untouched.
+        expect(
+            ClientRegistry.mergeReorder(
+                full: ["a", "b", "c"], visible: ["a", "b", "c"], from: "a", to: "a")
+                == ["a", "b", "c"],
+            "mergeReorder no-op leaves full order unchanged")
+        // Empty saved order → just the reordered visible sequence.
+        expect(
+            ClientRegistry.mergeReorder(
+                full: [], visible: ["a", "b"], from: "a", to: "b")
+                == ["b", "a"],
+            "mergeReorder with empty full writes the visible sequence")
+
+        // knownLimitsClients (the hoisted universe): present clients with a
+        // known limit, unioned with quota-snapshot holders (dedup, ordered).
+        expect(
+            ClientRegistry.knownLimitsClients(
+                present: ["cursor", "claude"], quotaIds: ["antigravity"],
+                placeholders: ["codex", "claude", "gemini"])
+                == ["claude", "antigravity"],
+            "knownLimitsClients drops no-limit present ids, keeps quota-only ids")
+
+        // CSV id-set parse helper: empty string → empty set; commas split.
+        expect(ClientRegistry.parseIdSet("").isEmpty, "parseIdSet empty string is empty")
+        expect(
+            ClientRegistry.parseIdSet("a,b,a") == Set(["a", "b"]),
+            "parseIdSet splits and dedups")
+
         // FFI envelope/error contract (hermetic; no FFI allocation or live data).
         for (label, passed) in TBCore.envelopeContractChecks() {
             expect(passed, "envelope: \(label)")

--- a/Sources/TokenBar/Views/AgentLimitsCard.swift
+++ b/Sources/TokenBar/Views/AgentLimitsCard.swift
@@ -26,6 +26,10 @@ struct AgentLimitsCard: View {
     /// order persists to UserDefaults. Only the multi-agent overview opts in.
     var reorderable = false
 
+    /// Master switch: off hides the card everywhere it's rendered (Overview
+    /// summary, single-client tabs, Settings live-preview) regardless of
+    /// per-client visibility.
+    @AppStorage("tokenbar.limits.enabled") private var limitsEnabled = true
     /// Bar fills by used (true) or remaining (false).
     @AppStorage("tokenbar.limits.asUsed") private var asUsed = false
     @AppStorage("tokenbar.limits.paceMode") private var paceModeRaw = PaceMode.historical.rawValue
@@ -34,6 +38,8 @@ struct AgentLimitsCard: View {
     /// Reordering providers in Settings → Client tabs now also reorders the
     /// quota cards shown in Overview → Agent limits (and vice-versa via drag).
     @AppStorage(ClientRegistry.tabOrderKey) private var orderRaw = ""
+    /// Per-client Agent-limits visibility, independent of tab visibility.
+    @AppStorage(ClientRegistry.limitsHiddenKey) private var limitsHiddenRaw = ""
 
     @State private var dragId: String?
     @State private var overId: String?
@@ -56,6 +62,20 @@ struct AgentLimitsCard: View {
         "Codex": "codex", "Claude": "claude", "Copilot": "copilot",
         "Gemini": "antigravity",
     ]
+
+    /// Every client id that can show a row in the multi-agent Agent-limits
+    /// card: `present` clients (local session data) plus anything with a
+    /// placeholder row or a live quota snapshot. Some agents (e.g.
+    /// Antigravity) report OAuth quota with no local session logs, so they
+    /// wouldn't otherwise appear in `present` — Settings needs this superset
+    /// to offer a hide toggle for them too.
+    static func knownClientIds(agentUsage: AgentUsagePayload?, present: [String]) -> [String] {
+        let snapshotIds = Set((agentUsage?.agents ?? []).map(\.clientId))
+        func known(_ id: String) -> Bool { placeholderRows[id] != nil || snapshotIds.contains(id) }
+        var seen = Set<String>()
+        return (present.filter(known) + (agentUsage?.agents.map(\.clientId) ?? []))
+            .filter { seen.insert($0).inserted }
+    }
 
     private var snapshots: [String: AgentUsageSnapshot] {
         var dict = Dictionary(
@@ -100,9 +120,13 @@ struct AgentLimitsCard: View {
         var base = (clients.filter(known) + (agentUsage?.agents.map(\.clientId) ?? []))
             .filter { seen.insert($0).inserted }
 
-        // Apply the same hide logic as Client tabs: hidden providers should not appear in limits cards either.
+        // Apply the same hide logic as Client tabs, plus the independent
+        // per-client Agent-limits toggle: either one keeps a client out of
+        // the multi-agent limits card.
         if reorderable {
-            let hidden = ClientRegistry.hiddenClients()
+            let limitsHidden = Set(
+                limitsHiddenRaw.isEmpty ? [] : limitsHiddenRaw.split(separator: ",").map(String.init))
+            let hidden = ClientRegistry.hiddenClients().union(limitsHidden)
             base = base.filter { !hidden.contains($0) }
         }
         return base
@@ -122,31 +146,33 @@ struct AgentLimitsCard: View {
     }
 
     var body: some View {
-        DashCard(title, trailing: { noteLabel }) {
-            if opencodeView {
-                integrationLine("↔ Routes through opencode")
-            } else if !restrict && !opencodeSubs.isEmpty {
-                integrationLine("opencode also taps: \(opencodeSubs.joined(separator: " · "))")
-            }
-            let visible = visibleClients
-            if visible.isEmpty {
-                Text(
-                    opencodeView && !opencodeSubs.isEmpty
-                        ? "Subscriptions: \(opencodeSubs.joined(separator: " · "))"
-                        : "No supported agents yet"
-                )
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.vertical, 8)
-            } else {
-                VStack(spacing: 12) {
-                    ForEach(visible, id: \.self) { id in
-                        agentSection(id, visible: visible)
-                    }
+        if limitsEnabled {
+            DashCard(title, trailing: { noteLabel }) {
+                if opencodeView {
+                    integrationLine("↔ Routes through opencode")
+                } else if !restrict && !opencodeSubs.isEmpty {
+                    integrationLine("opencode also taps: \(opencodeSubs.joined(separator: " · "))")
                 }
-                .coordinateSpace(name: Self.dragSpace)
-                .onPreferenceChange(CardFramesKey.self) { cardFrames = $0 }
+                let visible = visibleClients
+                if visible.isEmpty {
+                    Text(
+                        opencodeView && !opencodeSubs.isEmpty
+                            ? "Subscriptions: \(opencodeSubs.joined(separator: " · "))"
+                            : "No supported agents yet"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(visible, id: \.self) { id in
+                            agentSection(id, visible: visible)
+                        }
+                    }
+                    .coordinateSpace(name: Self.dragSpace)
+                    .onPreferenceChange(CardFramesKey.self) { cardFrames = $0 }
+                }
             }
         }
     }

--- a/Sources/TokenBar/Views/AgentLimitsCard.swift
+++ b/Sources/TokenBar/Views/AgentLimitsCard.swift
@@ -26,10 +26,6 @@ struct AgentLimitsCard: View {
     /// order persists to UserDefaults. Only the multi-agent overview opts in.
     var reorderable = false
 
-    /// Master switch: off hides the card everywhere it's rendered (Overview
-    /// summary, single-client tabs, Settings live-preview) regardless of
-    /// per-client visibility.
-    @AppStorage("tokenbar.limits.enabled") private var limitsEnabled = true
     /// Bar fills by used (true) or remaining (false).
     @AppStorage("tokenbar.limits.asUsed") private var asUsed = false
     @AppStorage("tokenbar.limits.paceMode") private var paceModeRaw = PaceMode.historical.rawValue
@@ -64,17 +60,14 @@ struct AgentLimitsCard: View {
     ]
 
     /// Every client id that can show a row in the multi-agent Agent-limits
-    /// card: `present` clients (local session data) plus anything with a
-    /// placeholder row or a live quota snapshot. Some agents (e.g.
-    /// Antigravity) report OAuth quota with no local session logs, so they
-    /// wouldn't otherwise appear in `present` — Settings needs this superset
-    /// to offer a hide toggle for them too.
+    /// card. Thin wrapper over `ClientRegistry.knownLimitsClients` (the one
+    /// implementation) that supplies this card's placeholder-row keys, so the
+    /// registry-level lists and the card agree on the universe.
     static func knownClientIds(agentUsage: AgentUsagePayload?, present: [String]) -> [String] {
-        let snapshotIds = Set((agentUsage?.agents ?? []).map(\.clientId))
-        func known(_ id: String) -> Bool { placeholderRows[id] != nil || snapshotIds.contains(id) }
-        var seen = Set<String>()
-        return (present.filter(known) + (agentUsage?.agents.map(\.clientId) ?? []))
-            .filter { seen.insert($0).inserted }
+        ClientRegistry.knownLimitsClients(
+            present: present,
+            quotaIds: (agentUsage?.agents ?? []).map(\.clientId),
+            placeholders: Set(placeholderRows.keys))
     }
 
     private var snapshots: [String: AgentUsageSnapshot] {
@@ -124,8 +117,7 @@ struct AgentLimitsCard: View {
         // per-client Agent-limits toggle: either one keeps a client out of
         // the multi-agent limits card.
         if reorderable {
-            let limitsHidden = Set(
-                limitsHiddenRaw.isEmpty ? [] : limitsHiddenRaw.split(separator: ",").map(String.init))
+            let limitsHidden = ClientRegistry.parseIdSet(limitsHiddenRaw)
             let hidden = ClientRegistry.hiddenClients().union(limitsHidden)
             base = base.filter { !hidden.contains($0) }
         }
@@ -133,46 +125,41 @@ struct AgentLimitsCard: View {
     }
 
     /// Saved drag order applied; ids without a saved position keep their
-    /// natural order at the end. Disabled in non-reorderable views.
+    /// natural order at the end. Disabled in non-reorderable views. Reads the
+    /// observed `orderRaw` so a drag re-sorts the cards reactively.
     private var visibleClients: [String] {
-        let base = baseClients
-        let order = orderRaw.isEmpty ? [] : orderRaw.split(separator: ",").map(String.init)
-        guard reorderable, !order.isEmpty else { return base }
-        return base.sorted { a, b in
-            let ia = order.firstIndex(of: a) ?? Int.max
-            let ib = order.firstIndex(of: b) ?? Int.max
-            return ia == ib ? base.firstIndex(of: a)! < base.firstIndex(of: b)! : ia < ib
-        }
+        reorderable ? ClientRegistry.orderedClients(baseClients, orderRaw: orderRaw) : baseClients
     }
 
+    // The master `tokenbar.limits.enabled` gate lives at every call site
+    // (OverviewView, SettingsWindowView) rather than inside `body`, so an
+    // "off" card leaves no structural gap in its parent VStack.
     var body: some View {
-        if limitsEnabled {
-            DashCard(title, trailing: { noteLabel }) {
-                if opencodeView {
-                    integrationLine("↔ Routes through opencode")
-                } else if !restrict && !opencodeSubs.isEmpty {
-                    integrationLine("opencode also taps: \(opencodeSubs.joined(separator: " · "))")
-                }
-                let visible = visibleClients
-                if visible.isEmpty {
-                    Text(
-                        opencodeView && !opencodeSubs.isEmpty
-                            ? "Subscriptions: \(opencodeSubs.joined(separator: " · "))"
-                            : "No supported agents yet"
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, 8)
-                } else {
-                    VStack(spacing: 12) {
-                        ForEach(visible, id: \.self) { id in
-                            agentSection(id, visible: visible)
-                        }
+        DashCard(title, trailing: { noteLabel }) {
+            if opencodeView {
+                integrationLine("↔ Routes through opencode")
+            } else if !restrict && !opencodeSubs.isEmpty {
+                integrationLine("opencode also taps: \(opencodeSubs.joined(separator: " · "))")
+            }
+            let visible = visibleClients
+            if visible.isEmpty {
+                Text(
+                    opencodeView && !opencodeSubs.isEmpty
+                        ? "Subscriptions: \(opencodeSubs.joined(separator: " · "))"
+                        : "No supported agents yet"
+                )
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+            } else {
+                VStack(spacing: 12) {
+                    ForEach(visible, id: \.self) { id in
+                        agentSection(id, visible: visible)
                     }
-                    .coordinateSpace(name: Self.dragSpace)
-                    .onPreferenceChange(CardFramesKey.self) { cardFrames = $0 }
                 }
+                .coordinateSpace(name: Self.dragSpace)
+                .onPreferenceChange(CardFramesKey.self) { cardFrames = $0 }
             }
         }
     }
@@ -200,17 +187,11 @@ struct AgentLimitsCard: View {
         }
     }
 
-    /// Move `from` to the `to` card's slot, direction-aware: dragging downward
-    /// drops it just after `to`, dragging upward just before it. (Plain
-    /// "insert before" makes single-step downward moves a no-op.)
+    /// Move `from` to the `to` card's slot, direction-aware. Delegates to the
+    /// single `ClientRegistry.reorder` implementation (SelfTest asserts against
+    /// this symbol; keeping the wrapper keeps those checks addressing the card).
     static func reorder(_ list: [String], from: String, to: String) -> [String] {
-        guard let fromI = list.firstIndex(of: from), let toI = list.firstIndex(of: to),
-              fromI != toI
-        else { return list }
-        var out = list.filter { $0 != from }
-        let anchor = out.firstIndex(of: to)!
-        out.insert(from, at: fromI < toI ? anchor + 1 : anchor)
-        return out
+        ClientRegistry.reorder(list, from: from, to: to)
     }
 
     /// Which edge of a card the drop line sits on, matching the
@@ -231,8 +212,14 @@ struct AgentLimitsCard: View {
             }
             .onEnded { _ in
                 if let over = overId, over != id {
-                    let next = Self.reorder(visible, from: id, to: over)
-                    orderRaw = next.joined(separator: ",")
+                    // `visible` is a subset of the shared tab order (it excludes
+                    // hidden and non-quota clients). Merge the reordered subset
+                    // back into the full saved order so off-screen ids keep
+                    // their slots instead of being dropped from the key.
+                    let full = ClientRegistry.parseIdList(orderRaw)
+                    let merged = ClientRegistry.mergeReorder(
+                        full: full, visible: visible, from: id, to: over)
+                    orderRaw = merged.joined(separator: ",")
                 }
                 dragId = nil
                 overId = nil

--- a/Sources/TokenBar/Views/OverviewView.swift
+++ b/Sources/TokenBar/Views/OverviewView.swift
@@ -18,14 +18,23 @@ struct OverviewView: View {
     /// Dashboard year filter (nil = all time), forwarded to the chart card.
     var year: String?
 
+    /// Per-client Agent-limits visibility, independent of tab visibility.
+    @AppStorage(ClientRegistry.limitsHiddenKey) private var limitsHiddenRaw = ""
+
+    private var hiddenLimits: Set<String> {
+        Set(limitsHiddenRaw.isEmpty ? [] : limitsHiddenRaw.split(separator: ",").map(String.init))
+    }
+
     var body: some View {
         VStack(spacing: 12) {
             if let singleClient {
                 let name = ClientRegistry.style(singleClient).displayName
-                AgentLimitsCard(
-                    clients: [singleClient], trace: trace, agentUsage: agentUsage,
-                    title: "\(name) limits", note: "Session / weekly / model limits",
-                    restrict: true)
+                if !hiddenLimits.contains(singleClient) {
+                    AgentLimitsCard(
+                        clients: [singleClient], trace: trace, agentUsage: agentUsage,
+                        title: "\(name) limits", note: "Session / weekly / model limits",
+                        restrict: true)
+                }
                 chart
                 ModelBreakdownCard(
                     report: modelReport, clientIds: clientIds, colors: colors,

--- a/Sources/TokenBar/Views/OverviewView.swift
+++ b/Sources/TokenBar/Views/OverviewView.swift
@@ -18,18 +18,20 @@ struct OverviewView: View {
     /// Dashboard year filter (nil = all time), forwarded to the chart card.
     var year: String?
 
+    /// Master switch: off hides the Agent-limits card everywhere.
+    @AppStorage("tokenbar.limits.enabled") private var limitsEnabled = true
     /// Per-client Agent-limits visibility, independent of tab visibility.
     @AppStorage(ClientRegistry.limitsHiddenKey) private var limitsHiddenRaw = ""
 
     private var hiddenLimits: Set<String> {
-        Set(limitsHiddenRaw.isEmpty ? [] : limitsHiddenRaw.split(separator: ",").map(String.init))
+        ClientRegistry.parseIdSet(limitsHiddenRaw)
     }
 
     var body: some View {
         VStack(spacing: 12) {
             if let singleClient {
                 let name = ClientRegistry.style(singleClient).displayName
-                if !hiddenLimits.contains(singleClient) {
+                if limitsEnabled && !hiddenLimits.contains(singleClient) {
                     AgentLimitsCard(
                         clients: [singleClient], trace: trace, agentUsage: agentUsage,
                         title: "\(name) limits", note: "Session / weekly / model limits",
@@ -41,9 +43,11 @@ struct OverviewView: View {
                     title: "\(name) models")
             } else {
                 chart
-                AgentLimitsCard(
-                    clients: clientIds, trace: trace, agentUsage: agentUsage,
-                    reorderable: true)
+                if limitsEnabled {
+                    AgentLimitsCard(
+                        clients: clientIds, trace: trace, agentUsage: agentUsage,
+                        reorderable: true)
+                }
                 UsageTraceCard(buckets: trace, windowSecs: 600)
                 ModelBreakdownCard(
                     report: modelReport, clientIds: clientIds, colors: colors)

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -52,6 +52,14 @@ struct SettingsPanel: View {
 
     static let refreshIntervalOptions = [1, 5, 15, 30, 60]
 
+    /// First-wins dedup of two id lists, preserving order (a's entries first,
+    /// then b's not already seen). Used to build the client-tabs universe from
+    /// present clients ∪ quota-card clients.
+    private static func orderedUnion(_ a: [String], _ b: [String]) -> [String] {
+        var seen = Set<String>()
+        return (a + b).filter { seen.insert($0).inserted }
+    }
+
     // MARK: - Client tabs drag reorder helpers (adapted from AgentLimitsCard)
 
     private func dropEdge(for id: String, in orderList: [String]) -> VerticalEdge? {
@@ -82,7 +90,22 @@ struct SettingsPanel: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        // Computed once and shared by the two sections below (Agent limits +
+        // Client tabs), instead of re-deriving `knownClientIds` per section.
+        // `orderRaw:` overloads keep both lists reactive to a drag/reorder.
+        let knownIds = AgentLimitsCard.knownClientIds(
+            agentUsage: agentUsage, present: presentClients)
+        // Agent-limits management universe: only clients that can actually
+        // render a quota card (placeholder rows or a live snapshot).
+        let limitOrdered = ClientRegistry.orderedClients(knownIds, orderRaw: tabsOrderRaw)
+        // Client-tabs universe: every client that can be a top tab (present)
+        // OR a quota card (knownIds — e.g. quota-only Antigravity), so both
+        // orderings are managed from one list. Mirrors displayClients' source.
+        let presentSet = Set(presentClients)
+        let tabsUniverse = ClientRegistry.orderedClients(
+            Self.orderedUnion(presentClients, knownIds), orderRaw: tabsOrderRaw)
+
+        return VStack(alignment: .leading, spacing: 14) {
             section("Menubar title") {
                 radioGroup(
                     selection: $trayModeRaw,
@@ -142,18 +165,15 @@ struct SettingsPanel: View {
                         hint("The deficit/reserve marker. Historical learns your weekly usage curve and shows run-out risk, falling back to linear until enough weeks accrue; Linear paces evenly by the clock; Off hides the marker.")
                     }
 
-                    let knownClients = ClientRegistry.orderedClients(
-                        AgentLimitsCard.knownClientIds(agentUsage: agentUsage, present: presentClients))
-                    if !knownClients.isEmpty {
-                        let limitsHiddenSet = Set(
-                            limitsHiddenRaw.isEmpty ? [] : limitsHiddenRaw.split(separator: ",").map(String.init))
+                    if !limitOrdered.isEmpty {
+                        let limitsHiddenSet = ClientRegistry.parseIdSet(limitsHiddenRaw)
                         // A tab hidden below always hides its quota card too — the
                         // toggle here reflects that (off + disabled) rather than
                         // offering a state the card can never actually reach.
-                        let tabHiddenSet = Set(tabsHiddenRaw.isEmpty ? [] : tabsHiddenRaw.split(separator: ",").map(String.init))
+                        let tabHiddenSet = ClientRegistry.parseIdSet(tabsHiddenRaw)
                         Divider()
                         VStack(spacing: 1) {
-                            ForEach(knownClients, id: \.self) { id in
+                            ForEach(limitOrdered, id: \.self) { id in
                                 let tabHidden = tabHiddenSet.contains(id)
                                 HStack {
                                     HStack(spacing: 6) {
@@ -191,62 +211,70 @@ struct SettingsPanel: View {
             }
 
             section("Client tabs (top bar)") {
-                let hiddenSet = Set(tabsHiddenRaw.isEmpty ? [] : tabsHiddenRaw.split(separator: ",").map(String.init))
+                let hiddenSet = ClientRegistry.parseIdSet(tabsHiddenRaw)
 
-                // Master order: every client that can appear in the top bar
-                // OR the Agent-limits card (checked or unchecked, present or
-                // quota-only like Antigravity), sorted by saved order.
-                let fullOrdered = ClientRegistry.orderedClients(
-                    AgentLimitsCard.knownClientIds(agentUsage: agentUsage, present: presentClients))
-
-                if fullOrdered.isEmpty {
+                if tabsUniverse.isEmpty {
                     Text("No clients with usage data yet.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
                     VStack(alignment: .leading, spacing: 6) {
-                        Text("Drag to reorder. Check = show in top tabs, uncheck = hide from top tabs (but stays here).")
+                        Text("Drag to set the order used by both the top tabs and the quota cards. The switch shows/hides a client's top tab (hiding also drops its quota card).")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
 
                         VStack(spacing: 1) {
-                            ForEach(fullOrdered, id: \.self) { id in
+                            ForEach(tabsUniverse, id: \.self) { id in
                                 let isVisible = !hiddenSet.contains(id)
+                                // Only present clients can be top tabs, so only
+                                // they get the show/hide switch. Quota-only ids
+                                // (e.g. Antigravity — OAuth quota, no local
+                                // sessions) appear solely to order their quota
+                                // card, so they show a caption instead.
+                                let canTab = presentSet.contains(id)
                                 HStack(spacing: 8) {
                                     // Drag handle - always shown for every provider
                                     Text("⠿")
                                         .font(.caption)
                                         .foregroundStyle(tabsDragId == id ? .primary : .tertiary)
                                         .help("Drag to reorder")
-                                        .gesture(dragGestureForTab(id: id, orderList: fullOrdered))
+                                        .gesture(dragGestureForTab(id: id, orderList: tabsUniverse))
 
                                     AgentIconView(clientId: id, size: 14)
                                     Text(ClientRegistry.shortName(id))
                                         .font(.caption)
 
+                                    if !canTab {
+                                        Text("(quota card only)")
+                                            .font(.caption2)
+                                            .foregroundStyle(.tertiary)
+                                    }
+
                                     Spacer()
 
-                                    Toggle("", isOn: Binding(
-                                        get: { isVisible },
-                                        set: { show in
-                                            var hidden = hiddenSet
-                                            if show {
-                                                hidden.remove(id)
-                                            } else {
-                                                hidden.insert(id)
+                                    if canTab {
+                                        Toggle("", isOn: Binding(
+                                            get: { isVisible },
+                                            set: { show in
+                                                var hidden = hiddenSet
+                                                if show {
+                                                    hidden.remove(id)
+                                                } else {
+                                                    hidden.insert(id)
+                                                }
+                                                tabsHiddenRaw = hidden.sorted().joined(separator: ",")
                                             }
-                                            tabsHiddenRaw = hidden.sorted().joined(separator: ",")
-                                        }
-                                    ))
-                                    .toggleStyle(.switch)
-                                    .controlSize(.mini)
-                                    .labelsHidden()
+                                        ))
+                                        .toggleStyle(.switch)
+                                        .controlSize(.mini)
+                                        .labelsHidden()
+                                    }
                                 }
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 7)
                                 .opacity(tabsDragId == id ? 0.5 : 1)
-                                .overlay(alignment: dropEdge(for: id, in: fullOrdered) == .top ? .top : .bottom) {
-                                    if let edge = dropEdge(for: id, in: fullOrdered) {
+                                .overlay(alignment: dropEdge(for: id, in: tabsUniverse) == .top ? .top : .bottom) {
+                                    if let edge = dropEdge(for: id, in: tabsUniverse) {
                                         Rectangle()
                                             .fill(Color.accentColor)
                                             .frame(height: 2)
@@ -267,7 +295,7 @@ struct SettingsPanel: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                hint("All providers always appear here so you can arrange order + visibility. Unchecked = hidden from top tabs AND from Agent limits cards (and overview charts). Order applies to top tabs and quota cards.")
+                hint("Present clients have a switch to show/hide their top tab — hiding also removes that client's quota card. Quota-only clients (OAuth quota, no local sessions, e.g. Antigravity) have no tab, so they appear here only to order their quota card. Drag order applies to both top tabs and quota cards.")
             }
 
             section("Live trace") {

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -20,6 +20,7 @@ struct SettingsPanel: View {
     @AppStorage("tokenbar.updates.beta") private var betaUpdates = false
     /// Mirrors SMAppService's actual state (read once per panel appearance).
     @State private var autostartEnabled = AutostartService.isAvailable && AutostartService.isEnabled
+    @AppStorage("tokenbar.limits.enabled") private var limitsEnabled = true
     @AppStorage("tokenbar.limits.asUsed") private var limitsAsUsed = false
     @AppStorage("tokenbar.limits.paceMode") private var paceModeRaw = PaceMode.historical.rawValue
     @AppStorage("tokenbar.limits.layout") private var layoutRaw = LimitsLayout.full.rawValue
@@ -32,6 +33,8 @@ struct SettingsPanel: View {
     // New for tabs improvement
     @AppStorage(ClientRegistry.tabOrderKey) private var tabsOrderRaw = ""
     @AppStorage(ClientRegistry.tabHiddenKey) private var tabsHiddenRaw = ""
+    /// Per-client Agent-limits visibility, independent of tab visibility.
+    @AppStorage(ClientRegistry.limitsHiddenKey) private var limitsHiddenRaw = ""
 
     // Drag state for client tabs reorder (scoped to this panel)
     @State private var tabsDragId: String?
@@ -122,36 +125,81 @@ struct SettingsPanel: View {
             }
 
             section("Agent limits") {
-                toggleRow("Show as used", isOn: $limitsAsUsed)
-                hint("On, bars count up as quota is used; off, they count down to what's left. The color always warns as quota runs low.")
-                radioGroup(
-                    selection: $layoutRaw,
-                    options: LimitsLayout.allCases.map { ($0.rawValue, "Layout: \($0.rawValue.capitalized)") })
-                hint("Full is the wide card with the pace line; Classic is the original compact layout without pace.")
-                if LimitsLayout(rawValue: layoutRaw) != .classic {
+                toggleRow("Show Agent limits card", isOn: $limitsEnabled)
+                hint("Off hides the Agent-limits quota card everywhere — the Overview summary, every client's own tab, and this preview. Cost/token data is unaffected.")
+
+                if limitsEnabled {
+                    toggleRow("Show as used", isOn: $limitsAsUsed)
+                    hint("On, bars count up as quota is used; off, they count down to what's left. The color always warns as quota runs low.")
                     radioGroup(
-                        selection: $paceModeRaw,
-                        options: PaceMode.allCases.map { ($0.rawValue, "Pace: \($0.rawValue.capitalized)") })
-                    hint("The deficit/reserve marker. Historical learns your weekly usage curve and shows run-out risk, falling back to linear until enough weeks accrue; Linear paces evenly by the clock; Off hides the marker.")
+                        selection: $layoutRaw,
+                        options: LimitsLayout.allCases.map { ($0.rawValue, "Layout: \($0.rawValue.capitalized)") })
+                    hint("Full is the wide card with the pace line; Classic is the original compact layout without pace.")
+                    if LimitsLayout(rawValue: layoutRaw) != .classic {
+                        radioGroup(
+                            selection: $paceModeRaw,
+                            options: PaceMode.allCases.map { ($0.rawValue, "Pace: \($0.rawValue.capitalized)") })
+                        hint("The deficit/reserve marker. Historical learns your weekly usage curve and shows run-out risk, falling back to linear until enough weeks accrue; Linear paces evenly by the clock; Off hides the marker.")
+                    }
+
+                    let knownClients = ClientRegistry.orderedClients(
+                        AgentLimitsCard.knownClientIds(agentUsage: agentUsage, present: presentClients))
+                    if !knownClients.isEmpty {
+                        let limitsHiddenSet = Set(
+                            limitsHiddenRaw.isEmpty ? [] : limitsHiddenRaw.split(separator: ",").map(String.init))
+                        // A tab hidden below always hides its quota card too — the
+                        // toggle here reflects that (off + disabled) rather than
+                        // offering a state the card can never actually reach.
+                        let tabHiddenSet = Set(tabsHiddenRaw.isEmpty ? [] : tabsHiddenRaw.split(separator: ",").map(String.init))
+                        Divider()
+                        VStack(spacing: 1) {
+                            ForEach(knownClients, id: \.self) { id in
+                                let tabHidden = tabHiddenSet.contains(id)
+                                HStack {
+                                    HStack(spacing: 6) {
+                                        AgentIconView(clientId: id, size: 14)
+                                        Text(ClientRegistry.shortName(id))
+                                            .font(.caption)
+                                    }
+                                    Spacer()
+                                    Toggle("", isOn: Binding(
+                                        get: { !tabHidden && !limitsHiddenSet.contains(id) },
+                                        set: { show in
+                                            var hidden = limitsHiddenSet
+                                            if show {
+                                                hidden.remove(id)
+                                            } else {
+                                                hidden.insert(id)
+                                            }
+                                            limitsHiddenRaw = hidden.sorted().joined(separator: ",")
+                                        }
+                                    ))
+                                    .disabled(tabHidden)
+                                    .toggleStyle(.switch)
+                                    .controlSize(.mini)
+                                    .labelsHidden()
+                                }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 7)
+                                .opacity(tabHidden ? 0.5 : 1)
+                            }
+                        }
+                        .glassCard(cornerRadius: 8)
+                        hint("Hides only that client's quota card here and on its own tab — the tab and its cost/token data stay visible. Useful for accounts with no OAuth quota (e.g. Claude Console). Grayed out when the tab itself is hidden below, since a hidden tab always hides its quota card too.")
+                    }
                 }
             }
 
             section("Client tabs (top bar)") {
                 let hiddenSet = Set(tabsHiddenRaw.isEmpty ? [] : tabsHiddenRaw.split(separator: ",").map(String.init))
 
-                // Master order: show ALL present clients (checked or unchecked) sorted by saved order.
-                // Hidden ones remain visible in settings so you can always reorder them.
-                let order = tabsOrderRaw.isEmpty ? [] : tabsOrderRaw.split(separator: ",").map(String.init)
-                let fullOrdered = presentClients.sorted { a, b in
-                    let ia = order.firstIndex(of: a) ?? Int.max
-                    let ib = order.firstIndex(of: b) ?? Int.max
-                    if ia == ib {
-                        return presentClients.firstIndex(of: a)! < presentClients.firstIndex(of: b)!
-                    }
-                    return ia < ib
-                }
+                // Master order: every client that can appear in the top bar
+                // OR the Agent-limits card (checked or unchecked, present or
+                // quota-only like Antigravity), sorted by saved order.
+                let fullOrdered = ClientRegistry.orderedClients(
+                    AgentLimitsCard.knownClientIds(agentUsage: agentUsage, present: presentClients))
 
-                if presentClients.isEmpty {
+                if fullOrdered.isEmpty {
                     Text("No clients with usage data yet.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -161,7 +209,7 @@ struct SettingsPanel: View {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
 
-                        VStack(spacing: 4) {
+                        VStack(spacing: 1) {
                             ForEach(fullOrdered, id: \.self) { id in
                                 let isVisible = !hiddenSet.contains(id)
                                 HStack(spacing: 8) {
@@ -172,7 +220,13 @@ struct SettingsPanel: View {
                                         .help("Drag to reorder")
                                         .gesture(dragGestureForTab(id: id, orderList: fullOrdered))
 
-                                    Toggle(isOn: Binding(
+                                    AgentIconView(clientId: id, size: 14)
+                                    Text(ClientRegistry.shortName(id))
+                                        .font(.caption)
+
+                                    Spacer()
+
+                                    Toggle("", isOn: Binding(
                                         get: { isVisible },
                                         set: { show in
                                             var hidden = hiddenSet
@@ -183,22 +237,13 @@ struct SettingsPanel: View {
                                             }
                                             tabsHiddenRaw = hidden.sorted().joined(separator: ",")
                                         }
-                                    )) {
-                                        HStack(spacing: 6) {
-                                            AgentIconView(clientId: id, size: 14)
-                                            Text(ClientRegistry.shortName(id))
-                                                .font(.caption)
-                                            if !isVisible {
-                                                Text("(hidden)")
-                                                    .font(.caption2)
-                                                    .foregroundStyle(.secondary)
-                                            }
-                                        }
-                                    }
-                                    .toggleStyle(.checkbox)
-
-                                    Spacer()
+                                    ))
+                                    .toggleStyle(.switch)
+                                    .controlSize(.mini)
+                                    .labelsHidden()
                                 }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 7)
                                 .opacity(tabsDragId == id ? 0.5 : 1)
                                 .overlay(alignment: dropEdge(for: id, in: fullOrdered) == .top ? .top : .bottom) {
                                     if let edge = dropEdge(for: id, in: fullOrdered) {
@@ -218,6 +263,7 @@ struct SettingsPanel: View {
                         }
                         .coordinateSpace(name: Self.tabsDragSpace)
                         .onPreferenceChange(TabsCardFramesKey.self) { tabsCardFrames = $0 }
+                        .glassCard(cornerRadius: 8)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/Sources/TokenBar/Views/SettingsWindowView.swift
+++ b/Sources/TokenBar/Views/SettingsWindowView.swift
@@ -14,6 +14,14 @@ struct SettingsWindowView: View {
     @State private var model = DashboardModel()
     @State private var tokensPerMin: Double?
 
+    /// Master switch: off hides the preview's Agent-limits card too.
+    @AppStorage("tokenbar.limits.enabled") private var limitsEnabled = true
+    /// Observed so the preview's tab list re-derives the instant the user
+    /// toggles visibility or reorders in the left panel, instead of lagging a
+    /// poller tick behind.
+    @AppStorage(ClientRegistry.tabHiddenKey) private var tabsHiddenRaw = ""
+    @AppStorage(ClientRegistry.tabOrderKey) private var tabsOrderRaw = ""
+
     var body: some View {
         HStack(spacing: 0) {
             ScrollView {
@@ -62,12 +70,16 @@ struct SettingsWindowView: View {
                 }
             }
 
-            section("Agent limits card") {
-                let displayClients = ClientRegistry.displayClients(present: model.stats?.presentClients ?? [])
-                AgentLimitsCard(
-                    clients: displayClients,
-                    trace: model.trace, agentUsage: model.agentUsage,
-                    reorderable: true)
+            if limitsEnabled {
+                section("Agent limits card") {
+                    let displayClients = ClientRegistry.displayClients(
+                        present: model.stats?.presentClients ?? [],
+                        hiddenRaw: tabsHiddenRaw, orderRaw: tabsOrderRaw)
+                    AgentLimitsCard(
+                        clients: displayClients,
+                        trace: model.trace, agentUsage: model.agentUsage,
+                        reorderable: true)
+                }
             }
 
             section("Live session card") {

--- a/Sources/TokenBarCore/ClientRegistry.swift
+++ b/Sources/TokenBarCore/ClientRegistry.swift
@@ -81,26 +81,61 @@ public enum ClientRegistry {
     /// Added for accounts whose plan has no OAuth quota (e.g. Claude Console).
     public static let limitsHiddenKey = "tokenbar.limits.hidden"
 
+    /// Parses the comma-separated id form persisted by the tab order/hidden
+    /// defaults into a set, tolerating an empty string. Single source of the
+    /// CSV split so callers (and the reactive views, which pass their observed
+    /// @AppStorage string) all agree on the shape.
+    public static func parseIdSet(_ raw: String) -> Set<String> {
+        Set(raw.isEmpty ? [] : raw.split(separator: ",").map(String.init))
+    }
+
+    /// Ordered variant of `parseIdSet` — keeps the saved sequence for callers
+    /// that need positions (reorder/order sorting), not just membership.
+    public static func parseIdList(_ raw: String) -> [String] {
+        raw.isEmpty ? [] : raw.split(separator: ",").map(String.init)
+    }
+
     /// Returns the set of client ids that the user has hidden from the top tabs (and now also from Agent limits cards).
     public static func hiddenClients() -> Set<String> {
-        let defaults = UserDefaults.standard
-        let raw = defaults.string(forKey: tabHiddenKey) ?? ""
-        return Set(raw.isEmpty ? [] : raw.split(separator: ",").map(String.init))
+        parseIdSet(UserDefaults.standard.string(forKey: tabHiddenKey) ?? "")
     }
 
     /// Returns the set of client ids whose Agent-limits card the user has
     /// hidden, independent of top-tab visibility.
     public static func hiddenLimitsClients() -> Set<String> {
-        let defaults = UserDefaults.standard
-        let raw = defaults.string(forKey: limitsHiddenKey) ?? ""
-        return Set(raw.isEmpty ? [] : raw.split(separator: ",").map(String.init))
+        parseIdSet(UserDefaults.standard.string(forKey: limitsHiddenKey) ?? "")
+    }
+
+    /// The superset of client ids that can show a row in the multi-agent
+    /// Agent-limits card: `present` clients that carry a known limit
+    /// (a placeholder row or a live quota snapshot), unioned with every client
+    /// that has a quota snapshot right now. Some agents (e.g. Antigravity)
+    /// report OAuth quota with no local session logs, so they are absent from
+    /// `present` yet must still be offered a management row. `quotaIds` is the
+    /// ordered list of snapshot client ids; `placeholders` the ids rendered
+    /// with a placeholder row even without a snapshot. Pure — the View layer
+    /// passes plain arrays/sets so TokenBarCore imports no UI types.
+    public static func knownLimitsClients(
+        present: [String], quotaIds: [String], placeholders: Set<String>
+    ) -> [String] {
+        let quotaSet = Set(quotaIds)
+        func known(_ id: String) -> Bool { placeholders.contains(id) || quotaSet.contains(id) }
+        var seen = Set<String>()
+        return (present.filter(known) + quotaIds).filter { seen.insert($0).inserted }
     }
 
     /// Sorts `ids` by the user's saved tab order (`tabOrderKey`), appending
     /// ids not yet in the saved order at the end in their incoming order.
     public static func orderedClients(_ ids: [String]) -> [String] {
-        let orderRaw = UserDefaults.standard.string(forKey: tabOrderKey) ?? ""
-        let order = orderRaw.isEmpty ? [] : orderRaw.split(separator: ",").map(String.init)
+        orderedClients(ids, orderRaw: UserDefaults.standard.string(forKey: tabOrderKey) ?? "")
+    }
+
+    /// Reactive overload: sorts against an explicitly-passed saved order string
+    /// so a SwiftUI view that observes the @AppStorage raw re-renders when the
+    /// order changes (the zero-arg variant reads UserDefaults for non-view
+    /// callers and never invalidates a body on its own).
+    public static func orderedClients(_ ids: [String], orderRaw: String) -> [String] {
+        let order = parseIdList(orderRaw)
         guard !order.isEmpty else { return ids }
         return ids.sorted { a, b in
             let ia = order.firstIndex(of: a) ?? Int.max
@@ -122,6 +157,17 @@ public enum ClientRegistry {
         return orderedClients(present.filter { !hidden.contains($0) })
     }
 
+    /// Reactive overload of `displayClients`: takes the observed hidden/order
+    /// raw strings so a SwiftUI view (e.g. the settings live preview) re-renders
+    /// the instant the user toggles a tab or reorders, instead of waiting for
+    /// the next poller tick to re-read UserDefaults.
+    public static func displayClients(
+        present: [String], hiddenRaw: String, orderRaw: String
+    ) -> [String] {
+        let hidden = parseIdSet(hiddenRaw)
+        return orderedClients(present.filter { !hidden.contains($0) }, orderRaw: orderRaw)
+    }
+
     /// Direction-aware reorder helper (drag down inserts after, up before).
     /// Mirrors the logic used in AgentLimitsCard.
     public static func reorder(_ list: [String], from: String, to: String) -> [String] {
@@ -133,6 +179,41 @@ public enum ClientRegistry {
         var out = list.filter { $0 != from }
         let anchor = out.firstIndex(of: to)!
         out.insert(from, at: fromI < toI ? anchor + 1 : anchor)
+        return out
+    }
+
+    /// Reorder a `visible` subset while preserving the positions of every id in
+    /// `full` that isn't part of that subset. The drag operates on `visible`
+    /// (e.g. the quota cards actually on screen — a subset that excludes hidden
+    /// and non-quota clients), yet the saved order key drives the whole tab
+    /// universe: writing only the reordered visible sequence would silently
+    /// drop every off-screen id from the shared order. This recomputes the
+    /// visible sequence, then rebuilds the full order by refilling the visible
+    /// slots in their new order and leaving non-visible ids exactly where they
+    /// were. Visible ids absent from `full` are appended at the end (the
+    /// existing "newly discovered agent" semantics).
+    public static func mergeReorder(
+        full: [String], visible: [String], from: String, to: String
+    ) -> [String] {
+        let newVisible = reorder(visible, from: from, to: to)
+        let visibleSet = Set(visible)
+        var queue = newVisible[...]
+        var out: [String] = []
+        for id in full {
+            if visibleSet.contains(id) {
+                // Refill this visible slot with the next id from the reordered
+                // sequence. `queue` starts as a permutation of `visible`, so it
+                // has at least as many ids as there are visible slots in `full`.
+                if let next = queue.first {
+                    queue = queue.dropFirst()
+                    out.append(next)
+                }
+            } else {
+                out.append(id)
+            }
+        }
+        // Visible ids that weren't already positioned in `full` land at the end.
+        out.append(contentsOf: queue)
         return out
     }
 

--- a/Sources/TokenBarCore/ClientRegistry.swift
+++ b/Sources/TokenBarCore/ClientRegistry.swift
@@ -76,6 +76,10 @@ public enum ClientRegistry {
 
     public static let tabOrderKey = "tokenbar.tabs.order"
     public static let tabHiddenKey = "tokenbar.tabs.hidden"
+    /// Independent from `tabHiddenKey`: hides a client's Agent-limits quota
+    /// card only, leaving its top tab (and cost/token/model data) visible.
+    /// Added for accounts whose plan has no OAuth quota (e.g. Claude Console).
+    public static let limitsHiddenKey = "tokenbar.limits.hidden"
 
     /// Returns the set of client ids that the user has hidden from the top tabs (and now also from Agent limits cards).
     public static func hiddenClients() -> Set<String> {
@@ -84,32 +88,38 @@ public enum ClientRegistry {
         return Set(raw.isEmpty ? [] : raw.split(separator: ",").map(String.init))
     }
 
+    /// Returns the set of client ids whose Agent-limits card the user has
+    /// hidden, independent of top-tab visibility.
+    public static func hiddenLimitsClients() -> Set<String> {
+        let defaults = UserDefaults.standard
+        let raw = defaults.string(forKey: limitsHiddenKey) ?? ""
+        return Set(raw.isEmpty ? [] : raw.split(separator: ",").map(String.init))
+    }
+
+    /// Sorts `ids` by the user's saved tab order (`tabOrderKey`), appending
+    /// ids not yet in the saved order at the end in their incoming order.
+    public static func orderedClients(_ ids: [String]) -> [String] {
+        let orderRaw = UserDefaults.standard.string(forKey: tabOrderKey) ?? ""
+        let order = orderRaw.isEmpty ? [] : orderRaw.split(separator: ",").map(String.init)
+        guard !order.isEmpty else { return ids }
+        return ids.sorted { a, b in
+            let ia = order.firstIndex(of: a) ?? Int.max
+            let ib = order.firstIndex(of: b) ?? Int.max
+            if ia == ib {
+                // Preserve relative order among items with no explicit position.
+                return ids.firstIndex(of: a)! < ids.firstIndex(of: b)!
+            }
+            return ia < ib
+        }
+    }
+
     /// Returns the subset of `present` clients to show in the top tab bar,
     /// filtered by hidden list and sorted according to the user's saved order.
     /// Clients not yet in the saved order are appended at the end (so newly
     /// discovered agents become visible without breaking existing custom order).
     public static func displayClients(present: [String]) -> [String] {
-        let orderRaw = UserDefaults.standard.string(forKey: tabOrderKey) ?? ""
         let hidden = hiddenClients()
-
-        let order = orderRaw.isEmpty ? [] : orderRaw.split(separator: ",").map(String.init)
-
-        let visible = present.filter { !hidden.contains($0) }
-
-        guard !order.isEmpty else {
-            // No custom order yet — preserve incoming order (historically alpha).
-            return visible
-        }
-
-        return visible.sorted { a, b in
-            let ia = order.firstIndex(of: a) ?? Int.max
-            let ib = order.firstIndex(of: b) ?? Int.max
-            if ia == ib {
-                // Preserve relative order among items with no explicit position.
-                return visible.firstIndex(of: a)! < visible.firstIndex(of: b)!
-            }
-            return ia < ib
-        }
+        return orderedClients(present.filter { !hidden.contains($0) })
     }
 
     /// Direction-aware reorder helper (drag down inserts after, up before).


### PR DESCRIPTION
Hi there! 👋 Thanks for TokenBar — opening this PR to take a crack at #33.

## Summary
- Adds two new Settings controls under "Agent limits": a master "Show Agent limits card" switch, and a per-client list (Claude/Codex/Antigravity/etc.) so a client's quota card can be hidden independently of its top tab and cost/token data.
- A hidden top tab still force-hides (and disables) that client's Agent-limits toggle — one-way sync, so a stale "on" toggle can't linger for a tab that's gone, but hiding the quota card never hides the tab or its other data.
- Both per-client lists (Agent limits + Client tabs) now share `AgentLimitsCard.knownClientIds`, so clients that only report OAuth quota with no local session logs (e.g. Antigravity) show up in both lists, not just the Agent-limits one.
- Toggle rows now use switch style + bordered card, matching the rest of Settings.

Related to #33 — Claude Console accounts have no OAuth quota, so the Agent-limits card previously had no way to be hidden without also losing the tab's cost/token data.

## Test plan
- [x] `cargo build --release && swift build`
- [x] `swift run TokenBar --selftest` / `--smoke`
- [x] Manually verified in a bundled `dist/TokenBar.app`: per-client hide/unhide, master hide, tab-hide auto-disabling the corresponding Agent-limits toggle, Antigravity now toggleable in both lists.