### PR TITLE
fix(ui): clamp popover tooltips with region dodge and live viewport

### DIFF
--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -108,13 +108,24 @@ struct PopoverView: View {
                 .padding(.horizontal, 12)
                 .padding(.bottom, 10)
             Divider()
-            ScrollView {
-                content
-                    .padding(12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(OverlayScrollerEnforcer())
+            GeometryReader { viewport in
+                ScrollView {
+                    content
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(OverlayScrollerEnforcer())
+                }
+                // Live global frame for tooltip clamp. While the height
+                // handle is dragged, publish nil so placement falls back to
+                // the source card only — avoids every-pixel env churn AND a
+                // frozen pre-drag rect that would leave a fake dodge after
+                // the user hovers Models/Usage immediately post-resize.
+                .environment(
+                    \.popoverScrollViewport,
+                    dragBase == nil ? viewport.frame(in: .global) : nil)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
             }
-            .clipped()
             Divider()
             footer
         }

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -1055,6 +1055,87 @@ enum SelfTest {
         expect(shiftedBars.last?.date == "2026-07-05" && (shiftedBars.last?.totalTokens ?? 0) == 0,
             "unfiltered anchor would shift the window past the visible activity")
 
+        // Tooltip placement stays inside the visible ScrollView viewport, not
+        // merely inside the source card. Region-dodge (container 0.45) prefers
+        // above/below by cursor Y; viewport only clamps / rescues.
+        let viewport = CGRect(x: 100, y: 200, width: 400, height: 300)
+        let chartFrame = CGRect(x: 120, y: 250, width: 360, height: 150)
+        let tooltipSize = CGSize(width: 210, height: 120)
+        let belowPlacement = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 30), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: viewport)
+        expect(belowPlacement?.height == 42,
+            "upper-half anchor places tooltip below the cursor")
+        let abovePlacement = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 140), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: viewport)
+        expect(abovePlacement?.height == 8,
+            "lower-half anchor places tooltip above the cursor")
+        // Lower-half region even when the viewport still has room below —
+        // the old "prefer below if fits" path felt like sticky follow.
+        let regionDodge = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 100), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: viewport)
+        expect(regionDodge?.height == -32,
+            "lower-half still dodges above when the viewport has room below")
+        let constrainedPlacement = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 110), tooltipSize: CGSize(width: 210, height: 260),
+            containerFrame: chartFrame, viewport: viewport)
+        expect(constrainedPlacement?.height == -46,
+            "tooltip clamps to the side with more visible space")
+        let edgePlacement = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 2, y: 30), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: viewport)
+        expect(edgePlacement?.width == 0,
+            "tooltip clamps a near-edge anchor horizontally")
+        let tallPlacement = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 30), tooltipSize: CGSize(width: 210, height: 400),
+            containerFrame: chartFrame, viewport: viewport)
+        expect(tallPlacement?.height == -46,
+            "viewport-taller tooltip pins to the visible top inset")
+        // Pre-resize viewport that no longer covers the card must not clamp.
+        let staleViewport = CGRect(x: 100, y: 0, width: 400, height: 80)
+        let stalePlacement = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 30), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: staleViewport)
+        let containerOnly = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 30), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: nil)
+        expect(stalePlacement?.height == containerOnly?.height,
+            "stale non-intersecting viewport falls back to container-only")
+        // Pre-resize short viewport that still overlaps the card but leaves
+        // the hover anchor below it (grow handoff) must also fall back.
+        let partialStale = CGRect(x: 100, y: 200, width: 400, height: 80)
+        // chartFrame y=250..400; partialStale y=200..280 intersects the card
+        // but anchor at local y=100 → global y=350 is outside partialStale.
+        let partialPlacement = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 100), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: partialStale)
+        let partialContainerOnly = PopoverTooltipPlacement.offset(
+            anchor: CGPoint(x: 180, y: 100), tooltipSize: tooltipSize,
+            containerFrame: chartFrame, viewport: nil)
+        expect(partialPlacement?.height == partialContainerOnly?.height,
+            "partial-overlap stale viewport that misses the anchor falls back")
+
+        let chartWidth: CGFloat = 360
+        let barGap = UsageChartGeometry.gap
+        let barWidth = (chartWidth - barGap * 2) / 3
+        let firstFrame = UsageChartGeometry.barFrame(index: 0, barWidth: barWidth)
+        let secondFrame = UsageChartGeometry.barFrame(index: 1, barWidth: barWidth)
+        let lastFrame = UsageChartGeometry.barFrame(index: 2, barWidth: barWidth)
+        expect(firstFrame.minX == 0 && secondFrame.minX - firstFrame.maxX == barGap,
+            "chart bar frames start at zero and leave draw gaps")
+        expect(abs(lastFrame.maxX - chartWidth) < 0.0001,
+            "last chart bar frame reaches the trailing edge")
+        // Production hover uses floor(x / stride); gap pixels attach left.
+        let gapX = firstFrame.maxX + barGap / 2
+        expect(UsageChartGeometry.barIndex(atX: gapX, barWidth: barWidth, count: 3) == 0,
+            "gap pixels floor-attach to the left bar")
+        expect(UsageChartGeometry.barIndex(atX: secondFrame.minX, barWidth: barWidth, count: 3) == 1,
+            "bar starts hit their own index")
+        expect(UsageChartGeometry.barIndex(atX: lastFrame.maxX + barGap + 1, barWidth: barWidth, count: 3) == nil,
+            "past the last stride is out of range")
+
         // Synthetic --demo source: one fixture must drive every usage lens,
         // quota card, trace row, tray rate, and year selection without a live
         // FFI call. The fixture itself is the only data definition here.

