### PR TITLE
fix(popover): prevent reentrant resize crash and normalize quota bars

### DIFF
--- a/Sources/TokenBar/StatusItemController.swift
+++ b/Sources/TokenBar/StatusItemController.swift
@@ -65,7 +65,13 @@ final class StatusItemController: NSObject {
         defaultsObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification, object: nil, queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.chrome.reloadFromDefaults() }
+            // macOS can post this synchronously from registerDefaults() while
+            // SwiftUI is laying out a newly opened popover. Resizing in that
+            // AttributeGraph transaction aborts the process, so apply the
+            // value-gated reload on the next main-queue turn.
+            DispatchQueue.main.async { [weak self] in
+                MainActor.assumeIsolated { self?.chrome.reloadFromDefaults() }
+            }
         }
 
         if let button = statusItem.button {

--- a/Sources/TokenBar/Views/AgentLimitsCard.swift
+++ b/Sources/TokenBar/Views/AgentLimitsCard.swift
@@ -570,10 +570,14 @@ struct AgentLimitsCard: View {
     ) -> some View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
-                Capsule().fill(.quaternary.opacity(0.6))
+                Capsule()
+                    .fill(.quaternary.opacity(0.6))
+                    .frame(height: geo.size.height)
                 Capsule()
                     .fill(color.opacity(0.85))
-                    .frame(width: geo.size.width * fillPercent / 100)
+                    .frame(
+                        width: geo.size.width * fillPercent / 100,
+                        height: geo.size.height)
                 if let paceLeft {
                     RoundedRectangle(cornerRadius: 0.75)
                         .fill(paceIsDeficit ? Color.orange : Color.secondary)


### PR DESCRIPTION
## Summary

- Defer defaults-driven popover height reloads to the next main-queue turn so AppKit cannot resize the `NSPopover` from inside an active SwiftUI `AttributeGraph` render transaction.
- Keep quota bars at a consistent six-point thickness whether or not a taller pace marker is present.

## Root cause

Four matching TokenBar 1.6.1 crash reports on macOS 26.5.2 showed `AG::precondition_failure` after AppKit lazily called `NSUserDefaults.registerDefaults()` during initial popover text layout. That synchronous `didChangeNotification` entered `PopoverChrome.reloadFromDefaults()`; when a saved height required normalization, the resize callback changed `popover.contentSize` while SwiftUI was still rendering and aborted the process with `SIGABRT`.

Opening the right-click quota menu first avoided the crash because `NSMenu` initialized the AppKit text path outside the SwiftUI transaction. The observer now preserves its existing value gate but schedules the reload for the next main-queue turn, removing that initialization-order dependency.

The quota-bar mismatch had a separate SwiftUI sizing cause: the ten-point pace marker became the `ZStack`'s tallest child, so unconstrained capsules expanded from six to ten points. Explicit capsule heights preserve the marker overhang without changing the horizontal bar.

## Verification

| Check | Result |
|---|---|
| `swift build --target TokenBar` | Passed |
| `swift run TokenBar --selftest` | Passed |
| Crash-report stack comparison | Four reports had the same AttributeGraph abort signature |
| Fresh adversarial verification | Confirmed |
| `git diff --check origin/main...HEAD` | Passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
