### PR TITLE
feat(ui): improve model hover visibility

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -923,8 +923,11 @@ enum SelfTest {
             "empty client selection shows no months")
         let mSlices = MonthlyView.modelSlices(
             for: mRows[0], clientIds: ["a"], colors: ModelColorMap(report: nil))
-        expect(mSlices.count == 1 && mSlices[0].key == "m1|p" && mSlices[0].tokens == .max,
-            "drill-down merges the month's model slices across days with saturation")
+        expect(
+            mSlices.count == 1 && mSlices[0].key == "m1|p"
+                && mSlices[0].tokens == .max && mSlices[0].input == .max
+                && mSlices[0].output == 0,
+            "drill-down merges the month's model token lanes across days with saturation")
         expect(MonthlyView.modelSlices(
                 for: mRows[0], clientIds: ["a", "b"], colors: ModelColorMap(report: nil)).count == 2,
             "drill-down shows client b's model when b is selected")
@@ -1135,6 +1138,15 @@ enum SelfTest {
             "bar starts hit their own index")
         expect(UsageChartGeometry.barIndex(atX: lastFrame.maxX + barGap + 1, barWidth: barWidth, count: 3) == nil,
             "past the last stride is out of range")
+
+        let modelWidths = ModelBarGeometry.widths(
+            values: [1_000_000, 1, 1, 1, 1], totalWidth: 120)
+        let renderedModelWidth = modelWidths.reduce(0, +)
+            + ModelBarGeometry.gap * CGFloat(modelWidths.count - 1)
+        expect(
+            abs(renderedModelWidth - 120) < 0.0001
+                && modelWidths.dropFirst().allSatisfy { $0 >= 1 },
+            "model bar widths preserve tiny segments without trailing overflow")
 
         // Synthetic --demo source: one fixture must drive every usage lens,
         // quota card, trace row, tray rate, and year selection without a live