--- a/Sources/TokenBar/Views/Cards.swift
+++ b/Sources/TokenBar/Views/Cards.swift
@@ -1,6 +1,122 @@
 import SwiftUI
 import TokenBarCore
 
+private struct PopoverScrollViewportKey: EnvironmentKey {
+    static let defaultValue: CGRect? = nil
+}
+
+extension EnvironmentValues {
+    var popoverScrollViewport: CGRect? {
+        get { self[PopoverScrollViewportKey.self] }
+        set { self[PopoverScrollViewportKey.self] = newValue }
+    }
+}
+
+enum PopoverTooltipPlacement {
+    static let edgeInset: CGFloat = 4
+    static let cursorGap: CGFloat = 12
+    /// Local Y ratio inside the source container. Above this, prefer placing
+    /// the tooltip above the cursor (dodge); below it, prefer below. Matches
+    /// the pre-viewport chart dodge (`chartHeight * 0.45`) and Models feel.
+    static let preferAboveRatio: CGFloat = 0.45
+
+    /// Position a tooltip in its local overlay while keeping it inside the
+    /// visible ScrollView viewport. Prefers the side that dodges the cursor
+    /// (region-based), then falls back / clamps so it never sits under the
+    /// footer. Container and viewport share global coordinates; the returned
+    /// offset is local to the container.
+    static func offset(
+        anchor: CGPoint,
+        tooltipSize: CGSize,
+        containerFrame: CGRect,
+        viewport: CGRect?
+    ) -> CGSize? {
+        guard tooltipSize.width > 0, tooltipSize.height > 0 else { return nil }
+
+        let anchorGlobal = CGPoint(
+            x: containerFrame.minX + anchor.x,
+            y: containerFrame.minY + anchor.y)
+
+        // Freshness: continuous hover only fires over the *visible* scroll
+        // area, so a live viewport must contain the anchor (tiny slack for
+        // float edges). Mere container intersection is not enough — a
+        // pre-resize short viewport can still overlap the card while the
+        // newly exposed hover point sits below it, inventing a fake dodge.
+        let viewport: CGRect = {
+            guard let candidate = viewport, !candidate.isEmpty else { return containerFrame }
+            let slack: CGFloat = 2
+            if candidate.insetBy(dx: -slack, dy: -slack).contains(anchorGlobal) {
+                return candidate
+            }
+            return containerFrame
+        }()
+        guard !viewport.isEmpty else { return nil }
+        let visible = viewport.insetBy(dx: edgeInset, dy: edgeInset)
+        guard visible.width > 0, visible.height > 0 else { return nil }
+        let horizontalMin = max(containerFrame.minX, visible.minX)
+        let horizontalMax = min(containerFrame.maxX, visible.maxX)
+        guard horizontalMax > horizontalMin else { return nil }
+
+        let maxX = horizontalMax - tooltipSize.width
+        let originX = maxX >= horizontalMin
+            ? min(max(anchorGlobal.x - tooltipSize.width / 2, horizontalMin), maxX)
+            : horizontalMin
+
+        let minY = visible.minY
+        let maxY = visible.maxY - tooltipSize.height
+        let belowY = anchorGlobal.y + cursorGap
+        let aboveY = anchorGlobal.y - tooltipSize.height - cursorGap
+        // Region dodge uses the source container (chart / rows), not the
+        // full scroll viewport — "below if the viewport still has room"
+        // always wins on a tall popover and feels like sticky follow.
+        let preferBelow = containerFrame.height > 0
+            ? anchor.y < containerFrame.height * preferAboveRatio
+            : true
+        let originY: CGFloat
+        if tooltipSize.height >= visible.height {
+            originY = minY
+        } else if preferBelow {
+            if belowY <= maxY {
+                originY = max(belowY, minY)
+            } else if aboveY >= minY {
+                originY = min(aboveY, maxY)
+            } else {
+                originY = clampedPreferredY(
+                    belowY: belowY, aboveY: aboveY,
+                    anchorGlobalY: anchorGlobal.y,
+                    minY: minY, maxY: maxY, visible: visible)
+            }
+        } else if aboveY >= minY {
+            originY = min(aboveY, maxY)
+        } else if belowY <= maxY {
+            originY = max(belowY, minY)
+        } else {
+            originY = clampedPreferredY(
+                belowY: belowY, aboveY: aboveY,
+                anchorGlobalY: anchorGlobal.y,
+                minY: minY, maxY: maxY, visible: visible)
+        }
+
+        return CGSize(
+            width: originX - containerFrame.minX,
+            height: originY - containerFrame.minY)
+    }
+
+    private static func clampedPreferredY(
+        belowY: CGFloat,
+        aboveY: CGFloat,
+        anchorGlobalY: CGFloat,
+        minY: CGFloat,
+        maxY: CGFloat,
+        visible: CGRect
+    ) -> CGFloat {
+        let belowSpace = visible.maxY - anchorGlobalY
+        let aboveSpace = anchorGlobalY - visible.minY
+        let preferred = belowSpace >= aboveSpace ? belowY : aboveY
+        return min(max(preferred, minY), maxY)
+    }
+}
+
 /// Liquid Glass card surface on macOS 26+, material fallback below — the
 /// glass lives on the cards themselves (the Control Center look), not on a
 /// backdrop hidden behind opaque fills.

