### PR TITLE
docs(contributing): add contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to TokenBar
+
+TokenBar welcomes focused fixes, well-supported bug reports, and carefully scoped improvements. This document is the public entry point for contributors; it explains how to prepare a change and routes durable project facts to the repository knowledge base.
+
+> [`docs/knowledge/`](docs/knowledge/README.md) is the canonical source for architecture, verification, workflow, vendor, release, and maintenance decisions. If this guide and an execution source disagree, verify the execution source and update the canonical knowledge rather than copying a second version here.
+
+## Contents
+
+- [Before you start](#before-you-start)
+- [Project knowledge](#project-knowledge)
+- [Development environment](#development-environment)
+- [Repository workflow](#repository-workflow)
+- [Change-specific guardrails](#change-specific-guardrails)
+- [Verification](#verification)
+- [Pull requests](#pull-requests)
+- [Review, credit, and integration](#review-credit-and-integration)
+- [Public repository safety](#public-repository-safety)
+
+---
+
+## Before you start
+
+TokenBar is in a maintenance phase. User-visible correctness, missing or stale data, cache invalidation, the Rust-to-Swift contract, and release-chain failures take priority over broad client expansion or large UI redesigns. The rolling tokscale inventory in [issue #45](https://github.com/Nanako0129/TokenBar/issues/45) is a decision surface, not a promise to implement every listed item.
+
+| Proposed contribution | Expected first step |
+|---|---|
+| Wrong or missing usage, cost, quota, or hidden-client data | Describe a minimal reproduction, the expected value, and the affected client or report |
+| Parser, cache, deduplication, aggregation, or FFI correction | Identify the producing layer and the smallest deterministic old-fail/new-pass fixture |
+| Narrow upstream tokscale fix | Compare the current upstream diff with the current vendor tree and local patch ledger |
+| New client, broad UI redesign, or major product expansion | Open a discussion or focused issue before implementation |
+| Release, Sparkle, Homebrew, or migration change | Describe the affected delivery surface; publishing remains maintainer-controlled |
+
+See the current priority order in [`docs/knowledge/current-state.md`](docs/knowledge/current-state.md) before treating an inventory item as committed work.
+
+## Project knowledge
+
+Start with the [knowledge index](docs/knowledge/README.md), then follow the task-specific route below. These documents explain the contract; the linked code, build files, and workflows remain the execution sources.
+
+If you use an automated coding client, it must also follow [`AGENTS.md`](AGENTS.md) and the applicable nested adapter before editing. Those files route agents and define automation boundaries; they do not replace the contributor workflow in this guide.
+
+| Change area | Required reading |
+|---|---|
+| Rust, C ABI, Swift data flow, reports, or filters | [`architecture.md`](docs/knowledge/architecture.md) and [`verification.md`](docs/knowledge/verification.md) |
+| Branches, commits, review, or integration | [`workflow.md`](docs/knowledge/workflow.md) and [`communication.md`](docs/knowledge/communication.md) |
+| Tests, fixtures, cache invalidation, or UX acceptance | [`verification.md`](docs/knowledge/verification.md) |
+| Vendored tokscale | [`vendor/AGENTS.md`](vendor/AGENTS.md), [`vendor/README.md`](vendor/README.md), and [`vendor-tokscale.md`](docs/knowledge/vendor-tokscale.md) |
+| Sparkle, appcast, Homebrew, Pages, or release notes | [`release.md`](docs/knowledge/release.md) and [`workflow.md`](docs/knowledge/workflow.md) |
+| Landing site structure, deployment, or product claims | [`landing/AGENTS.md`](landing/AGENTS.md) and [`release.md`](docs/knowledge/release.md) |
+
+Durable architecture, verification, workflow, and release facts belong in `docs/knowledge/`. Exact vendor baselines and local patch records belong only in `vendor/README.md`.
+
+## Development environment
+
+The supported application target is Apple Silicon on macOS 14 or later. The package uses Swift tools 6.0, and CI uses stable Rust. Run build and Swift commands from the repository root because the Rust static-library search path in [`Package.swift`](Package.swift) is relative.
+
+Build the Rust static library first, link the Swift package, and run the UI-free contract checks:
+
+```bash
+make build
+swift run TokenBar --selftest
+swift run TokenBar --smoke
+```
+
+Use `make run` to build and launch TokenBar. For ordinary popover or interaction acceptance that does not require `.app` bundle semantics, use:
+
+```bash
+swift run TokenBar --open-popover
+```
+
+These commands are onboarding checks, not the complete gate for every change. The canonical change-specific gates are in [`docs/knowledge/verification.md`](docs/knowledge/verification.md).
+
+## Repository workflow
+
+Create a topic branch from the current upstream `main` branch, and keep each branch, commit, and pull request focused on one reviewable concern.
+
+| Area | Convention |
+|---|---|
+| Branch name | `<type>-<kebab-summary>`, such as `fix-ffi-resilience` or `docs-contributing-guide` |
+| Commit subject | `type(scope): imperative subject` |
+| Commit scope | One reviewable concern; do not mix unrelated cleanup with the functional change |
+| Submission | Open a pull request for the completed topic; core, FFI, vendor, contract, release-chain, user-visible, or multi-file changes require full review |
+| Durable project facts | Update the appropriate canonical knowledge document in the same change |
+| Generated or local artifacts | Keep build outputs, private fixtures, and machine-local instructions out of the patch |
+
+## Change-specific guardrails
+
+> **Cross-language contract:** A boundary change must check the C declarations in `Sources/CTB/include/ctb.h`, the Rust FFI entry point or mapper, the Swift decoder or model, and parity or smoke evidence. Successful heap JSON pointers must retain the documented `tb_free` ownership path.
+
+> **Pre-aggregation:** Do not try to subtract a client after contributions have been combined into a mixed aggregate. Pass non-empty filters to the producer while client identity is still available, and preserve the documented `nil` or empty-list semantics across Swift, C, and Rust.
+
+> **Vendor boundary:** Port reviewed upstream hunks into the patched vendor tree. Never replace a whole vendored file when that could erase TokenBar's streaming, cache, report, pricing, or FFI adaptations; update `vendor/README.md` whenever vendor code changes.
+
+| Change class | Required evidence or treatment |
+|---|---|
+| Data-dependent correctness | A hermetic old-fail/new-pass fixture plus a non-trigger regression case |
+| Parser reads a sibling file or WAL | Fingerprint, active lane, latest-mtime probe, pruning, and report-parity coverage |
+| Parsed output, attribution, dedup key, or resume state changes | An explicit local cache-schema decision and a same-fingerprint stale-cache regression |
+| Rust-to-Swift payload changes | C header, Rust mapper, Swift decoder or model, and end-to-end parity or smoke evidence |
+| UI lifecycle changes | Evidence that closing the popover or settings window stops polling and background rendering |
+| Product or repository documentation | Relative links, canonical ownership, public-safe wording, and the documentation gate |
+| Landing-only changes | Aligned English and `zh-tw` content plus the package build declared under `landing/` |
+
+## Verification
+
+Select evidence that proves the behavior being changed. A live app run without the triggering data cannot prove a data-dependent correctness fix, and a green CI run does not replace the full local code-change gate.
+
+| Change | Minimum contributor evidence |
+|---|---|
+| Every patch | Review tracked, staged, and untracked files; before submission, run `git diff --check origin/main...HEAD` or the equivalent current upstream-main comparison, then inspect any remaining working-tree files separately |
+| Documentation or routing | Follow the [documentation checks](docs/knowledge/verification.md#documentation-checks) and verify every relative link |
+| Rust or cross-language code | Run the [local full code-change gates](docs/knowledge/verification.md#local-full-code-change-gates) |
+| Parser, cache, deduplication, or aggregation | Add the relevant [hermetic fixture](docs/knowledge/verification.md#hermetic-fixtures) and cache or sibling matrix |
+| FFI contract | Run the Rust and Swift gates, `--selftest`, and `--smoke`; verify ownership and envelope shape |
+| Popover, lens, keyboard, scroll, or appearance | Use the [local UX acceptance path](docs/knowledge/verification.md#local-build-and-ux-acceptance) and record the interaction checked |
+| Local icon, `Info.plist`, `LSUIElement`, or autostart behavior | Use the bundle-only path in the verification contract and record cleanup of temporary artifacts |
+| Homebrew, stable Sparkle update, or formal install path | Validate `/Applications/TokenBar.app` as documented; do not substitute the temporary `dist/TokenBar.app` |
+
+If a smoke or live check is limited by local credentials, session data, or a provider response, report that environmental limitation separately. Do not use it to replace or invalidate hermetic evidence.
+
+## Pull requests
+
+Write GitHub issues and pull requests in English with soft-wrapped paragraphs. Keep repository links relative and external-project references public.
+
+| PR field | Expected content |
+|---|---|
+| Motivation or reproduction | What is wrong, who or what is affected, and the smallest reproducible trigger |
+| Root cause | The producing layer or data flow responsible for the behavior |
+| Scope | What changed, what deliberately did not change, and why the boundary is narrow |
+| Verification | Exact commands, fixture names, results, and any before/after measurement required by the claim |
+| Canonical documentation | Documents updated, or why the change does not alter a durable project fact |
+| Known limitations | Environmental constraints, deferred work, and remaining risk |
+| Contributor identity | The actual GitHub handle or authorship represented by the commits |
+
+Correctness claims require regression evidence or a source-traced proof with an explicit limitation. Performance claims require before/after measurements with the workload and lifecycle stated. Upstream-fidelity claims require the exact upstream diff and an explanation of retained local adaptations.
+
+## Review, credit, and integration
+
+Contributors may use the normal fork and pull-request flow. Submission is a proposal: passing checks do not guarantee merge, and a merged change does not by itself authorize a release.
+
+| Stage | Project expectation |
+|---|---|
+| Review | Maintainers read the complete diff and revalidate important paths against the current base |
+| Authorship | Rebase-and-merge preserves contributor authorship; no `Co-Authored-By` trailer is required |
+| Credit | Public credit follows actual code, reproduction, logs, or root-cause evidence and names contributors by GitHub handle |
+| Integration | Maintainers control merge or fast-forward changes into `main` |
+| Release | Tags, GitHub Releases, appcast changes, Homebrew updates, and published assets remain maintainer-controlled |
+
+## Public repository safety
+
+Public issues, pull requests, fixtures, and documentation must contain only sanitized, reproducible evidence. If a reproduction depends on private session data, replace it with the smallest hermetic synthetic fixture that preserves the triggering shape.
+
+| Material | Public-safe treatment |
+|---|---|
+| Credentials, tokens, keys, or signed private material | Never commit, paste, or include them in logs or screenshots |
+| Personal session content or account data | Replace with a synthetic fixture and non-identifying values |
+| Personal absolute paths, private hosts, or machine-specific tooling | Use repository-relative paths, documented product-relative paths, placeholders, or omit the detail |
+| Machine-local instructions | Keep them outside the tracked repository; they are not project facts |
+| Unpublished or sensitive work | Describe only the sanitized project conclusion appropriate for a public repository |

--- a/README.md
+++ b/README.md
@@ -82,14 +82,19 @@ Swift as a C-ABI staticlib (`crates/tb_core_ffi`). Swift owns the rest: SwiftUI
 views, the `NSStatusItem` shell, Sparkle updates.
 
 ```sh
-make        # cargo build --release, then swift build
-make run    # build + run the smoke binary
+make                        # cargo build --release, then swift build
+make run                    # build + launch TokenBar
+swift run TokenBar --smoke  # run the FFI smoke test
 ```
 
-For maintainers and coding agents, the [project knowledge base](docs/knowledge/README.md) is the canonical guide to the Rust-to-Swift architecture, verification gates, vendor boundary, release chain, and maintenance state.
+The [project knowledge base](docs/knowledge/README.md) is the canonical guide to the Rust-to-Swift architecture, verification gates, vendor boundary, release chain, and maintenance state.
 
 > Run `swift build` from the repo root — the linker's `-L target/release` path
 > in `Package.swift` is relative.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, change-specific guardrails, verification, and pull-request requirements.
 
 ## Credits
 

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -4,8 +4,8 @@ id: kb-index
 kind: index
 scope: repository
 read_when: before any TokenBar task or handoff
-last_verified: 2026-07-14
-sources: ["README.md", "AGENTS.md", "Makefile", "Package.swift", ".github/workflows/ci.yml", ".github/workflows/pages.yml", ".github/workflows/release.yml", ".github/workflows/update-install-count.yml"]
+last_verified: 2026-07-15
+sources: ["README.md", "CONTRIBUTING.md", "AGENTS.md", "Makefile", "Package.swift", ".github/workflows/ci.yml", ".github/workflows/pages.yml", ".github/workflows/release.yml", ".github/workflows/update-install-count.yml"]
 ---
 
 # TokenBar project knowledge
@@ -13,6 +13,8 @@ sources: ["README.md", "AGENTS.md", "Makefile", "Package.swift", ".github/workfl
 ## 文件目的
 
 這份索引是 TokenBar 的 canonical project knowledge entry point。它把架構、工作流程、驗證、vendored tokscale、發版、溝通、目前狀態與歷史決策分開保存，讓人類維護者與不同 coding client 都能從同一份 project-owned source 接手。
+
+公開 contributor 從 [`CONTRIBUTING.md`](../../CONTRIBUTING.md) 進入；該文件負責 onboarding、穩定 guardrail 與任務路由，技術與流程事實仍由本 knowledge tree 擁有。
 
 > Adapters 只負責 routing、invariants、authorization 與 private boundary。若一條規則需要在多個 client 之間一致，請改 canonical document，不要在 adapter 內複製一份。
 
@@ -46,6 +48,7 @@ sources: ["README.md", "AGENTS.md", "Makefile", "Package.swift", ".github/workfl
 ```text
 AGENTS.md
 CLAUDE.md
+CONTRIBUTING.md
 vendor/AGENTS.md
 landing/AGENTS.md
 docs/knowledge/
@@ -81,6 +84,7 @@ docs/knowledge/
 | `Makefile` | Local build order and stale Rust static-library relink guard |
 | `Package.swift` | SwiftPM targets and linker contract |
 | `README.md` | Product-facing description and install path |
+| `CONTRIBUTING.md` | Public contributor onboarding, stable guardrails, and routes to canonical and execution sources |
 | `docs/knowledge/` | Human-readable synthesis of durable project facts and decisions |
 | `.agent-local/` | Optional machine-local overlay; never a public source of project facts |
 

--- a/scripts/check_knowledge.py
+++ b/scripts/check_knowledge.py
@@ -154,7 +154,7 @@ def validate(root):
                     if slug(anchor) not in aset: errors.append(Issue(rel,number,f'missing heading anchor #{anchor} in {target.relative_to(root)}'))
         errors += scan_text(rel,text)
     # Adapters are part of the same contract, not just knowledge documents.
-    adapter_paths.update(p for p in files if p.name in ('AGENTS.md','CLAUDE.md'))
+    adapter_paths.update(p for p in files if p.name in ('AGENTS.md','CLAUDE.md','CONTRIBUTING.md'))
     for p in sorted(adapter_paths): errors += check_adapter(root,p)
     claude=root/'CLAUDE.md'
     if claude.exists() and not claude.is_symlink() and not re.search(r'(?:AGENTS\.md|docs/knowledge(?:/README\.md)?)',claude.read_text(encoding='utf-8'),re.I):
@@ -291,6 +291,9 @@ def self_test():
         def test_root_adapter_contract(self):
             r=self.root(); (r/'CLAUDE.md').write_text('[missing](nope.md) /Users/local/file')
             s='\n'.join(map(str,validate(r))); self.assertIn('missing adapter link target',s); self.assertIn('machine-local path',s); self.assertIn('root CLAUDE.md must route',s)
+        def test_contributing_adapter_contract(self):
+            r=self.root(); (r/'CONTRIBUTING.md').write_text('[Knowledge](docs/knowledge/README.md) [missing](nope.md) /Users/local/file')
+            s='\n'.join(map(str,validate(r))); self.assertIn('CONTRIBUTING.md:1: missing adapter link target',s); self.assertIn('CONTRIBUTING.md:1: machine-local path',s)
         def test_linux_home_path(self):
             r=self.root(); (r/'CLAUDE.md').write_text('See AGENTS.md /home/alice/workspace/file')
             self.assertIn('machine-local path','\n'.join(map(str,validate(r))))


### PR DESCRIPTION
## Summary

- add a public `CONTRIBUTING.md` that routes contributors to the canonical knowledge base
- document the supported development entry points, change-specific guardrails, verification expectations, and pull-request contract
- correct the README description of `make run` and add the explicit FFI smoke command
- register the contributor guide in the knowledge index and validate it as a routing adapter

## Why

The repository already had canonical architecture, workflow, verification, vendor, release, and communication contracts, but no human-facing contribution entry point. The README also described `make run` as a smoke command even though the Makefile launches TokenBar.

This keeps contributor onboarding thin and public while linking durable or change-prone facts back to their canonical sources.

## Impact

Contributors get one discoverable workflow for preparing changes and evidence. The knowledge validator now checks `CONTRIBUTING.md` links and public-path safety alongside the existing adapters.

## Validation

- `python3 scripts/check_knowledge.py --self-test` — 20 tests passed
- `python3 -m py_compile scripts/check_knowledge.py`
- `python3 scripts/check_knowledge.py`
- `make check-docs`
- `git diff --check origin/main...HEAD`

## Scope

Documentation and documentation validation only. No runtime behavior, release state, or private overlay material changed.