### PR TITLE
fix(quota): preserve delimiters in card selections

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -523,7 +523,8 @@ enum SelfTest {
         {"generatedAt":"now","agents":[
           {"clientId":"codex","source":"oauth","updatedAt":"now",
            "windows":[{"cardId":"session.v1","label":"Session","usedPercent":20,"remainingPercent":80},
-                      {"cardId":"weekly.v1","label":"Weekly","usedPercent":65,"remainingPercent":35}]},
+                      {"cardId":"weekly.v1","label":"Weekly","usedPercent":65,"remainingPercent":35},
+                      {"cardId":"model.gpt|preview.v1","label":"Delimiter","usedPercent":5,"remainingPercent":95}]},
           {"clientId":"claude","source":"oauth","updatedAt":"now",
            "windows":[{"cardId":"session.v1","label":"Session","usedPercent":88,"remainingPercent":12},
                       {"cardId":"weekly.v1","label":"Weekly","usedPercent":10,"remainingPercent":90}]},
@@ -541,6 +542,15 @@ enum SelfTest {
         expect(
             QuotaResolver.selection(clientId: "codex", cardId: "weekly.v1") == "codex|weekly.v1",
             "canonical selection stores cardId")
+        let delimiterSelection = QuotaResolver.selection(
+            clientId: "codex", cardId: "model.gpt|preview.v1")
+        expect(
+            delimiterSelection == "codex|model.gpt|preview.v1"
+                && QuotaResolver.canonicalSelection(
+                    payload: quotaPayload, selection: delimiterSelection) == delimiterSelection
+                && QuotaResolver.resolve(payload: quotaPayload, selection: delimiterSelection)?
+                    .window.cardId == "model.gpt|preview.v1",
+            "card selection preserves delimiters inside cardId")
         expect(
             QuotaResolver.canonicalSelection(payload: quotaPayload, selection: "codex|Weekly")
                 == "codex|weekly.v1"
@@ -567,14 +577,24 @@ enum SelfTest {
             "temporarily absent explicit client stays selected instead of following Auto")
         expect(
             QuotaResolver.canonicalSelection(payload: quotaPayload, selection: "codex|Weekly|extra")
-                == QuotaResolver.auto,
-            "malformed selection normalizes to Auto")
+                == "codex|Weekly|extra"
+                && QuotaResolver.resolve(
+                    payload: quotaPayload, selection: "codex|Weekly|extra") == nil,
+            "unmatched explicit selection preserves delimiter characters")
         expect(
             QuotaResolver.canonicalSelection(payload: nil, selection: "future|legacy-card.v1")
                 == "future|legacy-card.v1"
                 && QuotaResolver.canonicalSelection(payload: nil, selection: "future|legacy|extra")
+                    == "future|legacy|extra",
+            "payload nil preserves explicit selection delimiters")
+        expect(
+            QuotaResolver.canonicalSelection(payload: quotaPayload, selection: "future")
+                == QuotaResolver.auto
+                && QuotaResolver.canonicalSelection(payload: quotaPayload, selection: "|card")
+                    == QuotaResolver.auto
+                && QuotaResolver.canonicalSelection(payload: quotaPayload, selection: "future|")
                     == QuotaResolver.auto,
-            "payload nil preserves well-formed explicit selection")
+            "structurally malformed selections normalize to Auto")
         expect(QuotaResolver.resolve(payload: nil, selection: "auto") == nil, "no payload, no quota")
 
         let duplicateJSON = """

--- a/Sources/TokenBarCore/QuotaResolver.swift
+++ b/Sources/TokenBarCore/QuotaResolver.swift
@@ -85,7 +85,8 @@ public enum QuotaResolver {
         _ raw: String
     ) -> (clientId: String, value: String)? {
         guard !raw.isEmpty, raw != auto else { return nil }
-        let parts = raw.split(separator: "|", omittingEmptySubsequences: false)
+        let parts = raw.split(
+            separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
         guard parts.count == 2 else { return nil }
         let clientId = String(parts[0])
         let value = String(parts[1])


### PR DESCRIPTION
## Summary

- Split persisted quota selections at the first `|` only.
- Preserve the complete provider-owned card ID remainder, including delimiter characters.
- Update self-tests for exact, unmatched, nil-payload, and structurally malformed selections.

## Context

Follow-up to PR #58 and [review discussion](https://github.com/Nanako0129/TokenBar/pull/58#discussion_r3604044319). Antigravity card IDs embed exact provider model IDs, so treating every `|` as a structural delimiter could canonicalize a valid explicit selection to Auto.

## Verification

- `swift run TokenBar --selftest`
- `git diff --cached --check`