--- a/Sources/TokenBar/Views/ModelBreakdownCard.swift
+++ b/Sources/TokenBar/Views/ModelBreakdownCard.swift
@@ -15,6 +15,7 @@ struct ModelBreakdownCard: View {
     @State private var expanded = false
     @State private var hover: HoverState?
     @State private var tooltipSize: CGSize = .zero
+    @Environment(\.popoverScrollViewport) private var popoverScrollViewport
 
     private struct HoverState {
         let entry: ModelReportEntry
@@ -75,9 +76,21 @@ struct ModelBreakdownCard: View {
                 .overlay(alignment: .topLeading) {
                     if let hover {
                         GeometryReader { geo in
+                            let measuredSize = tooltipSize == .zero
+                                ? CGSize(width: Self.tooltipWidth, height: 120)
+                                : tooltipSize
+                            let offset = PopoverTooltipPlacement.offset(
+                                anchor: hover.point,
+                                tooltipSize: measuredSize,
+                                containerFrame: geo.frame(in: .global),
+                                viewport: popoverScrollViewport)
                             tooltip(hover.entry)
-                                .offset(tooltipOffset(point: hover.point, container: geo.size))
+                                .offset(offset ?? .zero)
                         }
+                        // GeometryReader fills the rows; keep hits on the rows
+                        // so continuous hover does not end while the tooltip
+                        // is up.
+                        .allowsHitTesting(false)
                     }
                 }
                 let hidden = rows.count - min(rows.count, Self.maxRows)
@@ -91,6 +104,7 @@ struct ModelBreakdownCard: View {
                 }
             }
         }
+        .zIndex(hover == nil ? 0 : 1)
     }
 
     private var legend: some View {
@@ -166,22 +180,6 @@ struct ModelBreakdownCard: View {
 
     // MARK: - Hover tooltip
 
-    /// Keep the tooltip inside the card horizontally; flip above the cursor
-    /// for rows past the first few so it never clips out the card's bottom.
-    private func tooltipOffset(point: CGPoint, container: CGSize) -> CGSize {
-        let x = min(max(point.x - Self.tooltipWidth / 2, 0), max(0, container.width - Self.tooltipWidth))
-        let height = tooltipSize.height > 0 ? tooltipSize.height : 120
-        let y = point.y > 110 ? point.y - height - 10 : point.y + 14
-        return CGSize(width: x, height: y)
-    }
-
-    private struct TooltipSizeKey: PreferenceKey {
-        static let defaultValue: CGSize = .zero
-        static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-            value = nextValue()
-        }
-    }
-
     /// True token counts and linear shares per category — the bar itself is
     /// sqrt-scaled, so this is where the real numbers live.
     private func tooltip(_ entry: ModelReportEntry) -> some View {
@@ -225,11 +223,7 @@ struct ModelBreakdownCard: View {
         .frame(width: Self.tooltipWidth, alignment: .leading)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.quaternary))
-        .background(
-            GeometryReader { geo in
-                Color.clear.preference(key: TooltipSizeKey.self, value: geo.size)
-            })
-        .onPreferenceChange(TooltipSizeKey.self) { tooltipSize = $0 }
+        .onGeometryChange(for: CGSize.self) { $0.size } action: { tooltipSize = $0 }
         .allowsHitTesting(false)
     }
 }

