### PR TITLE
chore(release): prepare v1.8.0 notes

### DIFF
--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -1,9 +1,13 @@
 ## Highlights
 
-- **Copilot Desktop usage is now included.** TokenBar reads token-bearing local sessions from Copilot Desktop, preserves model, workspace, and agent attribution, and lets Copilot OTEL remain authoritative when both sources contain the same session. Totals may increase because previously invisible Desktop usage is now counted, not because the update created new spend. [#83](https://github.com/Nanako0129/TokenBar/pull/83)
-- **Model usage is easier to inspect.** Hovered Token Usage and Models bars now gain adaptive outlines and glow in both light and dark appearances. Model markers glow with their rows, and Daily/Monthly drill-downs show detailed Input, Output, Cache read, Cache write, and Reasoning tooltips above neighboring rows. [#88](https://github.com/Nanako0129/TokenBar/pull/88)
+- **Animated status icons now use far less TokenBar CPU.** In controlled 40 FPS benchmarks, TokenBar process CPU fell from 14.938% to 0.458% for Cat and from 10.287% to 0.462% for Parrot while preserving the configured cadence. Visible animation still carries WindowServer composition cost. [#95](https://github.com/Nanako0129/TokenBar/pull/95)
+- **Quota cards now survive transient provider outages without hiding the error.** TokenBar keeps the last known windows for the same account and shows the current Error. Sign-outs, account changes, authentication failures, and invalid responses still clear stale data instead of reusing it. [#94](https://github.com/Nanako0129/TokenBar/pull/94)
 
 ## Changes
 
-- **Usage caching is now sharded by source identity.** TokenBar replaces the single message cache with bounded per-source shards that isolate parser versions, preserve concurrent updates, and let report paths seed their own cache entries. The first scan after updating starts cold because the legacy cache is intentionally left untouched; later refreshes use the new cache without changing report semantics. [#90](https://github.com/Nanako0129/TokenBar/pull/90)
-- **Hermes discovery supports native Windows layouts** for the downstream Windows build while leaving the macOS app unchanged. [#82](https://github.com/Nanako0129/TokenBar/pull/82)
+- **Usage cache validation now follows related files more precisely.** TokenBar invalidates cached source data when dependencies move, appear, or disappear. The first scan after updating starts cold, then later refreshes use the rebuilt cache. [#91](https://github.com/Nanako0129/TokenBar/pull/91)
+
+## Fixes
+
+- **Local data discovery remains reliable when GUI launches lack a full shell environment.** Explicit source overrides keep their existing precedence. [#92](https://github.com/Nanako0129/TokenBar/pull/92)
+- **Claude version detection now runs at most once per TokenBar launch,** avoiding repeated CLI starts during quota refreshes. [#93](https://github.com/Nanako0129/TokenBar/pull/93)

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -1,9 +1,8 @@
-New:
-- Copilot Desktop token-bearing local sessions are now counted with model, workspace, and agent details. Copilot OTEL remains authoritative when both sources contain the same session, so overlapping usage is not counted twice. Totals may increase because previously invisible Desktop usage is now included, not because the update created new spend.
-
 Improved:
-- Hovered Token Usage and Models bars now gain adaptive outlines and glow in light and dark appearances. Model markers glow with their rows, and Daily/Monthly drill-downs show detailed Input, Output, Cache read, Cache write, and Reasoning tooltips above neighboring rows.
+- Animated Cat and Parrot icons now use a dedicated AppKit rendering surface. In controlled 40 FPS benchmarks, TokenBar process CPU fell from 14.938% to 0.458% for Cat and from 10.287% to 0.462% for Parrot while preserving the configured cadence; visible animation still carries WindowServer composition cost.
+- Usage cache validation now notices related files moving, appearing, or disappearing. The first scan after updating starts cold, then later refreshes use the rebuilt cache.
 
-Under the hood:
-- Usage caching now uses bounded identity-aware shards instead of one message-cache file. The first scan after updating starts cold because the legacy cache is intentionally left untouched; later refreshes use the new cache without changing report semantics.
-- Hermes discovery supports native Windows layouts for the downstream Windows build without changing the macOS app.
+Fixes:
+- Quota cards keep the last known windows during transient same-account provider failures and show the current Error. Sign-outs, account changes, authentication failures, and invalid responses still clear stale data.
+- Local data discovery remains reliable when GUI launches lack a full shell environment.
+- Claude version detection now runs at most once per TokenBar launch, avoiding repeated CLI starts during quota refreshes.


### PR DESCRIPTION
## Summary

Replace the shipped v1.7.0 override files with hand-written release notes for the exact v1.8.0 candidate range. The GitHub Markdown body and the plain-text Sparkle/latest.json form now describe the same shipped behavior and bypass the release workflow's non-deterministic DeepSeek rewriting.

The notes cover PRs #91 through #95 only: exact related-file cache validation, platform-home fallback for GUI source discovery, process-wide Claude version detection, account-bound quota preservation during transient provider failures, and the tray animation rendering change.

## Accuracy boundaries

The animation claim is explicitly limited to controlled 40 FPS TokenBar process CPU measurements: Cat decreased from 14.938% to 0.458%, and Parrot decreased from 10.287% to 0.462%. Both note formats retain the WindowServer composition-cost limitation instead of presenting the measurements as whole-system CPU savings.

The provider note states that transient failures may retain the last successful windows only for the same account while showing the current Error. Sign-outs, account changes, authentication failures, and invalid responses still clear stale data.

The notes do not repeat v1.7.0 claims, include closed-unmerged PRs #72, #74, or #86, claim pending M19-B0/M19-B1/D2 work, or present upstream-only changes as shipped TokenBar behavior. There are no external contributors to credit in this range.

## Verification

- `cargo check --workspace --locked`
- `cargo test --workspace` — `tb_core_ffi` 291 passed; `tokscale-core` 1,286 passed / 1 ignored; integration suites passed
- `cargo test --workspace --release` — same result
- `cargo clippy -p tb_core_ffi --all-targets --no-deps`
- `make build`
- `swift run TokenBar --selftest`
- Bundled release executable `--selftest`
- `python3 scripts/check_knowledge.py --self-test`
- `python3 scripts/check_knowledge.py`
- `make check-docs`
- `git diff --check`
- Release-note format, PR-link, previous-release, deferred-scope, private-data, and cross-format claim audit
- Pre-edit and post-edit workspace formatting/Clippy baselines are identical; the existing formatting drift and `vendor/tokscale-core/src/sessions/grok.rs:153` `wrong_self_convention` denial are unchanged
- Ad-hoc v1.8.0 provisional bundle checks covered plist metadata, bundle identity, Sparkle feed URL, signature identity, RunCat Neo license, release-only marker absence, clean archive structure, checksum, and extraction integrity
- Fresh outcome verifier: `CONFIRMED`

## Release boundary

This PR prepares notes only. It does not create a tag, GitHub Release, appcast item, `latest.json`, Homebrew cask update, or install-count change. The provisional pre-commit artifact is not publishable because this notes commit changes the build number; after merge, the exact final tag-target SHA must pass required CI and all version-bound bundle, archive, metadata, signature, license, and checksum gates again before `v1.8.0` can be tagged.

No live provider or account-scope smoke was run because it requires separate per-run authorization and is not the correctness authority for this notes-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
