### PR TITLE
feat(app): add synthetic demo mode

### DIFF
--- a/Sources/TokenBar/AppDelegate.swift
+++ b/Sources/TokenBar/AppDelegate.swift
@@ -8,6 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let defaultRefreshSecs = 300
     private static let intervalKey = "tokenbar.refresh.intervalMin"
 
+    private let usageSource: any UsageDataSource = UsageDataSources.current
     private var statusController: StatusItemController?
     private var trayAnimator: TrayAnimator?
     private var titleRefreshTask: Task<Void, Never>?
@@ -48,7 +49,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let controller = StatusItemController()
         statusController = controller
-        let animator = TrayAnimator(controller: controller)
+        let animator = TrayAnimator(controller: controller, source: usageSource)
         trayAnimator = animator
         controller.quotaPayloadProvider = { [weak animator] in animator?.quota }
         // A fresh quota or rate fetch re-renders the title right away.
@@ -137,10 +138,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // poll fetch still in flight (which carries an older generation).
         guard let generation = trayAnimator?.nextRateGeneration() else { return }
         Task { [weak self] in
-            let rate = try? await Task.detached(priority: .utility) {
-                try LiveRate.current()
-            }.value
-            guard let self, let rate else { return }
+            guard let self else { return }
+            let rate = try? await LiveRate.current(source: self.usageSource)
+            guard let rate else { return }
             self.lastRate = rate
             self.trayAnimator?.applyRate(rate, generation: generation)
         }
@@ -161,17 +161,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 let mode = TrayMode.current
                 let intervalMin = self.refreshIntervalMin
                 let forceRefresh = Date().timeIntervalSince(self.lastFullRefresh) >= Double(intervalMin) * 60
-                let graph = try? await Task.detached(priority: .utility) {
-                    forceRefresh ? try TBCore.refreshGraph() : try TBCore.graph()
-                }.value
+                let graph: UsagePayload?
+                if forceRefresh {
+                    graph = try? await self.usageSource.refreshGraph(
+                        year: nil, priority: .utility)
+                } else {
+                    graph = try? await self.usageSource.graph(
+                        year: nil, priority: .utility)
+                }
                 if forceRefresh && graph != nil { self.lastFullRefresh = Date() }
                 // Failed refreshes keep the last good numbers — the title
                 // must never blank/zero out on a transient error.
                 if let graph { self.lastGraph = graph }
                 if mode == .tokensPerMin {
-                    let rate = try? await Task.detached(priority: .utility) {
-                        try LiveRate.current()
-                    }.value
+                    let rate = try? await LiveRate.current(source: self.usageSource)
                     if let rate { self.lastRate = rate }
                 }
                 guard !Task.isCancelled else { break }