--- a/Sources/TokenBar/Views/UsageChartCard.swift
+++ b/Sources/TokenBar/Views/UsageChartCard.swift
@@ -1,6 +1,30 @@
 import SwiftUI
 import TokenBarCore
 
+/// Pure chart geometry shared by canvas, hover hit math, and selftests.
+/// Kept outside `UsageChartCard` so tests do not hit View MainActor isolation.
+enum UsageChartGeometry {
+    static let chartHeight: CGFloat = 150
+    static let gap: CGFloat = 3
+
+    static func barFrame(index: Int, barWidth: CGFloat) -> CGRect {
+        CGRect(
+            x: CGFloat(index) * (barWidth + gap),
+            y: 0,
+            width: barWidth,
+            height: chartHeight)
+    }
+
+    /// Floor-division hit index (pre-change). Gap pixels attach to the left
+    /// bar; points past the last stride are out of range.
+    static func barIndex(atX x: CGFloat, barWidth: CGFloat, count: Int) -> Int? {
+        guard count > 0, barWidth > 0, x >= 0 else { return nil }
+        let stride = barWidth + gap
+        let index = Int(x / stride)
+        return (0..<count).contains(index) ? index : nil
+    }
+}
+
 /// The "Token Usage" card, port of UsageBarGraph2D.tsx: trailing-30-day
 /// stacked bars (Model/Agent stacking, Tokens/Price metric, wrapping legend,
 /// rich hover tooltip) toggling with the full-year 3D contribution grid.
