### PR TITLE
chore(release): prepare v1.7.0 notes

### DIFF
--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -1,4 +1,8 @@
-## Fixes
+## Highlights
 
-- **Opening the popover no longer crashes the app.** Some users updating to v1.6.1 could see TokenBar quit immediately when opening the popover. Height synchronization now waits until the current layout is complete. [#80](https://github.com/Nanako0129/TokenBar/pull/80)
-- **Quota bars keep a consistent thickness.** Rows without a pace marker no longer appear thinner than rows with one.
+- **Copilot Desktop usage is now included.** TokenBar reads token-bearing local sessions from Copilot Desktop, preserves model, workspace, and agent attribution, and lets Copilot OTEL remain authoritative when both sources contain the same session. Totals may increase because previously invisible Desktop usage is now counted, not because the update created new spend. [#83](https://github.com/Nanako0129/TokenBar/pull/83)
+- **Model usage is easier to inspect.** Hovered Token Usage and Models bars now gain adaptive outlines and glow in both light and dark appearances. Model markers glow with their rows, and Daily/Monthly drill-downs show detailed Input, Output, Cache read, Cache write, and Reasoning tooltips above neighboring rows. [#88](https://github.com/Nanako0129/TokenBar/pull/88)
+
+## Changes
+
+- **Hermes discovery supports native Windows layouts** for the downstream Windows build while leaving the macOS app unchanged. [#82](https://github.com/Nanako0129/TokenBar/pull/82)

--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -5,4 +5,5 @@
 
 ## Changes
 
+- **Usage caching is now sharded by source identity.** TokenBar replaces the single message cache with bounded per-source shards that isolate parser versions, preserve concurrent updates, and let report paths seed their own cache entries. The first scan after updating starts cold because the legacy cache is intentionally left untouched; later refreshes use the new cache without changing report semantics. [#90](https://github.com/Nanako0129/TokenBar/pull/90)
 - **Hermes discovery supports native Windows layouts** for the downstream Windows build while leaving the macOS app unchanged. [#82](https://github.com/Nanako0129/TokenBar/pull/82)

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -1,3 +1,8 @@
-Fixes:
-- Opening the popover no longer causes TokenBar to quit on some installations after v1.6.1.
-- Quota bars now keep a consistent thickness whether or not a pace marker is available.
+New:
+- Copilot Desktop token-bearing local sessions are now counted with model, workspace, and agent details. Copilot OTEL remains authoritative when both sources contain the same session, so overlapping usage is not counted twice. Totals may increase because previously invisible Desktop usage is now included, not because the update created new spend.
+
+Improved:
+- Hovered Token Usage and Models bars now gain adaptive outlines and glow in light and dark appearances. Model markers glow with their rows, and Daily/Monthly drill-downs show detailed Input, Output, Cache read, Cache write, and Reasoning tooltips above neighboring rows.
+
+Under the hood:
+- Hermes discovery supports native Windows layouts for the downstream Windows build without changing the macOS app.

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -5,4 +5,5 @@ Improved:
 - Hovered Token Usage and Models bars now gain adaptive outlines and glow in light and dark appearances. Model markers glow with their rows, and Daily/Monthly drill-downs show detailed Input, Output, Cache read, Cache write, and Reasoning tooltips above neighboring rows.
 
 Under the hood:
+- Usage caching now uses bounded identity-aware shards instead of one message-cache file. The first scan after updating starts cold because the legacy cache is intentionally left untouched; later refreshes use the new cache without changing report semantics.
 - Hermes discovery supports native Windows layouts for the downstream Windows build without changing the macOS app.


### PR DESCRIPTION
## Summary

Replace the v1.6.2 hotfix overrides with deterministic v1.7.0 release notes for both published formats, including M26-A after PR #90 entered `main`.

| Change | Treatment |
|---|---|
| [#83 Copilot Desktop usage](https://github.com/Nanako0129/TokenBar/pull/83) | Main highlight, including OTEL overlap suppression and the expected increase from previously invisible usage |
| [#88 Model hover visibility](https://github.com/Nanako0129/TokenBar/pull/88) | Main highlight across Token Usage, Models, Daily, and Monthly |
| [#90 Identity-aware shard cache](https://github.com/Nanako0129/TokenBar/pull/90) | Under-the-hood cache lifecycle change, including the intentional cold first scan and untouched legacy cache |
| [#82 Hermes Windows roots](https://github.com/Nanako0129/TokenBar/pull/82) | Under-the-hood Windows portability with an explicit no-change statement for macOS |
| #84, #85, #87 | Excluded as docs-only vendor bookkeeping |
| M26-B shard payload follow-up | Excluded because it is not in `main` |

`release-notes.override.md` feeds the GitHub Release body. `release-notes.override.txt` feeds Sparkle, `appcast.xml`, and the stable Tauri migration metadata. Both formats carry the same user-visible scope.

## Verification

- `git diff --check`
- Automated required-term and PR-link checks, including #90
- Automated exclusion checks for docs-only M24, unmerged M26-B, and stale v1.6.2 claims
- Markdown/plain-text scope parity check
- PR #90 and latest `main` CI: passed

## Authorization boundary

This PR prepares notes only. It does not create tag `v1.7.0`, publish assets, update the appcast, or bump the Homebrew cask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