--- a/Sources/TokenBar/Views/DailyView.swift
+++ b/Sources/TokenBar/Views/DailyView.swift
@@ -14,6 +14,9 @@ struct DailyView: View {
     let colors: ModelColorMap
 
     @State private var openDate: String?
+    @State private var hover: HoverState?
+    @State private var tooltipSize: CGSize = .zero
+    @Environment(\.popoverScrollViewport) private var popoverScrollViewport
 
     private struct DayRow {
         let date: String
@@ -28,9 +31,21 @@ struct DailyView: View {
         let model: String
         let provider: String
         let color: String
+        var input: Int64
+        var output: Int64
+        var cacheRead: Int64
+        var cacheWrite: Int64
+        var reasoning: Int64
         var tokens: Int64
         var cost: Double
     }
+
+    private struct HoverState {
+        let slice: ModelSlice
+        let point: CGPoint
+    }
+
+    private static let rowsSpace = "daily-model-rows"
 
     private static func tokenTotal(_ t: TokenBreakdown) -> Int64 {
         // Delegate to the shared saturating sum (was a plain-`+` 4th copy).
@@ -66,7 +81,14 @@ struct DailyView: View {
             let key = "\(model)|\(cc.providerId)"
             var slot = grouped[key] ?? ModelSlice(
                 key: key, model: model, provider: cc.providerId,
-                color: colors.color(cc.providerId, model), tokens: 0, cost: 0)
+                color: colors.color(cc.providerId, model),
+                input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0,
+                tokens: 0, cost: 0)
+            slot.input = slot.input.saturatingAdding(cc.tokens.input)
+            slot.output = slot.output.saturatingAdding(cc.tokens.output)
+            slot.cacheRead = slot.cacheRead.saturatingAdding(cc.tokens.cacheRead)
+            slot.cacheWrite = slot.cacheWrite.saturatingAdding(cc.tokens.cacheWrite)
+            slot.reasoning = slot.reasoning.saturatingAdding(cc.tokens.reasoning)
             slot.tokens = slot.tokens.saturatingAdding(tokens)
             slot.cost += cc.cost
             grouped[key] = slot
@@ -98,12 +120,14 @@ struct DailyView: View {
                 }
             }
         }
+        .zIndex(hover == nil ? 0 : 1)
     }
 
     @ViewBuilder private func dayItem(_ row: DayRow) -> some View {
         let isOpen = openDate == row.date
         VStack(spacing: 4) {
             Button {
+                hover = nil
                 withAnimation(.easeOut(duration: 0.15)) {
                     openDate = isOpen ? nil : row.date
                 }
@@ -134,15 +158,23 @@ struct DailyView: View {
             if isOpen {
                 VStack(spacing: 4) {
                     ForEach(models(for: row.contribution), id: \.key) { slice in
+                        let isHovered = hover?.slice.key == slice.key
                         HStack(spacing: 8) {
                             Circle()
                                 .fill(Color(hex: slice.color))
                                 .frame(width: 6, height: 6)
+                                .overlay {
+                                    Circle().stroke(
+                                        Color.primary.opacity(isHovered ? 0.85 : 0),
+                                        lineWidth: 1)
+                                }
+                                .shadow(
+                                    color: Color.primary.opacity(isHovered ? 0.65 : 0),
+                                    radius: isHovered ? 3 : 0)
                             Text(slice.model)
                                 .font(.caption2)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
-                                .help("\(slice.model) · \(slice.provider)")
                             Spacer()
                             Text(Format.compactTokens(slice.tokens))
                                 .font(.caption2.monospacedDigit())
@@ -151,11 +183,57 @@ struct DailyView: View {
                                 .font(.caption2.monospacedDigit())
                                 .frame(minWidth: 50, alignment: .trailing)
                         }
+                        .contentShape(Rectangle())
+                        .onContinuousHover(coordinateSpace: .named(Self.rowsSpace)) { phase in
+                            switch phase {
+                            case let .active(point):
+                                hover = HoverState(slice: slice, point: point)
+                            case .ended:
+                                if hover?.slice.key == slice.key {
+                                    hover = nil
+                                }
+                            }
+                        }
+                    }
+                }
+                .coordinateSpace(name: Self.rowsSpace)
+                .overlay(alignment: .topLeading) {
+                    if let hover {
+                        GeometryReader { geo in
+                            let measuredSize = tooltipSize == .zero
+                                ? CGSize(width: ModelUsageTooltip.width, height: 120)
+                                : tooltipSize
+                            let offset = PopoverTooltipPlacement.offset(
+                                anchor: hover.point,
+                                tooltipSize: measuredSize,
+                                containerFrame: geo.frame(in: .global),
+                                viewport: popoverScrollViewport)
+                            tooltip(hover.slice)
+                                .offset(offset ?? .zero)
+                        }
+                        .allowsHitTesting(false)
                     }
                 }
                 .padding(.leading, 18)
                 .padding(.bottom, 6)
             }
         }
+        .zIndex(isOpen ? 1 : 0)
+    }
+
+    private func tooltip(_ slice: ModelSlice) -> some View {
+        ModelUsageTooltip(
+            model: slice.model,
+            provider: slice.provider,
+            context: nil,
+            color: slice.color,
+            input: slice.input,
+            output: slice.output,
+            cacheRead: slice.cacheRead,
+            cacheWrite: slice.cacheWrite,
+            reasoning: slice.reasoning,
+            total: slice.tokens,
+            cost: slice.cost,
+            measuredSize: $tooltipSize)
     }
 }

--- a/Sources/TokenBar/Views/ModelBreakdownCard.swift
+++ b/Sources/TokenBar/Views/ModelBreakdownCard.swift
@@ -1,6 +1,21 @@
 import SwiftUI
 import TokenBarCore
 
+enum ModelBarGeometry {
+    static let gap: CGFloat = 1
+
+    static func widths(values: [Int64], totalWidth: CGFloat) -> [CGFloat] {
+        guard !values.isEmpty, totalWidth > 0 else { return [] }
+        let available = max(0, totalWidth - gap * CGFloat(values.count - 1))
+        let minimum = min(1, available / CGFloat(values.count))
+        let remainder = available - minimum * CGFloat(values.count)
+        let weights = values.map { Double(max(0, $0)).squareRoot() }
+        let totalWeight = weights.reduce(0, +)
+        guard totalWeight > 0 else { return Array(repeating: 0, count: values.count) }
+        return weights.map { minimum + remainder * CGFloat($0 / totalWeight) }
+    }
+}
+
 /// "Models" card: one row per model sorted by cost, with the token-category
 /// split as a stacked bar. Port of ModelBreakdownCard.tsx — bar widths use a
 /// square-root scale (cache reads dwarf everything linearly; log flattens
@@ -24,7 +39,6 @@ struct ModelBreakdownCard: View {
     }
 
     private static let maxRows = 8
-    private static let tooltipWidth: CGFloat = 210
     private static let rowsSpace = "model-rows"
 
     /// Token-category palette (matches the Tauri .model-seg-* CSS classes).
@@ -77,7 +91,7 @@ struct ModelBreakdownCard: View {
                     if let hover {
                         GeometryReader { geo in
                             let measuredSize = tooltipSize == .zero
-                                ? CGSize(width: Self.tooltipWidth, height: 120)
+                                ? CGSize(width: ModelUsageTooltip.width, height: 120)
                                 : tooltipSize
                             let offset = PopoverTooltipPlacement.offset(
                                 anchor: hover.point,
@@ -123,16 +137,25 @@ struct ModelBreakdownCard: View {
     }
 
     private func row(_ entry: ModelReportEntry) -> some View {
-        HStack(spacing: 8) {
+        let isHovered = hover?.entry.rowID == entry.rowID
+        return HStack(spacing: 8) {
             Circle()
                 .fill(Color(hex: colors.color(entry.provider, entry.model)))
                 .frame(width: 8, height: 8)
+                .overlay {
+                    Circle().stroke(
+                        Color.primary.opacity(isHovered ? 0.85 : 0),
+                        lineWidth: 1)
+                }
+                .shadow(
+                    color: Color.primary.opacity(isHovered ? 0.65 : 0),
+                    radius: isHovered ? 3 : 0)
             VStack(alignment: .leading, spacing: 3) {
                 Text(entry.model)
                     .font(.caption)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                segmentBar(entry)
+                segmentBar(entry, isHovered: isHovered)
             }
             Spacer(minLength: 8)
             VStack(alignment: .trailing, spacing: 2) {
@@ -158,24 +181,29 @@ struct ModelBreakdownCard: View {
     }
 
     /// sqrt-scaled stacked category bar.
-    private func segmentBar(_ entry: ModelReportEntry) -> some View {
+    private func segmentBar(_ entry: ModelReportEntry, isHovered: Bool) -> some View {
         let segments = Self.tokenKinds
             .map { (color: $0.color, value: $0.pick(entry)) }
             .filter { $0.value > 0 }
-        let scaleTotal = segments.reduce(0.0) { $0 + Double($1.value).squareRoot() }
         return GeometryReader { geo in
-            HStack(spacing: 1) {
+            let widths = ModelBarGeometry.widths(
+                values: segments.map(\.value), totalWidth: geo.size.width)
+            HStack(spacing: ModelBarGeometry.gap) {
                 ForEach(segments.indices, id: \.self) { i in
                     RoundedRectangle(cornerRadius: 1.5)
                         .fill(Color(hex: segments[i].color))
-                        .frame(
-                            width: scaleTotal > 0
-                                ? max(1, geo.size.width * Double(segments[i].value).squareRoot() / scaleTotal)
-                                : 0)
+                        .frame(width: widths[i])
                 }
             }
         }
         .frame(height: 6)
+        .overlay {
+            RoundedRectangle(cornerRadius: 1.5)
+                .stroke(Color.primary.opacity(isHovered ? 0.85 : 0), lineWidth: 1)
+        }
+        .shadow(
+            color: Color.primary.opacity(isHovered ? 0.65 : 0),
+            radius: isHovered ? 3 : 0)
     }
 
     // MARK: - Hover tooltip
@@ -183,26 +211,67 @@ struct ModelBreakdownCard: View {
     /// True token counts and linear shares per category — the bar itself is
     /// sqrt-scaled, so this is where the real numbers live.
     private func tooltip(_ entry: ModelReportEntry) -> some View {
-        let kinds = Self.tokenKinds
-            .map { (label: $0.label, color: $0.color, value: $0.pick(entry)) }
-            .filter { $0.value > 0 }
-        return VStack(alignment: .leading, spacing: 4) {
+        ModelUsageTooltip(
+            model: entry.model,
+            provider: entry.provider,
+            context: ClientRegistry.style(entry.client).displayName,
+            color: colors.color(entry.provider, entry.model),
+            input: entry.input,
+            output: entry.output,
+            cacheRead: entry.cacheRead,
+            cacheWrite: entry.cacheWrite,
+            reasoning: entry.reasoning,
+            total: entry.total,
+            cost: entry.cost,
+            measuredSize: $tooltipSize)
+    }
+}
+
+struct ModelUsageTooltip: View {
+    static let width: CGFloat = 210
+
+    let model: String
+    let provider: String
+    let context: String?
+    let color: String
+    let input: Int64
+    let output: Int64
+    let cacheRead: Int64
+    let cacheWrite: Int64
+    let reasoning: Int64
+    let total: Int64
+    let cost: Double
+    @Binding var measuredSize: CGSize
+
+    private var kinds: [(label: String, color: String, value: Int64)] {
+        [
+            ("Input", "#3b82f6", input),
+            ("Output", "#22c55e", output),
+            ("Cache read", "#f59e0b", cacheRead),
+            ("Cache write", "#a855f7", cacheWrite),
+            ("Reasoning", "#ec4899", reasoning),
+        ]
+        .filter { $0.value > 0 }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 5) {
                 Circle()
-                    .fill(Color(hex: colors.color(entry.provider, entry.model)))
+                    .fill(Color(hex: color))
                     .frame(width: 6, height: 6)
-                Text(entry.model)
+                Text(model)
                     .font(.caption.weight(.semibold))
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            Text("\(ClientRegistry.style(entry.client).displayName) · \(entry.provider)")
+            Text([context, provider].compactMap { $0 }.joined(separator: " · "))
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
             HStack {
-                Text("\(Format.compactTokens(entry.total)) tokens")
+                Text("\(Format.compactTokens(total)) tokens")
                 Spacer()
-                Text(Format.usd(entry.cost))
+                Text(Format.usd(cost))
             }
             .font(.caption2)
             .foregroundStyle(.secondary)
@@ -213,17 +282,17 @@ struct ModelBreakdownCard: View {
                         .frame(width: 6, height: 6)
                     Text(kind.label)
                     Spacer()
-                    Text("\(Format.compactTokens(kind.value)) · \(Int((Double(kind.value) / Double(max(1, entry.total)) * 100).rounded()))%")
+                    Text("\(Format.compactTokens(kind.value)) · \(Int((Double(kind.value) / Double(max(1, total)) * 100).rounded()))%")
                         .foregroundStyle(.secondary)
                 }
                 .font(.caption2)
             }
         }
         .padding(8)
-        .frame(width: Self.tooltipWidth, alignment: .leading)
+        .frame(width: Self.width, alignment: .leading)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.quaternary))
-        .onGeometryChange(for: CGSize.self) { $0.size } action: { tooltipSize = $0 }
+        .onGeometryChange(for: CGSize.self) { $0.size } action: { measuredSize = $0 }
         .allowsHitTesting(false)
     }
 }

--- a/Sources/TokenBar/Views/MonthlyView.swift
+++ b/Sources/TokenBar/Views/MonthlyView.swift
@@ -17,6 +17,9 @@ struct MonthlyView: View {
     let colors: ModelColorMap
 
     @State private var openMonth: String?
+    @State private var hover: HoverState?
+    @State private var tooltipSize: CGSize = .zero
+    @Environment(\.popoverScrollViewport) private var popoverScrollViewport
 
     struct MonthRow {
         let month: String  // "YYYY-MM"
@@ -31,9 +34,21 @@ struct MonthlyView: View {
         let model: String
         let provider: String
         let color: String
+        var input: Int64
+        var output: Int64
+        var cacheRead: Int64
+        var cacheWrite: Int64
+        var reasoning: Int64
         var tokens: Int64
         var cost: Double
     }
+
+    private struct HoverState {
+        let slice: ModelSlice
+        let point: CGPoint
+    }
+
+    private static let rowsSpace = "monthly-model-rows"
 
     /// Pure bucketing, internal (not private) so SelfTest can pin it.
     static func monthRows(payload: UsagePayload, clientIds: [String]) -> [MonthRow] {
@@ -78,7 +93,14 @@ struct MonthlyView: View {
                 let key = "\(model)|\(cc.providerId)"
                 var slot = grouped[key] ?? ModelSlice(
                     key: key, model: model, provider: cc.providerId,
-                    color: colors.color(cc.providerId, model), tokens: 0, cost: 0)
+                    color: colors.color(cc.providerId, model),
+                    input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0,
+                    tokens: 0, cost: 0)
+                slot.input = slot.input.saturatingAdding(cc.tokens.input)
+                slot.output = slot.output.saturatingAdding(cc.tokens.output)
+                slot.cacheRead = slot.cacheRead.saturatingAdding(cc.tokens.cacheRead)
+                slot.cacheWrite = slot.cacheWrite.saturatingAdding(cc.tokens.cacheWrite)
+                slot.reasoning = slot.reasoning.saturatingAdding(cc.tokens.reasoning)
                 slot.tokens = slot.tokens.saturatingAdding(tokens)
                 slot.cost += cc.cost
                 grouped[key] = slot
@@ -111,12 +133,14 @@ struct MonthlyView: View {
                 }
             }
         }
+        .zIndex(hover == nil ? 0 : 1)
     }
 
     @ViewBuilder private func monthItem(_ row: MonthRow) -> some View {
         let isOpen = openMonth == row.month
         VStack(spacing: 4) {
             Button {
+                hover = nil
                 withAnimation(.easeOut(duration: 0.15)) {
                     openMonth = isOpen ? nil : row.month
                 }
@@ -148,15 +172,23 @@ struct MonthlyView: View {
                 VStack(spacing: 4) {
                     ForEach(Self.modelSlices(for: row, clientIds: clientIds, colors: colors),
                             id: \.key) { slice in
+                        let isHovered = hover?.slice.key == slice.key
                         HStack(spacing: 8) {
                             Circle()
                                 .fill(Color(hex: slice.color))
                                 .frame(width: 6, height: 6)
+                                .overlay {
+                                    Circle().stroke(
+                                        Color.primary.opacity(isHovered ? 0.85 : 0),
+                                        lineWidth: 1)
+                                }
+                                .shadow(
+                                    color: Color.primary.opacity(isHovered ? 0.65 : 0),
+                                    radius: isHovered ? 3 : 0)
                             Text(slice.model)
                                 .font(.caption2)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
-                                .help("\(slice.model) · \(slice.provider)")
                             Spacer()
                             Text(Format.compactTokens(slice.tokens))
                                 .font(.caption2.monospacedDigit())
@@ -165,11 +197,57 @@ struct MonthlyView: View {
                                 .font(.caption2.monospacedDigit())
                                 .frame(minWidth: 50, alignment: .trailing)
                         }
+                        .contentShape(Rectangle())
+                        .onContinuousHover(coordinateSpace: .named(Self.rowsSpace)) { phase in
+                            switch phase {
+                            case let .active(point):
+                                hover = HoverState(slice: slice, point: point)
+                            case .ended:
+                                if hover?.slice.key == slice.key {
+                                    hover = nil
+                                }
+                            }
+                        }
+                    }
+                }
+                .coordinateSpace(name: Self.rowsSpace)
+                .overlay(alignment: .topLeading) {
+                    if let hover {
+                        GeometryReader { geo in
+                            let measuredSize = tooltipSize == .zero
+                                ? CGSize(width: ModelUsageTooltip.width, height: 120)
+                                : tooltipSize
+                            let offset = PopoverTooltipPlacement.offset(
+                                anchor: hover.point,
+                                tooltipSize: measuredSize,
+                                containerFrame: geo.frame(in: .global),
+                                viewport: popoverScrollViewport)
+                            tooltip(hover.slice)
+                                .offset(offset ?? .zero)
+                        }
+                        .allowsHitTesting(false)
                     }
                 }
                 .padding(.leading, 18)
                 .padding(.bottom, 6)
             }
         }
+        .zIndex(isOpen ? 1 : 0)
+    }
+
+    private func tooltip(_ slice: ModelSlice) -> some View {
+        ModelUsageTooltip(
+            model: slice.model,
+            provider: slice.provider,
+            context: nil,
+            color: slice.color,
+            input: slice.input,
+            output: slice.output,
+            cacheRead: slice.cacheRead,
+            cacheWrite: slice.cacheWrite,
+            reasoning: slice.reasoning,
+            total: slice.tokens,
+            cost: slice.cost,
+            measuredSize: $tooltipSize)
     }
 }

--- a/Sources/TokenBar/Views/UsageChartCard.swift
+++ b/Sources/TokenBar/Views/UsageChartCard.swift
@@ -197,6 +197,18 @@ struct UsageChartCard: View {
                 canvas(bars: bars, barWidth: barWidth, maxValue: maxValue)
                 if let index = hoverIndex, bars.indices.contains(index),
                    !bars[index].isEmpty {
+                    let bar = bars[index]
+                    let total = barTotal(bar)
+                    if total > 0 {
+                        let frame = UsageChartGeometry.barFrame(index: index, barWidth: barWidth)
+                        let height = CGFloat(total / maxValue) * (geo.size.height - 8)
+                        RoundedRectangle(cornerRadius: min(2, height / 2))
+                            .stroke(Color.primary.opacity(0.85), lineWidth: 1)
+                            .frame(width: barWidth, height: height)
+                            .position(x: frame.midX, y: geo.size.height - 1 - height / 2)
+                            .shadow(color: Color.primary.opacity(0.65), radius: 3)
+                            .allowsHitTesting(false)
+                    }
                     let measuredSize = tooltipSize == .zero
                         ? CGSize(width: Self.tooltipWidth, height: 120)
                         : tooltipSize
@@ -205,7 +217,7 @@ struct UsageChartCard: View {
                         tooltipSize: measuredSize,
                         containerFrame: geo.frame(in: .global),
                         viewport: popoverScrollViewport)
-                    tooltip(bars[index])
+                    tooltip(bar)
                         .offset(offset ?? .zero)
                 }
             }


### PR DESCRIPTION
## Summary

Improve model usage visibility on dark backgrounds by adding adaptive hover outlines and glow without changing the configured model palette.

- Token Usage bars gain a `Color.primary` outline and glow while preserving the existing continuous-hover tooltip behavior.
- Models rows apply the same treatment to both the model marker and the stacked token-category bar.
- Daily and Monthly model drill-downs gain glowing model markers and the shared rich tooltip with provider, total tokens, cost, and Input, Output, Cache read, Cache write, and Reasoning details.

## Correctness

`ModelBarGeometry` now reserves every one-point segment gap and minimum visible segment width inside the available bar width, so tiny token categories cannot push the rendered tail beyond its outline.

Daily and Monthly drill-downs saturating-fold each token category independently before presentation. Their tooltips reuse the existing viewport-aware placement path, do not intercept pointer events, and elevate the active date or month above sibling rows so the tooltip remains in front of the card content.

## Verification

| Gate | Result |
|---|---|
| `make build` | Passed |
| `swift run TokenBar --selftest` | Passed, including saturated category aggregation and tiny-segment width conservation |
| `swift run TokenBar --smoke` | Passed; tray, hourly, and Agents drift checks matched |
| `git diff --check` | Passed |
| Interactive light/dark hover acceptance | Passed for Token Usage, Models, Daily, and Monthly |
| Fresh outcome verifier | `CONFIRMED` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