@@ -19,12 +43,11 @@ struct UsageChartCard: View {
     /// "2d" = trailing-30-day stacked bars, "3d" = full-year contribution grid.
     @AppStorage("tokenbar.chart.view") private var chartViewRaw = "2d"
     @State private var hoverIndex: Int?
-    @State private var hoverY: CGFloat = 0
+    @State private var hoverPoint: CGPoint = .zero
     @State private var tooltipSize: CGSize = .zero
+    @Environment(\.popoverScrollViewport) private var popoverScrollViewport
 
     private static let legendMax = 12
-    private static let chartHeight: CGFloat = 150
-    private static let gap: CGFloat = 3
 
     private var stackBy: StackBy { StackBy(rawValue: stackByRaw) ?? .model }
     private var metric: ChartMetric { ChartMetric(rawValue: metricRaw) ?? .tokens }
@@ -43,6 +66,9 @@ struct UsageChartCard: View {
     var body: some View {
         let bars = self.bars
         let legend = DayBars.legend(bars: bars, metric: metric)
+        let showsTooltip = hoverIndex.map {
+            bars.indices.contains($0) && !bars[$0].isEmpty
+        } ?? false
         DashCard(
             "Token Usage",
             subtitle: is3D
@@ -71,6 +97,7 @@ struct UsageChartCard: View {
                 }
             }
         }
+        .zIndex(showsTooltip ? 1 : 0)
     }
 
     // MARK: - Header toggles
@@ -153,36 +180,51 @@ struct UsageChartCard: View {
     private func chart(_ bars: [DayBar]) -> some View {
         GeometryReader { geo in
             let width = geo.size.width
-            let barWidth = (width - Self.gap * CGFloat(bars.count - 1)) / CGFloat(bars.count)
+            let barWidth = (width - UsageChartGeometry.gap * CGFloat(max(bars.count - 1, 0)))
+                / CGFloat(max(bars.count, 1))
             let maxValue = max(bars.map(barTotal).max() ?? 1, metric == .cost ? 0.000001 : 1)
+            // Anchor X on the bar center (pre-change feel); Y tracks the
+            // cursor so region-dodge can flip above/below inside the chart.
+            let anchor: CGPoint = {
+                guard let index = hoverIndex, bars.indices.contains(index) else {
+                    return hoverPoint
+                }
+                let frame = UsageChartGeometry.barFrame(index: index, barWidth: barWidth)
+                return CGPoint(x: frame.midX, y: hoverPoint.y)
+            }()
 
             ZStack(alignment: .topLeading) {
                 canvas(bars: bars, barWidth: barWidth, maxValue: maxValue)
                 if let index = hoverIndex, bars.indices.contains(index),
                    !bars[index].isEmpty {
-                    // Dodge the cursor like the model-card tooltip: below the
-                    // pointer in the chart's upper half, above it lower down —
-                    // pinning to the top kept covering the hovered area.
+                    let measuredSize = tooltipSize == .zero
+                        ? CGSize(width: Self.tooltipWidth, height: 120)
+                        : tooltipSize
+                    let offset = PopoverTooltipPlacement.offset(
+                        anchor: anchor,
+                        tooltipSize: measuredSize,
+                        containerFrame: geo.frame(in: .global),
+                        viewport: popoverScrollViewport)
                     tooltip(bars[index])
-                        .offset(
-                            x: tooltipX(index: index, barWidth: barWidth, width: width),
-                            y: hoverY < Self.chartHeight * 0.45
-                                ? hoverY + 16
-                                : hoverY - (tooltipSize.height > 0 ? tooltipSize.height : 120) - 12)
+                        .offset(offset ?? .zero)
                 }
             }
+            // One continuous hover on the chart (not per-bar) — smoother and
+            // matches the pre-change dodge path. Gap pixels attach to the
+            // left bar via floor division (see `UsageChartGeometry.barIndex`).
+            .contentShape(Rectangle())
             .onContinuousHover { phase in
                 switch phase {
                 case let .active(point):
-                    let index = Int(point.x / (barWidth + Self.gap))
-                    hoverIndex = bars.indices.contains(index) ? index : nil
-                    hoverY = point.y
+                    hoverIndex = UsageChartGeometry.barIndex(
+                        atX: point.x, barWidth: barWidth, count: bars.count)
+                    hoverPoint = point
                 case .ended:
                     hoverIndex = nil
                 }
             }
         }
-        .frame(height: Self.chartHeight)
+        .frame(height: UsageChartGeometry.chartHeight)
     }
 
     private func canvas(bars: [DayBar], barWidth: CGFloat, maxValue: Double) -> some View {
@@ -194,11 +236,11 @@ struct UsageChartCard: View {
                 with: .color(.secondary.opacity(0.3)))
 
             for (index, bar) in bars.enumerated() {
-                let x = CGFloat(index) * (barWidth + Self.gap)
+                let frame = UsageChartGeometry.barFrame(index: index, barWidth: barWidth)
                 let total = barTotal(bar)
                 if total <= 0 {
                     context.fill(
-                        Path(roundedRect: CGRect(x: x, y: bottom - 2, width: barWidth, height: 2),
+                        Path(roundedRect: CGRect(x: frame.minX, y: bottom - 2, width: barWidth, height: 2),
                              cornerRadius: 1),
                         with: .color(.secondary.opacity(0.15)))
                     continue
@@ -210,7 +252,7 @@ struct UsageChartCard: View {
                     guard h > 0 else { continue }
                     y -= h
                     context.fill(
-                        Path(roundedRect: CGRect(x: x, y: y, width: barWidth, height: h),
+                        Path(roundedRect: CGRect(x: frame.minX, y: y, width: barWidth, height: h),
                              cornerRadius: min(2, h / 2)),
                         with: .color(Color(hex: segment.color).opacity(0.86)))
                 }
@@ -235,11 +277,6 @@ struct UsageChartCard: View {
     // MARK: - Tooltip
 
     private static let tooltipWidth: CGFloat = 210
-
-    private func tooltipX(index: Int, barWidth: CGFloat, width: CGFloat) -> CGFloat {
-        let center = CGFloat(index) * (barWidth + Self.gap) + barWidth / 2
-        return min(max(center - Self.tooltipWidth / 2, 0), width - Self.tooltipWidth)
-    }
 
     private func tooltip(_ bar: DayBar) -> some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -269,18 +306,7 @@ struct UsageChartCard: View {
         .frame(width: Self.tooltipWidth, alignment: .leading)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.quaternary))
-        .background(
-            GeometryReader { geo in
-                Color.clear.preference(key: TooltipSizeKey.self, value: geo.size)
-            })
-        .onPreferenceChange(TooltipSizeKey.self) { tooltipSize = $0 }
+        .onGeometryChange(for: CGSize.self) { $0.size } action: { tooltipSize = $0 }
         .allowsHitTesting(false)
-    }
-
-    private struct TooltipSizeKey: PreferenceKey {
-        static let defaultValue: CGSize = .zero
-        static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-            value = nextValue()
-        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes Token Usage (2D) and Models popover rich tooltips that could sit under the footer or liquid-glass siblings, stick under the cursor, or show a **fake dodge position** right after resizing the popover then hovering.

- Shared `PopoverTooltipPlacement`: region-based dodge (prefer above when the anchor is in the lower ~45% of the source container) plus clamp to the visible ScrollView viewport in global coordinates.
- Viewport freshness: accept the published scroll viewport only when it **contains the hover anchor** (2pt slack); partial-overlap pre-resize rects fall back to container-only so grow handoff cannot invent a dodge.
- While the height handle is dragging, publish `nil` viewport (no thrash, no frozen pre-drag rect); live frame resumes when the drag ends.
- Usage chart: one continuous hover (smoother), bar-center X, floor-division gap hit via `UsageChartGeometry.barIndex`.
- Models / Usage: raise `zIndex` while a tooltip is open; Models overlay `GeometryReader` is non-hit-testing so row hover does not flicker.

## Verification

- `swift build` (fix-hover-tooltips worktree)
- `TokenBar --selftest` green (placement, disjoint + partial-overlap stale viewport, floor-hit gaps)
- Local adversarial + Codex R2 (`gpt-5.6-sol` high): **approve**, 0 findings
- Manual: post-resize immediate hover no longer shows residual fake dodge (user-confirmed)

## Scope

Swift UI only — five files under `Sources/TokenBar/`. No vendor / cache schema / FFI changes.