### PR TITLE
chore(release): prepare v1.6.2 notes

### DIFF
--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -1,8 +1,4 @@
-## Highlights
-
-- **Popover tooltips stay readable.** Token Usage (2D) and Models rich tooltips clamp inside the visible popover scroll area so they no longer sit under the footer or liquid-glass cards, restore cursor dodge (prefer above the pointer in the lower half of the source card), and stop inventing a fake dodge position right after you resize the popover height then hover again. [#78](https://github.com/Nanako0129/TokenBar/pull/78)
-
 ## Fixes
 
-- **Tooltip layering and hit testing.** Open tooltips raise above neighboring glass cards; Models overlay geometry no longer steals hover from the row underneath.
-- **Resize then hover.** Live scroll-viewport coordinates (with anchor-based freshness) replace a frozen pre-drag rect so post-resize hover placement matches the new height.
+- **Opening the popover no longer crashes the app.** Some users updating to v1.6.1 could see TokenBar quit immediately when opening the popover. Height synchronization now waits until the current layout is complete. [#80](https://github.com/Nanako0129/TokenBar/pull/80)
+- **Quota bars keep a consistent thickness.** Rows without a pace marker no longer appear thinner than rows with one.

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -1,6 +1,3 @@
-Improved:
-- Token Usage (2D) and Models popover tooltips clamp inside the visible scroll area, dodge the cursor again, and stay above liquid-glass cards so they no longer hide under the footer or neighboring cards.
-
 Fixes:
-- Resizing the popover height then hovering no longer leaves a fake tooltip dodge from a stale viewport.
-- Models tooltip overlay no longer steals hover from the row underneath.
+- Opening the popover no longer causes TokenBar to quit on some installations after v1.6.1.
+- Quota bars now keep a consistent thickness whether or not a pace marker is available.


### PR DESCRIPTION
## Summary

- replace the v1.6.1 release-note overrides with the v1.6.2 hotfix notes
- describe the popover crash fix from #80 and the quota-bar thickness correction consistently across GitHub, Sparkle, appcast.xml, and latest.json
- keep both published formats deterministic by using the committed Markdown and plain-text overrides

## Verification

- `git diff --check`
- confirmed the Markdown and plain-text overrides carry the same two user-visible fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)