--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -54,6 +54,7 @@ private struct DashboardSnapshot {
     /// Whether this model owns the shared `lastSnapshot` (true only for the
     /// popover's model, whose teardown/rebuild is what the cache speeds up).
     private let cachesSnapshot: Bool
+    private let source: any UsageDataSource
     enum Phase {
         case loading
         case ready
@@ -78,8 +79,12 @@ private struct DashboardSnapshot {
     /// `cachesSnapshot` = true only for the popover's model (PopoverView), the
     /// one whose per-open teardown/rebuild the cache exists to speed up; the
     /// settings window passes false so it never writes the shared snapshot.
-    init(cachesSnapshot: Bool = false) {
+    init(
+        cachesSnapshot: Bool = false,
+        source: any UsageDataSource = UsageDataSources.current
+    ) {
         self.cachesSnapshot = cachesSnapshot
+        self.source = source
         // Guard snapshot restore on year-consistency: if the user changed the
         // year filter after the snapshot was written (e.g. setYear() persisted
         // the new year but reload() failed before apply() ran), the cached
@@ -157,18 +162,15 @@ private struct DashboardSnapshot {
         return computed
     }
 
-    /// TBCore is blocking — every fetch hops off the main actor.
+    /// The source owns the blocking FFI hop in live mode; demo mode returns
+    /// synthetic values through the same async contract.
     func load() async {
         do {
             let year = self.year
-            async let payloadTask = Task.detached(priority: .userInitiated) {
-                try TBCore.graph(year: year)
-            }.value
-            async let reportTask = Task.detached(priority: .userInitiated) {
-                try? TBCore.modelReport(year: year)
-            }.value
+            async let payloadTask = source.graph(year: year, priority: .userInitiated)
+            async let reportTask = source.modelReport(year: year, priority: .userInitiated)
             let payload = try await payloadTask
-            let report = await reportTask
+            let report = try? await reportTask
             // The year may have changed while we were off-actor (the user can
             // open the year menu during the initial load); drop a stale slice
             // so apply() never tags the new year — and the static snapshot —
@@ -226,14 +228,12 @@ private struct DashboardSnapshot {
 
     private func reload(force: Bool) async {
         let year = self.year
-        async let payloadTask = Task.detached(priority: .userInitiated) {
-            force ? try TBCore.refreshGraph(year: year) : try TBCore.graph(year: year)
-        }.value
-        async let reportTask = Task.detached(priority: .userInitiated) {
-            try? TBCore.modelReport(year: year)
-        }.value
+        async let payloadTask = force
+            ? source.refreshGraph(year: year, priority: .userInitiated)
+            : source.graph(year: year, priority: .userInitiated)
+        async let reportTask = source.modelReport(year: year, priority: .userInitiated)
         guard let payload = try? await payloadTask else { return }
-        let report = await reportTask
+        let report = try? await reportTask
         apply(payload: payload, report: report)
         // If apply() cleared a now-empty year filter, it spawned its own
         // unfiltered reload that re-fetches the lazy lenses for the new (nil)
@@ -249,16 +249,14 @@ private struct DashboardSnapshot {
         // strand the wrong slice on the lens.
         if hourly != nil {
             let captured = hourlyClients
-            let report = await Task.detached(priority: .userInitiated) {
-                try? TBCore.hourlyReport(year: year, clients: captured.map(Array.init))
-            }.value
+            let report = try? await source.hourlyReport(
+                year: year, clients: captured.map(Array.init), priority: .userInitiated)
             if self.year == year, self.hourlyClients == captured { hourly = report }
         }
         if agents != nil {
             let captured = agentsClients
-            let report = await Task.detached(priority: .userInitiated) {
-                try? TBCore.agentsReport(year: year, clients: captured.map(Array.init))
-            }.value
+            let report = try? await source.agentsReport(
+                year: year, clients: captured.map(Array.init), priority: .userInitiated)
             if self.year == year, self.agentsClients == captured { agents = report }
         }
     }
@@ -331,14 +329,10 @@ private struct DashboardSnapshot {
             // Don't race an in-flight manual Refresh or year switch.
             guard !refreshing else { continue }
             let year = self.year
-            async let payloadTask = Task.detached(priority: .utility) {
-                try? TBCore.graph(year: year)
-            }.value
-            async let reportTask = Task.detached(priority: .utility) {
-                try? TBCore.modelReport(year: year)
-            }.value
-            let fetched = await payloadTask
-            let report = await reportTask
+            async let payloadTask = source.graph(year: year, priority: .utility)
+            async let reportTask = source.modelReport(year: year, priority: .utility)
+            let fetched = try? await payloadTask
+            let report = try? await reportTask
             if Task.isCancelled { break }
             // The year may have changed while we were off-actor; drop a stale
             // slice so the chart never flickers to the wrong year.
@@ -355,16 +349,14 @@ private struct DashboardSnapshot {
             // the fresh slice with the stale one.
             if hourly != nil {
                 let captured = hourlyClients
-                let report = await Task.detached(priority: .utility) {
-                    try? TBCore.hourlyReport(year: year, clients: captured.map(Array.init))
-                }.value
+                let report = try? await source.hourlyReport(
+                    year: year, clients: captured.map(Array.init), priority: .utility)
                 if self.year == year, self.hourlyClients == captured { hourly = report }
             }
             if agents != nil {
                 let captured = agentsClients
-                let report = await Task.detached(priority: .utility) {
-                    try? TBCore.agentsReport(year: year, clients: captured.map(Array.init))
-                }.value
+                let report = try? await source.agentsReport(
+                    year: year, clients: captured.map(Array.init), priority: .utility)
                 if self.year == year, self.agentsClients == captured { agents = report }
             }
         }
@@ -375,9 +367,7 @@ private struct DashboardSnapshot {
     /// previous payload; per-provider errors live inside each snapshot.
     func pollAgentUsage() async {
         while !Task.isCancelled {
-            let payload = try? await Task.detached(priority: .utility) {
-                try TBCore.agentUsage()
-            }.value
+            let payload = try? await source.agentUsage()
             if Task.isCancelled { break }
             if let payload {
                 agentUsage = payload
@@ -392,9 +382,7 @@ private struct DashboardSnapshot {
     /// re-parses at most every 10s, so this matches its cadence.
     func pollTrace() async {
         while !Task.isCancelled {
-            let buckets = try? await Task.detached(priority: .utility) {
-                try TBCore.usageTrace(windowSecs: 600)
-            }.value
+            let buckets = try? await source.usageTrace(windowSecs: 600)
             if Task.isCancelled { break }
             if let buckets {
                 trace = buckets
@@ -427,10 +415,9 @@ private struct DashboardSnapshot {
             // against the NEW clientIds for one FFI latency (a shared hour's
             // hidden stripe would flash). Also covers plain tab switches.
             if hourly != nil, hourlyClients != selection { hourly = nil; hourlyClients = selection }
-            let report = await Task.detached(priority: .userInitiated) {
-                try? TBCore.hourlyReport(year: year, clients: clients)
-            }.value
-            // The detached FFI outlives this `.task(id:)`'s cancellation, so a
+            let report = try? await source.hourlyReport(
+                year: year, clients: clients, priority: .userInitiated)
+            // The source request may outlive this `.task(id:)`'s cancellation, so a
             // tab switch or year change during the await must not let this
             // superseded fetch commit: PopoverView cancels the task on an
             // activeTab/year change, so isCancelled captures the slice switch
@@ -442,14 +429,20 @@ private struct DashboardSnapshot {
         case .agents where agents == nil || agentsClients != selection:
             // Nil the stale report on a slice change (see the hourly case).
             if agents != nil, agentsClients != selection { agents = nil; agentsClients = selection }
-            let report = await Task.detached(priority: .userInitiated) {
-                try? TBCore.agentsReport(year: year, clients: clients)
-            }.value
+            let report = try? await source.agentsReport(
+                year: year, clients: clients, priority: .userInitiated)
             guard self.year == year, !Task.isCancelled else { return }
             agents = report
             agentsClients = selection
         default:
             break
         }
+    }
+
+    /// Shared async live-rate helper for PopoverView and SettingsWindowView.
+    /// The source remains the only owner of raw usage calls; hidden-client
+    /// filtering follows the same policy as the tray and live-session card.
+    func tokensPerMin() async -> Double? {
+        try? await LiveRate.current(source: source)
     }
 }

--- a/Sources/TokenBar/DemoData.swift
+++ b/Sources/TokenBar/DemoData.swift
@@ -1,0 +1,462 @@
+import Foundation
+import TokenBarCore
+
+/// Deterministic synthetic usage for the hidden `--demo` mode. The fixture is
+/// rebuilt on each source read so its rolling current-year window follows the
+/// local day, while every surface still derives from one set of client rows.
+enum DemoData {
+    static var payload: UsagePayload { payload(for: nil) }
+    static var modelReport: ModelReport { modelReport(for: nil) }
+    static var hourlyReport: HourlyReport { hourlyReport(for: nil, clients: nil) }
+    static var agentsReport: AgentsReport { agentsReport(for: nil, clients: nil) }
+    static var agentUsage: AgentUsagePayload { makeAgentUsage() }
+    static var trace: [TraceBucket] { trace(windowSecs: 600) }
+    static var tokensPerMin: Double {
+        trace(windowSecs: 600).reduce(0) { $0 + $1.tokensPerMin }
+    }
+
+    static func payload(
+        for year: String?, today: String = Format.todayKey()
+    ) -> UsagePayload {
+        let fixture = makeFixture(year: year, today: today)
+        let json: [String: Any] = [
+            "meta": [
+                "generatedAt": "\(fixture.end)T12:00:00Z",
+                "version": "demo",
+                "dateRange": ["start": fixture.start, "end": fixture.end],
+            ],
+            "summary": [
+                "totalTokens": fixture.allTotals.total,
+                "totalCost": fixture.allTotals.cost,
+                "totalDays": fixture.dates.count,
+                "activeDays": fixture.dates.count,
+                "averagePerDay": fixture.allTotals.cost / Double(fixture.dates.count),
+                "maxCostInSingleDay": fixture.maxDayCost,
+                "clients": ClientRegistry.allIds,
+                "models": ClientRegistry.allIds.map { "demo-\($0)" },
+            ],
+            "years": fixture.yearMetadata,
+            "contributions": fixture.contributionJSON,
+        ]
+        return decode(json, as: UsagePayload.self)
+    }
+
+    static func modelReport(
+        for year: String?, today: String = Format.todayKey()
+    ) -> ModelReport {
+        let fixture = makeFixture(year: year, today: today)
+        let entries = ClientRegistry.allIds.map { id in
+            let totals = fixture.clientTotals[id]!
+            return [
+                "client": id,
+                "model": "demo-\(id)",
+                "provider": "demo",
+                "input": totals.input,
+                "output": totals.output,
+                "cacheRead": totals.cacheRead,
+                "cacheWrite": totals.cacheWrite,
+                "reasoning": totals.reasoning,
+                "total": totals.total,
+                "messageCount": totals.messages,
+                "cost": totals.cost,
+                "msPer1kTokens": 1.25,
+            ] as [String: Any]
+        }
+        let json: [String: Any] = [
+            "entries": entries,
+            "totalInput": fixture.allTotals.input,
+            "totalOutput": fixture.allTotals.output,
+            "totalCacheRead": fixture.allTotals.cacheRead,
+            "totalCacheWrite": fixture.allTotals.cacheWrite,
+            "totalMessages": fixture.allTotals.messages,
+            "totalCost": fixture.allTotals.cost,
+        ]
+        return decode(json, as: ModelReport.self)
+    }
+
+    static func hourlyReport(
+        for year: String?, clients: [String]?, today: String = Format.todayKey()
+    ) -> HourlyReport {
+        let fixture = makeFixture(year: year, today: today)
+        let allowed = clientFilter(clients)
+        var buckets: [String: HourlyTotals] = [:]
+        for (dayIndex, rows) in fixture.rowsByDay.enumerated() {
+            for (clientIndex, row) in rows.enumerated() where allowed.contains(row.client) {
+                let hour = 8 + ((clientIndex + dayIndex) % 10)
+                let key = "\(row.date) \(String(format: "%02d:00", hour))"
+                var bucket = buckets[key] ?? HourlyTotals()
+                bucket.add(row)
+                buckets[key] = bucket
+            }
+        }
+
+        let entries = buckets.keys.sorted().map { hour in
+            let bucket = buckets[hour]!
+            return [
+                "hour": hour,
+                "clients": bucket.clients.sorted(),
+                "models": bucket.models.sorted(),
+                "input": bucket.input,
+                "output": bucket.output,
+                "cacheRead": bucket.cacheRead,
+                "cacheWrite": bucket.cacheWrite,
+                "reasoning": bucket.reasoning,
+                "total": bucket.total,
+                "messageCount": bucket.messages,
+                "turnCount": bucket.turns,
+                "cost": bucket.cost,
+            ] as [String: Any]
+        }
+        let totalCost = buckets.values.reduce(0.0) { $0 + $1.cost }
+        return decode(
+            ["entries": entries, "totalCost": totalCost],
+            as: HourlyReport.self)
+    }
+
+    static func agentsReport(
+        for year: String?, clients: [String]?, today: String = Format.todayKey()
+    ) -> AgentsReport {
+        let fixture = makeFixture(year: year, today: today)
+        let allowed = clientFilter(clients)
+        let entries = ClientRegistry.allIds.compactMap { id -> [String: Any]? in
+            guard allowed.contains(id), let totals = fixture.clientTotals[id] else { return nil }
+            return [
+                "agent": "Demo Main · \(id)",
+                "clients": [id],
+                "input": totals.input,
+                "output": totals.output,
+                "cacheRead": totals.cacheRead,
+                "cacheWrite": totals.cacheWrite,
+                "reasoning": totals.reasoning,
+                "total": totals.total,
+                "cost": totals.cost,
+                "messages": totals.messages,
+            ] as [String: Any]
+        }
+        let totalCost = entries.reduce(0.0) { partial, entry in
+            partial + (entry["cost"] as? Double ?? 0)
+        }
+        let totalMessages = entries.reduce(0) { partial, entry in
+            partial + (entry["messages"] as? Int ?? 0)
+        }
+        return decode(
+            [
+                "entries": entries,
+                "totalCost": totalCost,
+                "totalMessages": totalMessages,
+            ],
+            as: AgentsReport.self)
+    }
+
+    static func trace(windowSecs: Int64) -> [TraceBucket] {
+        _ = windowSecs
+        let fixture = makeFixture(year: nil, today: Format.todayKey())
+        let buckets = ClientRegistry.allIds.map { id in
+            let total = fixture.clientTotals[id]?.total ?? 1
+            let tokens = max(1, total / 10)
+            return [
+                "client": id,
+                "agent": "Demo Main",
+                "model": "demo-\(id)",
+                "tokens": tokens,
+                "messages": 1,
+                "tokens_per_min": Double(tokens) / 10.0,
+            ] as [String: Any]
+        }
+        return decode(buckets, as: [TraceBucket].self)
+    }
+
+    private struct ClientRow {
+        let date: String
+        let client: String
+        let model: String
+        let input: Int64
+        let output: Int64
+        let cacheRead: Int64
+        let cacheWrite: Int64
+        let reasoning: Int64
+        let cost: Double
+        let messages: Int
+
+        var total: Int64 {
+            input
+                .saturatingAdding(output)
+                .saturatingAdding(cacheRead)
+                .saturatingAdding(cacheWrite)
+                .saturatingAdding(reasoning)
+        }
+
+        var json: [String: Any] {
+            [
+                "client": client,
+                "modelId": model,
+                "providerId": "demo",
+                "tokens": [
+                    "input": input,
+                    "output": output,
+                    "cacheRead": cacheRead,
+                    "cacheWrite": cacheWrite,
+                    "reasoning": reasoning,
+                ],
+                "cost": cost,
+                "messages": messages,
+            ]
+        }
+    }
+
+    private struct Totals {
+        var input: Int64 = 0
+        var output: Int64 = 0
+        var cacheRead: Int64 = 0
+        var cacheWrite: Int64 = 0
+        var reasoning: Int64 = 0
+        var cost = 0.0
+        var messages = 0
+
+        var total: Int64 {
+            input
+                .saturatingAdding(output)
+                .saturatingAdding(cacheRead)
+                .saturatingAdding(cacheWrite)
+                .saturatingAdding(reasoning)
+        }
+
+        mutating func add(_ row: ClientRow) {
+            input = input.saturatingAdding(row.input)
+            output = output.saturatingAdding(row.output)
+            cacheRead = cacheRead.saturatingAdding(row.cacheRead)
+            cacheWrite = cacheWrite.saturatingAdding(row.cacheWrite)
+            reasoning = reasoning.saturatingAdding(row.reasoning)
+            cost += row.cost
+            messages += row.messages
+        }
+    }
+
+    private struct HourlyTotals {
+        var clients = Set<String>()
+        var models = Set<String>()
+        var input: Int64 = 0
+        var output: Int64 = 0
+        var cacheRead: Int64 = 0
+        var cacheWrite: Int64 = 0
+        var reasoning: Int64 = 0
+        var messages = 0
+        var turns = 0
+        var cost = 0.0
+
+        var total: Int64 {
+            input
+                .saturatingAdding(output)
+                .saturatingAdding(cacheRead)
+                .saturatingAdding(cacheWrite)
+                .saturatingAdding(reasoning)
+        }
+
+        mutating func add(_ row: ClientRow) {
+            clients.insert(row.client)
+            models.insert(row.model)
+            input = input.saturatingAdding(row.input)
+            output = output.saturatingAdding(row.output)
+            cacheRead = cacheRead.saturatingAdding(row.cacheRead)
+            cacheWrite = cacheWrite.saturatingAdding(row.cacheWrite)
+            reasoning = reasoning.saturatingAdding(row.reasoning)
+            messages += row.messages
+            turns += row.messages
+            cost += row.cost
+        }
+    }
+
+    private struct YearTotals {
+        var totals = Totals()
+        var start: String
+        var end: String
+    }
+
+    private struct Fixture {
+        let dates: [String]
+        let start: String
+        let end: String
+        let rowsByDay: [[ClientRow]]
+        let contributionJSON: [[String: Any]]
+        let clientTotals: [String: Totals]
+        let allTotals: Totals
+        let maxDayCost: Double
+        let yearMetadata: [[String: Any]]
+    }
+
+    private static func makeFixture(year: String?, today: String) -> Fixture {
+        let dates = dates(for: year, today: today)
+        let ids = ClientRegistry.allIds
+        var rowsByDay: [[ClientRow]] = []
+        var clientTotals = Dictionary(uniqueKeysWithValues: ids.map { ($0, Totals()) })
+        var allTotals = Totals()
+        var maxDayCost = 0.0
+        var yearTotals: [String: YearTotals] = [:]
+        var contributionJSON: [[String: Any]] = []
+
+        for (dayIndex, date) in dates.enumerated() {
+            var rows: [ClientRow] = []
+            var dayTotals = Totals()
+            for (clientIndex, id) in ids.enumerated() {
+                let input = Int64(900 + clientIndex * 73 + dayIndex * 31)
+                let output = Int64(420 + clientIndex * 29 + dayIndex * 17)
+                let cacheRead = Int64(90 + (clientIndex + dayIndex) * 11)
+                let cacheWrite = Int64(18 + (clientIndex * 3 + dayIndex) % 19)
+                let reasoning = Int64(35 + (clientIndex * 5 + dayIndex) % 23)
+                let messages = 2 + (clientIndex + dayIndex) % 3
+                let total = input + output + cacheRead + cacheWrite + reasoning
+                let cost = Double(total) * 0.000_003
+                let row = ClientRow(
+                    date: date, client: id, model: "demo-\(id)", input: input,
+                    output: output, cacheRead: cacheRead, cacheWrite: cacheWrite,
+                    reasoning: reasoning, cost: cost, messages: messages)
+                rows.append(row)
+                dayTotals.add(row)
+                clientTotals[id]!.add(row)
+                allTotals.add(row)
+            }
+            rowsByDay.append(rows)
+            maxDayCost = max(maxDayCost, dayTotals.cost)
+            let dateYear = String(date.prefix(4))
+            if var yearTotal = yearTotals[dateYear] {
+                yearTotal.totals.add(rows[0])
+                for row in rows.dropFirst() { yearTotal.totals.add(row) }
+                yearTotal.end = date
+                yearTotals[dateYear] = yearTotal
+            } else {
+                var yearTotal = YearTotals(totals: Totals(), start: date, end: date)
+                for row in rows { yearTotal.totals.add(row) }
+                yearTotals[dateYear] = yearTotal
+            }
+            contributionJSON.append([
+                "date": date,
+                "totals": [
+                    "tokens": dayTotals.total,
+                    "cost": dayTotals.cost,
+                    "messages": dayTotals.messages,
+                ],
+                "intensity": (dayIndex % 4) + 1,
+                "tokenBreakdown": [
+                    "input": dayTotals.input,
+                    "output": dayTotals.output,
+                    "cacheRead": dayTotals.cacheRead,
+                    "cacheWrite": dayTotals.cacheWrite,
+                    "reasoning": dayTotals.reasoning,
+                ],
+                "clients": rows.map(\.json),
+            ])
+        }
+
+        let yearMetadata = yearTotals.keys.sorted().map { key in
+            let value = yearTotals[key]!
+            return [
+                "year": key,
+                "totalTokens": value.totals.total,
+                "totalCost": value.totals.cost,
+                "range": ["start": value.start, "end": value.end],
+            ] as [String: Any]
+        }
+        return Fixture(
+            dates: dates, start: dates[0], end: dates[dates.count - 1],
+            rowsByDay: rowsByDay, contributionJSON: contributionJSON,
+            clientTotals: clientTotals, allTotals: allTotals,
+            maxDayCost: maxDayCost, yearMetadata: yearMetadata)
+    }
+
+    private static func makeAgentUsage() -> AgentUsagePayload {
+        let updated = "\(Format.todayKey())T00:00:00Z"
+        let agents = ClientRegistry.allIds.enumerated().map { index, id in
+            let sessionUsed = Double(12 + (index * 7) % 76)
+            let weeklyUsed = max(5, sessionUsed * 0.58)
+            return [
+                "clientId": id,
+                "source": "demo",
+                "updatedAt": updated,
+                "identity": ["email": "demo@\(id).local", "plan": "Demo"],
+                "windows": [
+                    [
+                        "label": "Session",
+                        "usedPercent": sessionUsed,
+                        "remainingPercent": 100 - sessionUsed,
+                        "resetsAt": "\(Format.todayKey())T23:59:59Z",
+                        "resetText": "today",
+                        "windowMinutes": 300,
+                    ],
+                    [
+                        "label": "Weekly",
+                        "usedPercent": weeklyUsed,
+                        "remainingPercent": 100 - weeklyUsed,
+                        "resetsAt": "\(Format.todayKey())T23:59:59Z",
+                        "resetText": "this week",
+                        "windowMinutes": 10080,
+                    ],
+                ],
+            ] as [String: Any]
+        }
+        return decode(
+            [
+                "generatedAt": updated,
+                "agents": agents,
+                "opencodeSubscriptions": ["Codex", "Claude"],
+            ],
+            as: AgentUsagePayload.self)
+    }
+
+    /// Returns the synthetic contribution dates for an injectable local today.
+    /// All-years keeps the rolling 14-day window, current-year clamps its start
+    /// to January 1, and every other valid year stays within that year.
+    static func dates(for year: String?, today: String) -> [String] {
+        guard let todayDay = ISODay(today) else {
+            return dates(for: nil, today: Format.todayKey())
+        }
+        let currentYear = String(today.prefix(4))
+        let end: ISODay
+        let validYear = year.flatMap(Self.parseYear)
+        if year == nil {
+            end = todayDay
+        } else if let validYear, String(format: "%04d", validYear) == currentYear {
+            end = todayDay
+        } else if let validYear, let yearEnd = ISODay("\(validYear)-12-31") {
+            end = yearEnd
+        } else {
+            // Invalid year input falls back to the all-years rolling fixture;
+            // DashboardModel still rejects the invalid filter via payload.years.
+            end = todayDay
+        }
+
+        let start: Int
+        if year == nil {
+            start = end.number - 13
+        } else if let validYear, String(format: "%04d", validYear) == currentYear,
+                  let yearStart = ISODay("\(currentYear)-01-01")
+        {
+            start = max(yearStart.number, end.number - 13)
+        } else if let validYear, let yearStart = ISODay("\(validYear)-01-01") {
+            start = max(yearStart.number, end.number - 13)
+        } else {
+            start = end.number - 13
+        }
+        return (start...end.number).map { ISODay(number: $0).iso }
+    }
+
+    private static func parseYear(_ raw: String) -> Int? {
+        guard raw.count == 4, let value = Int(raw), (1...9999).contains(value) else {
+            return nil
+        }
+        return value
+    }
+
+    private static func clientFilter(_ clients: [String]?) -> Set<String> {
+        guard let clients, !clients.isEmpty else { return Set(ClientRegistry.allIds) }
+        return Set(clients)
+    }
+
+    private static func decode<T: Decodable>(_ json: Any, as type: T.Type) -> T {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: json)
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            preconditionFailure("demo fixture failed to decode \(type): \(error)")
+        }
+    }
+}

--- a/Sources/TokenBar/LiveRate.swift
+++ b/Sources/TokenBar/LiveRate.swift
@@ -1,23 +1,14 @@
 import Foundation
 import TokenBarCore
 
-/// Live tokens/min for menu-bar display and tray-animation speed, with the
-/// user's hidden clients excluded (issue #35). A hidden client's live activity
-/// must not drive the "X/m" tray mode, the popover rate badge, or the cat/parrot
-/// spin speed — consistent with UsageTraceCard's filtered total rate.
-///
-/// Runs blocking FFI; call off the main actor like every other TBCore call.
+/// Shared rate policy for every UI surface. Hidden clients are removed from
+/// the live trace when necessary; otherwise the injected source's raw rate is
+/// used unchanged.
 enum LiveRate {
-    /// The single source of truth for the displayed live rate. With no hidden
-    /// clients this is the raw FFI rate unchanged (byte-identical regression
-    /// guard). Otherwise it re-derives the rate from the 600s usage-trace rows
-    /// (the same 10-minute window `tb_tokens_per_min` uses) filtered to the
-    /// non-hidden clients — summing those rows equals `rate_in_window(600)` for
-    /// the surviving clients.
-    static func current() throws -> Double {
+    static func current(source: any UsageDataSource) async throws -> Double {
         let hidden = ClientRegistry.hiddenClients()
-        guard !hidden.isEmpty else { return try TBCore.tokensPerMin() }
-        let rows = try TBCore.usageTrace(windowSecs: 600)
+        guard !hidden.isEmpty else { return try await source.tokensPerMin() }
+        let rows = try await source.usageTrace(windowSecs: 600)
         return TraceBucket.totalRate(rows, hidden: hidden)
     }
 }

--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -551,9 +551,7 @@ struct PopoverView: View {
     /// `.task` cancels this loop when the popover closes.
     private func pollTokensPerMin() async {
         while !Task.isCancelled {
-            let rate = try? await Task.detached(priority: .utility) {
-                try LiveRate.current()
-            }.value
+            let rate = await model.tokensPerMin()
             if Task.isCancelled { break }
             tokensPerMin = rate
             try? await Task.sleep(for: .seconds(10))

--- a/Sources/TokenBar/QuotaSelectionPolicy.swift
+++ b/Sources/TokenBar/QuotaSelectionPolicy.swift
@@ -1,0 +1,38 @@
+import TokenBarCore
+
+/// Shared quota-selection policy for the tray and Settings preview. Live mode
+/// preserves an explicit persisted selection exactly; demo mode may locally
+/// substitute Auto when a dynamic provider label is absent from its fixture.
+enum QuotaSelectionPolicy {
+    static func effectiveSelection(
+        payload: AgentUsagePayload?,
+        persistedSelection: String,
+        excluding: Set<String>,
+        fallbackUnknownExplicit: Bool
+    ) -> String {
+        guard fallbackUnknownExplicit,
+              !persistedSelection.isEmpty,
+              persistedSelection != QuotaResolver.auto,
+              QuotaResolver.resolve(
+                  payload: payload, selection: persistedSelection, excluding: excluding) == nil
+        else {
+            return persistedSelection
+        }
+        return QuotaResolver.auto
+    }
+
+    static func resolve(
+        payload: AgentUsagePayload?,
+        persistedSelection: String,
+        excluding: Set<String>,
+        fallbackUnknownExplicit: Bool
+    ) -> (clientId: String, window: UsageWindow)? {
+        let selection = effectiveSelection(
+            payload: payload,
+            persistedSelection: persistedSelection,
+            excluding: excluding,
+            fallbackUnknownExplicit: fallbackUnknownExplicit)
+        return QuotaResolver.resolve(
+            payload: payload, selection: selection, excluding: excluding)
+    }
+}

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -5,6 +5,10 @@ import TokenBarCore
 // Plain assertions instead of swift-testing/XCTest because the dev machine has
 // Command Line Tools only (no testing modules); CI runs this the same way.
 
+private final class AsyncResultBox<Value: Sendable>: @unchecked Sendable {
+    var result: Result<Value, Error>?
+}
+
 enum SelfTest {
     static func run() -> Never {
         var failures = 0
@@ -15,6 +19,23 @@ enum SelfTest {
                 failures += 1
                 print("FAIL \(label)")
             }
+        }
+
+        func awaitValue<Value: Sendable>(
+            _ operation: @escaping @Sendable () async throws -> Value
+        ) -> Value? {
+            let semaphore = DispatchSemaphore(value: 0)
+            let box = AsyncResultBox<Value>()
+            Task.detached(priority: .userInitiated) {
+                defer { semaphore.signal() }
+                do {
+                    box.result = .success(try await operation())
+                } catch {
+                    box.result = .failure(error)
+                }
+            }
+            semaphore.wait()
+            return try? box.result?.get()
         }
 
         // ModelColors: provider inference + shade math.
@@ -508,6 +529,217 @@ enum SelfTest {
             colors: chartColors, rangeEnd: "2026-07-05", endFallback: "2026-07-09")
         expect(shiftedBars.last?.date == "2026-07-05" && (shiftedBars.last?.totalTokens ?? 0) == 0,
             "unfiltered anchor would shift the window past the visible activity")
+
+        // Synthetic --demo source: one fixture must drive every usage lens,
+        // quota card, trace row, tray rate, and year selection without a live
+        // FFI call. The fixture itself is the only data definition here.
+        let demoSource = UsageDataSources.make(arguments: ["TokenBar", "--demo"])
+        let liveSource = UsageDataSources.make(arguments: ["TokenBar"])
+        expect(demoSource is DemoUsageDataSource, "usage source factory selects demo mode")
+        expect(liveSource is LiveUsageDataSource, "usage source factory selects live mode")
+        expect(!demoSource.allowsQuotaCachePersistence, "demo source disables quota cache persistence")
+        expect(liveSource.allowsQuotaCachePersistence, "live source allows quota cache persistence")
+
+        let demoPayload = DemoData.payload
+        let demoDates = demoPayload.contributions.map(\.date)
+        let demoDayNumbers = demoDates.compactMap { ISODay($0)?.number }
+        let consecutive = zip(demoDayNumbers, demoDayNumbers.dropFirst())
+            .allSatisfy { $1 == $0 + 1 }
+        expect(
+            demoDates.count == 14 && demoDates == demoDates.sorted() && consecutive,
+            "demo graph has 14 sorted consecutive days")
+        expect(
+            demoPayload.contributions.allSatisfy { $0.clients.count == ClientRegistry.allIds.count },
+            "demo graph carries every registered client on every day")
+
+        let contributionTokens = demoPayload.contributions.reduce(Int64(0)) {
+            $0.saturatingAdding($1.totals.tokens)
+        }
+        let contributionCost = demoPayload.contributions.reduce(0.0) { $0 + $1.totals.cost }
+        expect(
+            contributionTokens == demoPayload.summary.totalTokens
+                && abs(contributionCost - demoPayload.summary.totalCost) < 0.000_000_001,
+            "demo summary totals equal contribution totals")
+
+        let summaryClients = Set(demoPayload.summary.clients)
+        let contributionClients = Set(
+            demoPayload.contributions.flatMap { $0.clients.map(\.client) })
+        let quota = DemoData.agentUsage
+        let quotaClients = Set(quota.agents.map(\.clientId))
+        let registryClients = Set(ClientRegistry.allIds)
+        expect(
+            summaryClients == registryClients && contributionClients == registryClients
+                && quotaClients == registryClients,
+            "demo summary contributions and quota share the client set")
+        let dynamicLabelSelection = "\(ClientRegistry.allIds.first ?? "claude")|Sonnet"
+        let demoQuotaSelection = QuotaSelectionPolicy.effectiveSelection(
+            payload: quota,
+            persistedSelection: dynamicLabelSelection,
+            excluding: [],
+            fallbackUnknownExplicit: demoSource.fallsBackUnknownQuotaSelectionToAuto)
+        let liveQuotaSelection = QuotaSelectionPolicy.effectiveSelection(
+            payload: quota,
+            persistedSelection: dynamicLabelSelection,
+            excluding: [],
+            fallbackUnknownExplicit: liveSource.fallsBackUnknownQuotaSelectionToAuto)
+        expect(
+            demoQuotaSelection == QuotaResolver.auto && liveQuotaSelection == dynamicLabelSelection
+                && QuotaSelectionPolicy.resolve(
+                    payload: quota,
+                    persistedSelection: dynamicLabelSelection,
+                    excluding: [],
+                    fallbackUnknownExplicit: true) != nil
+                && QuotaSelectionPolicy.resolve(
+                    payload: quota,
+                    persistedSelection: dynamicLabelSelection,
+                    excluding: [],
+                    fallbackUnknownExplicit: false) == nil,
+            "demo unknown quota labels fall back locally while live stays exact")
+
+        let modelReport = DemoData.modelReport
+        let hourlyReport = DemoData.hourlyReport
+        let agentsReport = DemoData.agentsReport
+        let trace = DemoData.trace(windowSecs: 600)
+        let modelClients = Set(modelReport.entries.map(\.client))
+        let hourlyClients = Set(hourlyReport.entries.flatMap(\.clients))
+        let agentClients = Set(agentsReport.entries.flatMap(\.clients))
+        let traceClients = Set(trace.map(\.client))
+        let hourlyKeys = hourlyReport.entries.map(\.hour)
+        expect(
+            Set(hourlyKeys).count == hourlyKeys.count && hourlyKeys == hourlyKeys.sorted()
+                && hourlyReport.entries.allSatisfy {
+                    $0.clients == $0.clients.sorted() && $0.models == $0.models.sorted()
+                },
+            "demo hourly buckets are unique and sorted")
+        expect(
+            !modelReport.entries.isEmpty && !hourlyReport.entries.isEmpty
+                && !agentsReport.entries.isEmpty && !trace.isEmpty,
+            "demo reports and trace are non-empty")
+        expect(
+            modelClients == registryClients && hourlyClients == registryClients
+                && agentClients == registryClients && traceClients == registryClients,
+            "demo report and trace ids are registered clients")
+
+        let selectedClient = ClientRegistry.allIds.first ?? ""
+        var graphInput: Int64 = 0
+        var graphOutput: Int64 = 0
+        var graphCacheRead: Int64 = 0
+        var graphCacheWrite: Int64 = 0
+        var graphReasoning: Int64 = 0
+        var graphMessages = 0
+        var graphCost = 0.0
+        for contribution in demoPayload.contributions {
+            for client in contribution.clients where client.client == selectedClient {
+                graphInput += client.tokens.input
+                graphOutput += client.tokens.output
+                graphCacheRead += client.tokens.cacheRead
+                graphCacheWrite += client.tokens.cacheWrite
+                graphReasoning += client.tokens.reasoning
+                graphMessages += client.messages
+                graphCost += client.cost
+            }
+        }
+        let selectedHourly = DemoData.hourlyReport(for: nil, clients: [selectedClient])
+        let hourlyInput = selectedHourly.entries.reduce(Int64(0)) { $0 + $1.input }
+        let hourlyOutput = selectedHourly.entries.reduce(Int64(0)) { $0 + $1.output }
+        let hourlyCacheRead = selectedHourly.entries.reduce(Int64(0)) { $0 + $1.cacheRead }
+        let hourlyCacheWrite = selectedHourly.entries.reduce(Int64(0)) { $0 + $1.cacheWrite }
+        let hourlyReasoning = selectedHourly.entries.reduce(Int64(0)) { $0 + $1.reasoning }
+        let hourlyMessages = selectedHourly.entries.reduce(0) { $0 + $1.messageCount }
+        let hourlyCost = selectedHourly.entries.reduce(0.0) { $0 + $1.cost }
+        expect(
+            graphInput == hourlyInput && graphOutput == hourlyOutput
+                && graphCacheRead == hourlyCacheRead && graphCacheWrite == hourlyCacheWrite
+                && graphReasoning == hourlyReasoning && graphMessages == hourlyMessages
+                && abs(graphCost - hourlyCost) < 0.000_000_001,
+            "selected demo hourly totals equal graph client rows")
+
+        expect(
+            quota.agents.allSatisfy { agent in
+                !agent.windows.isEmpty && agent.windows.allSatisfy {
+                    $0.windowMinutes ?? 0 > 0
+                        && $0.usedPercent >= 0 && $0.remainingPercent > 0
+                        && abs($0.usedPercent + $0.remainingPercent - 100) < 0.000_001
+                }
+            },
+            "demo quota windows have valid labels and used-plus-remaining totals")
+        let rawDemoRate = DemoData.tokensPerMin
+        let traceRate = trace.reduce(0.0) { $0 + $1.tokensPerMin }
+        let selectedTraceRate = trace.first { $0.client == selectedClient }?.tokensPerMin ?? 0
+        let hiddenTraceRate = TraceBucket.totalRate(trace, hidden: [selectedClient])
+        let allHiddenTraceRate = TraceBucket.totalRate(trace, hidden: registryClients)
+        expect(
+            rawDemoRate > 0 && trace.allSatisfy { $0.tokensPerMin > 0 }
+                && abs(rawDemoRate - traceRate) < 0.000_001
+                && abs(hiddenTraceRate - (rawDemoRate - selectedTraceRate)) < 0.000_001
+                && allHiddenTraceRate == 0,
+            "demo raw rate equals trace and hidden-client reductions")
+
+        let currentYear = String(Format.todayKey().prefix(4))
+        let currentPayload = DemoData.payload(for: currentYear)
+        let otherYear = String((Int(currentYear) ?? 2000) - 1)
+        let otherPayload = DemoData.payload(for: otherYear)
+        expect(
+            demoPayload.contributions.last?.date == Format.todayKey()
+                && currentPayload.contributions.last?.date == Format.todayKey(),
+            "demo nil and current-year windows end today")
+        expect(
+            otherPayload.contributions.count == 14
+                && otherPayload.contributions.allSatisfy { $0.date.hasPrefix(otherYear) }
+                && otherPayload.years.contains { $0.year == otherYear },
+            "demo non-current year stays within the selected year")
+
+        let demoJan1 = DemoData.dates(for: "2024", today: "2024-01-01")
+        let demoJan13 = DemoData.dates(for: "2024", today: "2024-01-13")
+        let demoJan14 = DemoData.dates(for: "2024", today: "2024-01-14")
+        let rollingJan1 = DemoData.dates(for: nil, today: "2024-01-01")
+        let leapDay = DemoData.dates(for: "2024", today: "2024-02-29")
+        let priorYear = DemoData.dates(for: "2023", today: "2024-02-29")
+        let invalidYear = DemoData.dates(for: "not-a-year", today: "2024-02-29")
+        expect(
+            demoJan1.count == 1 && demoJan1.last == "2024-01-01"
+                && demoJan13.count == 13 && demoJan13.last == "2024-01-13"
+                && demoJan14.count == 14 && demoJan14.last == "2024-01-14",
+            "demo current-year dates clamp at January 1")
+        expect(
+            rollingJan1.count == 14 && rollingJan1.last == "2024-01-01"
+                && rollingJan1.first?.hasPrefix("2023-") == true,
+            "demo all-years dates retain the rolling cross-year window")
+        expect(
+            leapDay.count == 14 && leapDay.contains("2024-02-29")
+                && priorYear.count == 14 && priorYear.allSatisfy { $0.hasPrefix("2023-") }
+                && invalidYear.count == 14 && invalidYear.last == "2024-02-29",
+            "demo date helper handles leap and invalid years")
+
+        let sourcedPayload = awaitValue {
+            try await demoSource.graph(year: nil, priority: .userInitiated)
+        }
+        let sourcedRefresh = awaitValue {
+            try await demoSource.refreshGraph(year: nil, priority: .userInitiated)
+        }
+        let sourcedModels = awaitValue {
+            try await demoSource.modelReport(year: nil, priority: .userInitiated)
+        }
+        let sourcedHourly = awaitValue {
+            try await demoSource.hourlyReport(
+                year: nil, clients: nil, priority: .userInitiated)
+        }
+        let sourcedAgents = awaitValue {
+            try await demoSource.agentsReport(
+                year: nil, clients: nil, priority: .userInitiated)
+        }
+        let sourcedQuota = awaitValue { try await demoSource.agentUsage() }
+        let sourcedTrace = awaitValue { try await demoSource.usageTrace(windowSecs: 600) }
+        let sourcedRate = awaitValue { try await demoSource.tokensPerMin() }
+        expect(
+            sourcedPayload?.summary.totalTokens == demoPayload.summary.totalTokens
+                && sourcedRefresh?.summary.totalCost == demoPayload.summary.totalCost,
+            "demo source graph and refresh read synthetic data")
+        expect(
+            sourcedModels?.entries.isEmpty == false && sourcedHourly?.entries.isEmpty == false
+                && sourcedAgents?.entries.isEmpty == false && sourcedQuota?.agents.isEmpty == false
+                && sourcedTrace?.isEmpty == false && (sourcedRate ?? 0) > 0,
+            "demo source serves every usage API")
 
         // FFI envelope/error contract (hermetic; no FFI allocation or live data).
         for (label, passed) in TBCore.envelopeContractChecks() {

--- a/Sources/TokenBar/TrayAnimator.swift
+++ b/Sources/TokenBar/TrayAnimator.swift
@@ -14,6 +14,7 @@ final class TrayAnimator {
     static let quotaSourceKey = "tokenbar.quota.source"
 
     private weak var controller: StatusItemController?
+    private let source: any UsageDataSource
     /// Frame sets keyed by "<style>|<dark|light>".
     private let frames: [String: [NSImage]]
     private var animationTask: Task<Void, Never>?
@@ -27,8 +28,15 @@ final class TrayAnimator {
     /// Fired after every successful quota fetch (title refresh hook).
     var onQuotaUpdated: (() -> Void)?
 
-    init(controller: StatusItemController) {
+    init(
+        controller: StatusItemController,
+        source: any UsageDataSource = UsageDataSources.current
+    ) {
         self.controller = controller
+        self.source = source
+        self.cachedQuotaRemaining = source.allowsQuotaCachePersistence
+            ? UserDefaults.standard.object(forKey: Self.lastRemainingKey) as? Double
+            : nil
         var sets: [String: [NSImage]] = [:]
         for (style, dir) in [("cat", "anim-cat2"), ("parrot", "anim-parrot")] {
             sets["\(style)|dark"] = Self.loadFrames(directory: dir)
@@ -141,10 +149,9 @@ final class TrayAnimator {
 
     /// Last successfully resolved remaining percent — a transient fetch
     /// failure (or a provider erroring) must never zero/blank the display.
-    /// Persisted so a relaunch shows the last reading immediately instead of
-    /// a blank gauge while the first (network) fetch runs.
-    private var cachedQuotaRemaining: Double? =
-        UserDefaults.standard.object(forKey: lastRemainingKey) as? Double
+    /// Live mode seeds this from UserDefaults; demo mode starts nil and keeps
+    /// only the process-local synthetic value.
+    private var cachedQuotaRemaining: Double?
 
     /// The selected quota window's remaining percent, holding the last good
     /// value across failed refreshes (nil only before any data ever arrived).
@@ -154,9 +161,14 @@ final class TrayAnimator {
     /// didChangeNotification and re-entered the observers. `persistRemaining()`
     /// is called explicitly when fresh quota data arrives instead.
     var quotaRemaining: Double? {
-        let selection = UserDefaults.standard.string(forKey: Self.quotaSourceKey)
+        let persistedSelection = UserDefaults.standard.string(forKey: Self.quotaSourceKey)
             ?? QuotaResolver.auto
         let excluded = ClientRegistry.quotaExcludedClients()
+        let selection = QuotaSelectionPolicy.effectiveSelection(
+            payload: quota,
+            persistedSelection: persistedSelection,
+            excluding: excluded,
+            fallbackUnknownExplicit: source.fallsBackUnknownQuotaSelectionToAuto)
         if let value = QuotaResolver.resolve(
             payload: quota, selection: selection, excluding: excluded)?
             .window.remainingPercent
@@ -178,12 +190,14 @@ final class TrayAnimator {
         return cachedQuotaRemaining
     }
 
-    /// Persist the last good remaining percent so a relaunch shows it
-    /// immediately. Called at quota-arrival points, not from the getter.
-    /// Reads `quotaRemaining` (not `cachedQuotaRemaining`) so it resolves the
-    /// fresh value even for cat/parrot styles, where `renderGaugeIcon()`
-    /// returns early without touching the cache.
+    /// Persist the last good remaining percent so a live-mode relaunch shows it
+    /// immediately. Demo mode is deliberately process-local and returns before
+    /// touching UserDefaults. Called at quota-arrival points, not from the
+    /// getter. Reads `quotaRemaining` (not `cachedQuotaRemaining`) so it
+    /// resolves the fresh value even for cat/parrot styles, where
+    /// `renderGaugeIcon()` returns early without touching the cache.
     private func persistRemaining() {
+        guard source.allowsQuotaCachePersistence else { return }
         if let value = quotaRemaining {
             UserDefaults.standard.set(value, forKey: Self.lastRemainingKey)
         }
@@ -251,9 +265,8 @@ final class TrayAnimator {
     private func startQuotaPolling() {
         quotaTask = Task { [weak self] in
             while !Task.isCancelled {
-                let payload = try? await Task.detached(priority: .utility) {
-                    try TBCore.agentUsage()
-                }.value
+                guard let source = self?.source else { break }
+                let payload = try? await source.agentUsage()
                 guard let self, !Task.isCancelled else { break }
                 if let payload {
                     self.quota = payload
@@ -305,10 +318,8 @@ final class TrayAnimator {
     private func startLoadPolling() {
         loadTask = Task { [weak self] in
             while !Task.isCancelled {
-                guard let gen = self?.nextRateGeneration() else { break }
-                let rate = try? await Task.detached(priority: .utility) {
-                    try LiveRate.current()
-                }.value
+                guard let gen = self?.nextRateGeneration(), let source = self?.source else { break }
+                let rate = try? await LiveRate.current(source: source)
                 guard let self, !Task.isCancelled else { break }
                 if let rate { self.applyRate(rate, generation: gen) }
                 try? await Task.sleep(for: .seconds(30))

--- a/Sources/TokenBar/UsageDataSource.swift
+++ b/Sources/TokenBar/UsageDataSource.swift
@@ -1,0 +1,143 @@
+import Foundation
+import TokenBarCore
+
+/// App-level source of usage data. Every usage consumer depends on this
+/// contract so `--demo` can replace the complete usage surface without
+/// allowing live FFI calls to leak into the demo path.
+protocol UsageDataSource: Sendable {
+    /// Whether this source may read/write the persistent last-good quota cache.
+    var allowsQuotaCachePersistence: Bool { get }
+    /// Demo-only policy for stale explicit quota labels; live keeps exact picks.
+    var fallsBackUnknownQuotaSelectionToAuto: Bool { get }
+
+    func graph(year: String?, priority: TaskPriority) async throws -> UsagePayload
+    func refreshGraph(year: String?, priority: TaskPriority) async throws -> UsagePayload
+    func modelReport(year: String?, priority: TaskPriority) async throws -> ModelReport
+    func hourlyReport(
+        year: String?, clients: [String]?, priority: TaskPriority
+    ) async throws -> HourlyReport
+    func agentsReport(
+        year: String?, clients: [String]?, priority: TaskPriority
+    ) async throws -> AgentsReport
+    func agentUsage() async throws -> AgentUsagePayload
+    func usageTrace(windowSecs: Int64) async throws -> [TraceBucket]
+    func tokensPerMin() async throws -> Double
+}
+
+/// The only normal-runtime owner of usage calls into `TBCore`.
+struct LiveUsageDataSource: UsageDataSource {
+    let allowsQuotaCachePersistence = true
+    let fallsBackUnknownQuotaSelectionToAuto = false
+
+    func graph(year: String?, priority: TaskPriority) async throws -> UsagePayload {
+        try await Task.detached(priority: priority) {
+            try TBCore.graph(year: year)
+        }.value
+    }
+
+    func refreshGraph(year: String?, priority: TaskPriority) async throws -> UsagePayload {
+        try await Task.detached(priority: priority) {
+            try TBCore.refreshGraph(year: year)
+        }.value
+    }
+
+    func modelReport(year: String?, priority: TaskPriority) async throws -> ModelReport {
+        try await Task.detached(priority: priority) {
+            try TBCore.modelReport(year: year)
+        }.value
+    }
+
+    func hourlyReport(
+        year: String?, clients: [String]?, priority: TaskPriority
+    ) async throws -> HourlyReport {
+        try await Task.detached(priority: priority) {
+            try TBCore.hourlyReport(year: year, clients: clients)
+        }.value
+    }
+
+    func agentsReport(
+        year: String?, clients: [String]?, priority: TaskPriority
+    ) async throws -> AgentsReport {
+        try await Task.detached(priority: priority) {
+            try TBCore.agentsReport(year: year, clients: clients)
+        }.value
+    }
+
+    func agentUsage() async throws -> AgentUsagePayload {
+        try await Task.detached(priority: .utility) {
+            try TBCore.agentUsage()
+        }.value
+    }
+
+    func usageTrace(windowSecs: Int64) async throws -> [TraceBucket] {
+        try await Task.detached(priority: .utility) {
+            try TBCore.usageTrace(windowSecs: windowSecs)
+        }.value
+    }
+
+    func tokensPerMin() async throws -> Double {
+        try await Task.detached(priority: .utility) {
+            try TBCore.tokensPerMin()
+        }.value
+    }
+}
+
+/// Synthetic source used by the hidden `--demo` mode. It only exposes the
+/// deterministic fixtures in `DemoData`; it has no dependency on `TBCore`.
+struct DemoUsageDataSource: UsageDataSource {
+    let allowsQuotaCachePersistence = false
+    let fallsBackUnknownQuotaSelectionToAuto = true
+
+    func graph(year: String?, priority: TaskPriority) async throws -> UsagePayload {
+        _ = priority
+        return DemoData.payload(for: year)
+    }
+
+    func refreshGraph(year: String?, priority: TaskPriority) async throws -> UsagePayload {
+        _ = priority
+        // Rebuild rather than cache the value so manual refresh follows the same
+        // source boundary as live refresh and keeps the rolling date current.
+        return DemoData.payload(for: year)
+    }
+
+    func modelReport(year: String?, priority: TaskPriority) async throws -> ModelReport {
+        _ = priority
+        return DemoData.modelReport(for: year)
+    }
+
+    func hourlyReport(
+        year: String?, clients: [String]?, priority: TaskPriority
+    ) async throws -> HourlyReport {
+        _ = priority
+        return DemoData.hourlyReport(for: year, clients: clients)
+    }
+
+    func agentsReport(
+        year: String?, clients: [String]?, priority: TaskPriority
+    ) async throws -> AgentsReport {
+        _ = priority
+        return DemoData.agentsReport(for: year, clients: clients)
+    }
+
+    func agentUsage() async throws -> AgentUsagePayload {
+        DemoData.agentUsage
+    }
+
+    func usageTrace(windowSecs: Int64) async throws -> [TraceBucket] {
+        DemoData.trace(windowSecs: windowSecs)
+    }
+
+    func tokensPerMin() async throws -> Double {
+        DemoData.tokensPerMin
+    }
+}
+
+/// Selects one source for the process lifetime. The mode is intentionally
+/// launch-time only; changing the flag requires relaunching the app.
+enum UsageDataSources {
+    static let current: any UsageDataSource = make(arguments: CommandLine.arguments)
+
+    static func make(arguments: [String]) -> any UsageDataSource {
+        arguments.contains("--demo") ? DemoUsageDataSource() : LiveUsageDataSource()
+    }
+}

--- a/Sources/TokenBar/Views/SettingsWindowView.swift
+++ b/Sources/TokenBar/Views/SettingsWindowView.swift
@@ -107,9 +107,7 @@ struct SettingsWindowView: View {
     /// every 10s. Feeds the rate tray mode and the preview's spin speed.
     private func pollTokensPerMin() async {
         while !Task.isCancelled {
-            let rate = try? await Task.detached(priority: .utility) {
-                try LiveRate.current()
-            }.value
+            let rate = await model.tokensPerMin()
             if Task.isCancelled { break }
             tokensPerMin = rate
             try? await Task.sleep(for: .seconds(10))
@@ -178,12 +176,19 @@ private struct MenuBarMock: View {
     }
 
     /// Mirrors TrayAnimator.quotaRemaining minus the write-back: live resolve
-    /// first, then the persisted last-good reading. Excludes the tab- and
-    /// limits-hidden clients from the auto pick, same as the real tray.
+    /// first, then the persisted last-good reading when this source permits it.
+    /// Excludes the tab- and limits-hidden clients from the auto pick, same as
+    /// the real tray.
     private var quotaRemaining: Double? {
+        let source = UsageDataSources.current
         let excluded = ClientRegistry.quotaExcludedClients()
+        let selection = QuotaSelectionPolicy.effectiveSelection(
+            payload: agentUsage,
+            persistedSelection: quotaSource,
+            excluding: excluded,
+            fallbackUnknownExplicit: source.fallsBackUnknownQuotaSelectionToAuto)
         if let value = QuotaResolver.resolve(
-            payload: agentUsage, selection: quotaSource, excluding: excluded)?
+            payload: agentUsage, selection: selection, excluding: excluded)?
             .window.remainingPercent
         {
             return value
@@ -191,10 +196,11 @@ private struct MenuBarMock: View {
         // Same disambiguation as the real tray: don't fall back to the persisted
         // last-good reading when the nil is caused purely by the exclusion.
         if QuotaResolver.excludedAllCandidates(
-            payload: agentUsage, selection: quotaSource, excluding: excluded)
+            payload: agentUsage, selection: selection, excluding: excluded)
         {
             return nil
         }
+        guard source.allowsQuotaCachePersistence else { return nil }
         return UserDefaults.standard.object(forKey: TrayAnimator.lastRemainingKey) as? Double
     }
 

--- a/Sources/TokenBarCore/ClientRegistry.swift
+++ b/Sources/TokenBarCore/ClientRegistry.swift
@@ -47,6 +47,10 @@ public enum ClientRegistry {
         "grok": ("Grok Build", "#1f2937"),
     ]
 
+    /// Every registered client id, sorted. Demo fixtures use this canonical
+    /// universe so every usage surface renders the same client set.
+    public static var allIds: [String] { entries.keys.sorted() }
+
     public static func style(_ id: String) -> ClientStyle {
         if let entry = entries[id] {
             return ClientStyle(id: id, displayName: entry.displayName, color: entry.color)

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -1,0 +1,139 @@
+# Synthetic `--demo` usage mode
+
+> `--demo` 是 maintainer-only 的隱藏啟動旗標，用來在不需要 usage-provider network 或 OAuth credentials 的情況下驗證 UI 與截圖；它不是一般使用者功能，也不改變正式資料來源。
+
+## 目錄
+
+- [文件目的](#文件目的)
+- [旗標與建置範圍](#旗標與建置範圍)
+- [資料邊界](#資料邊界)
+- [啟動命令](#啟動命令)
+- [Synthetic 資料語意](#synthetic-資料語意)
+- [驗證方式](#驗證方式)
+
+---
+
+## 文件目的
+
+這份文件記錄 native TokenBar 的 synthetic usage mode：旗標如何選擇資料來源、哪些 usage surface 會被替換、哪些服務維持正常 runtime，以及 maintainer 應如何取得 selftest 與 GUI evidence。Synthetic fixture 位於 `Sources/TokenBar/DemoData.swift`，不依賴本機 usage logs、usage-provider network 或 Rust usage FFI。
+
+## 旗標與建置範圍
+
+`--demo` 在 process 啟動時由 `UsageDataSources.current` 只選一次。所有可啟動 TokenBar 的 build 形態都接受同一個旗標；旗標不寫入 `UserDefaults`，重新啟動時必須再次傳入。
+
+| Build 形態 | 入口 | 用途 |
+|---|---|---|
+| Debug SwiftPM | `swift run TokenBar --demo` | 日常開發；啟動後點擊新增的 status item 驗證 popover |
+| Debug settings | `swift run TokenBar --demo --settings` | 驗證 Settings preview、quota 與 trace |
+| Release SwiftPM | `swift run -c release TokenBar --demo` | 驗證 release optimization 下的資料流 |
+| Bundled `.app` | `open dist/TokenBar.app --args --demo` | 驗證實際 Sparkle、resource bundle 與 menu-bar app |
+
+> **注意：** `--demo` 是 maintainer-only hidden flag。不要在公開設定頁、README 或一般使用者文件中把它描述成支援的產品模式。
+
+## 資料邊界
+
+正常 app runtime 不再由各個 view 或 poller 直接呼叫 `TBCore`。所有 usage API 都經過 app-level `UsageDataSource`；live source 由 `LiveUsageDataSource` 集中處理 FFI，demo source 只讀 `DemoData`。
+
+```mermaid
+flowchart LR
+    ARGS[Process arguments] --> APP[App runtime]
+    subgraph USAGE[Usage source boundary]
+        FACTORY[UsageDataSources.current]
+        LIVE[LiveUsageDataSource]
+        DEMO[DemoUsageDataSource]
+        FFI[TBCore usage APIs]
+        FIXTURE[DemoData]
+        MODEL[DashboardModel / TrayAnimator / AppDelegate]
+        UI[Popover / Settings / tray]
+        FACTORY --> LIVE
+        FACTORY --> DEMO
+        LIVE --> FFI
+        DEMO --> FIXTURE
+        LIVE --> MODEL
+        DEMO --> MODEL
+        MODEL --> UI
+    end
+    APP --> FACTORY
+    APP --> SPARKLE[UpdaterService / Sparkle]
+```
+
+| Surface | `--demo` 行為 | 是否呼叫 live FFI |
+|---|---|---:|
+| Graph、model、hourly、agents | 回傳 synthetic payload/report | 否 |
+| Agent quota | 回傳所有 registered clients 的 synthetic windows | 否 |
+| Live trace、tokens/min | 回傳非空 synthetic rows 與正值 rate | 否 |
+| Popover、Settings | 使用注入的 `DashboardModel` source | 否 |
+| Tray title、gauge、animation | 使用同一 process source 的 graph、quota、rate | 否 |
+| Sparkle update service | 維持原本 updater 行為 | 不屬於 usage source |
+| `--smoke` CLI | 仍執行明確的 live FFI smoke flow | 是 |
+
+`Smoke.swift` 是刻意保留的 CLI gate，不是正常 menu-bar runtime。這個邊界讓 `grep` 對 app usage call sites 時，直接的八個 `TBCore` usage API 只會出現在 `LiveUsageDataSource` 與 smoke gate。
+
+## 啟動命令
+
+先以 repo root 建置 Rust staticlib 與 Swift executable，再傳入旗標。一般 Debug 截圖先啟動 app，再點擊新增的 TokenBar status item 開啟 popover：
+
+```bash
+make build
+swift run TokenBar --demo
+```
+
+Settings window 可獨立啟動：
+
+```bash
+swift run TokenBar --demo --settings
+```
+
+> **注意：** 既有 `--open-popover` launch-time screenshot hook 在 remote-hosted status item 尚未建立可用 anchor 時可能不會開啟 popover，不能作為 demo mode 的 correctness gate。GUI 驗證以啟動 `--demo` 後實際點擊該測試 process 的 status item 為準。
+
+要驗證實際 `.app` bundle，先走既有 bundle build，再以 `open` 傳入旗標：
+
+```bash
+make bundle
+open dist/TokenBar.app --args --demo
+```
+
+要同時預選 year 或 client tab，可把既有 debug flags 接在 `--demo` 後面：
+
+```bash
+swift run TokenBar --demo --year=2025 --tab=claude
+```
+
+## Synthetic 資料語意
+
+Fixture 以 `ClientRegistry.allIds` 為唯一 client universe。每個 contribution day 都有每個 registered client 的 stripe，因此 summary、contributions、model report、hourly report、agents report、trace 與 quota snapshots 可以在同一集合上交叉驗證。
+
+| 操作 | Synthetic 行為 |
+|---|---|
+| All years（`year == nil`） | 產生 14 天 rolling window，最後一天是 local today |
+| Current year | 以 local today 為結尾，從 Jan 1 起最多 14 天；年初可能少於 14 天 |
+| 其他明確 year | 產生該年內連續 14 天，結尾固定在該年年末，避免跨年 |
+| Manual refresh | 重新經過 `DemoUsageDataSource.refreshGraph` 讀取 synthetic source，不會觸碰 live logs |
+| Models lens | 每個 registered client 有非空 model row |
+| Daily lens | 使用 contribution stripes 與同一組 client IDs |
+| Hourly lens | 每個 client 有非空 hourly slot；client filter 仍在 source 邊界套用 |
+| Agents lens | 每個 client 有非空 synthetic agent row |
+| Live session lens | 每個 client 有正值 trace bucket 與 tokens/min |
+| Tray title | graph title、tokens/min title、quota title 都有可顯示資料 |
+| Tray gauge / animation | quota windows 與正值 rate 讓 gauge、frame speed 不會停在空資料狀態 |
+
+Year filter 的重要條件是：其他 year 也一定產生包含所選 year 的 `payload.years`。因此 `DashboardModel.apply` 不會把 synthetic year 判定為空資料後清回 All years。
+
+## 驗證方式
+
+`SelfTest` 是 hermetic data-contract gate，不會啟動 AppKit GUI，也不需要本機 usage logs。它會透過 `DemoData` 與 `DemoUsageDataSource` 檢查 source factory、14 天排序與連續性、summary totals、client 集合、四種 reports、trace、quota windows、positive rate，以及 nil/current/other year semantics。
+
+```bash
+swift run TokenBar --selftest
+```
+
+GUI evidence 則需要明確啟動 app，點擊該測試 process 的 status item，並確認六個 lenses、client tabs、quota card、trace card、tray title、gauge 與 animation 實際渲染；Settings 可用第二個命令自動開啟：
+
+```bash
+swift run TokenBar --demo
+swift run TokenBar --demo --settings
+```
+
+> **限制：** `swift run TokenBar --demo --smoke` 會先命中 `main.swift` 的 `--smoke` 分支，執行 live FFI smoke，而不是啟動 demo source。這個組合只能用來驗證 FFI smoke；它不能證明 demo mode 的 no-live 邊界，也不應用作 GUI evidence。
+
+Selftest 綠燈代表 synthetic contract 與 source wiring 通過；它不取代實際 menu-bar runtime、Sparkle bundle、AppKit rendering 或 resource loading 的 GUI 檢查。


### PR DESCRIPTION
## Summary

This PR adds a maintainer-only synthetic `--demo` mode that replaces the complete usage-data surface without mixing fixture data with live logs, provider credentials, or usage FFI calls. Sparkle and other non-usage runtime services remain unchanged.

## Architecture

| Layer | Responsibility |
|---|---|
| `UsageDataSource` | Defines graph, refresh, report, quota, trace, and rate access for app runtime consumers |
| `LiveUsageDataSource` | Owns all normal-runtime calls into the eight `TBCore` usage APIs |
| `DemoUsageDataSource` | Serves only in-memory `DemoData` fixtures and never references `TBCore` |
| `UsageDataSources.current` | Selects one process-lifetime source from `CommandLine.arguments` |
| `DashboardModel`, `TrayAnimator`, `AppDelegate` | Consume the same injected source across popover, Settings, tray title, gauge, and animation |

## Synthetic contract

The fixture uses `ClientRegistry.allIds` as its single client universe and provides graph data, model/hourly/agents reports, quota windows, trace buckets, and tokens-per-minute data. Dates use a rolling 14-day window, clamp the current year at January 1, preserve cross-year behavior for All years, and keep explicit historical years within their requested year.

Demo quota state does not read or write the live persisted quota cache. A stale explicit quota label falls back to Auto for the current demo process without mutating `UserDefaults`.

## Maintainer documentation

`docs/demo-mode.md` documents the hidden flag, source boundary, fixture semantics, launch commands, verification procedure, and the intentional `--demo --smoke` precedence. The existing launch-time `--open-popover` screenshot hook is not treated as a correctness gate because remote-hosted status-item anchoring is not reliable; GUI verification launches `--demo` and clicks the test process's status item.

## Verification

| Gate | Result |
|---|---|
| `cargo test` | Passed: 56 + 1020 + 10 + 3 + 1 tests, 1 ignored |
| `cargo clippy --workspace --all-targets` | Passed |
| `make build` | Passed |
| `swift build` after the final diff | Passed |
| `swift run TokenBar --selftest` | Passed |
| `swift run TokenBar --smoke` | Passed; graph, hourly, and agents drift checks matched |
| `git diff --check` and staged diff check | Passed |
| Direct usage-call audit | Calls are limited to `LiveUsageDataSource` and the explicit `Smoke.swift` CLI gate |
| Demo-source audit | `DemoUsageDataSource` and `DemoData` contain no `TBCore` references |
| GUI runtime | Settings rendered synthetic identities and quota windows; clicking the test status item produced the full popover |

> **Repository exception:** `cargo fmt --all -- --check` reports the pre-existing Rust/vendor formatting drift from the base branch. This PR has no Rust changes, and formatting the workspace would introduce approximately 2,545 unrelated lines of churn.

## Scope

This PR does not expose Demo mode in product UI, disable Sparkle, change the explicit smoke-test path, or include the separate canonical knowledge-base work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
