### PR TITLE
chore(release): prepare v1.8.1 notes

### DIFF
--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -10,4 +10,5 @@
 ## Fixes
 
 - **Local data discovery remains reliable when GUI launches lack a full shell environment.** Explicit source overrides keep their existing precedence. [#92](https://github.com/Nanako0129/TokenBar/pull/92)
+- **Configured roots now cover the affected default local sources and credentials.** OpenCode's default usage data and OAuth credentials use `XDG_DATA_HOME`, with an empty value falling back to `$HOME/.local/share`; Gemini CLI and Antigravity CLI data, plus Antigravity OAuth credentials, use `GEMINI_CLI_HOME`, falling back to `$HOME/.gemini`. [#97](https://github.com/Nanako0129/TokenBar/pull/97)
 - **Claude version detection now runs at most once per TokenBar launch,** avoiding repeated CLI starts during quota refreshes. [#93](https://github.com/Nanako0129/TokenBar/pull/93)

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -5,4 +5,5 @@ Improved:
 Fixes:
 - Quota cards keep the last known windows during transient same-account provider failures and show the current Error. Sign-outs, account changes, authentication failures, and invalid responses still clear stale data.
 - Local data discovery remains reliable when GUI launches lack a full shell environment.
+- Configured roots now cover the affected default local sources and credentials. OpenCode's default usage data and OAuth credentials use XDG_DATA_HOME, with an empty value falling back to $HOME/.local/share; Gemini CLI and Antigravity CLI data, plus Antigravity OAuth credentials, use GEMINI_CLI_HOME, falling back to $HOME/.gemini.
 - Claude version detection now runs at most once per TokenBar launch, avoiding repeated CLI starts during quota refreshes.


### PR DESCRIPTION
## Summary

Extend the hand-written release overrides for the corrected v1.8.1 candidate. The existing notes still cover the unreleased v1.7.0-to-v1.8.0 candidate behavior; this PR adds the provider-root correction merged in #97 so the GitHub Markdown and Sparkle/latest.json text remain aligned with the exact code that will ship.

The new item distinguishes the affected paths: OpenCode's default local usage sources and OAuth credentials use `XDG_DATA_HOME`, with an empty value falling back to `$HOME/.local/share`; Gemini CLI and Antigravity CLI data, plus Antigravity OAuth credentials, use `GEMINI_CLI_HOME`, with the existing `$HOME/.gemini` fallback. Explicit OpenCode DB paths and Antigravity IDE live usage are outside that root claim.

## Release recovery boundary

The `v1.8.0` tag is retained as an immutable record, but its workflow was cancelled before GitHub Release, appcast, `latest.json`, Homebrew, or install-count publication after two late PR #92 review findings were confirmed. This PR does not delete, move, or reuse that tag. The corrected public release will use a new `v1.8.1` tag at the final verified main SHA.

## Accuracy boundaries

The complete notes cover shipped behavior from PRs #91 through #95 and #97. PR #96 is notes-only. The performance claim remains limited to controlled 40 FPS TokenBar process CPU measurements: Cat decreased from 14.938% to 0.458%, and Parrot decreased from 10.287% to 0.462%. Both formats retain the WindowServer composition-cost limitation.

The provider note still limits last-good quota preservation to transient failures for the same account while showing the current Error. Sign-outs, account changes, authentication failures, and invalid responses clear stale data. The configured-root item does not claim new providers, credential formats, custom DB relocation, Antigravity IDE root changes, or live-account verification.

There are no external contributors to credit in this candidate range.

## Verification

- PR #97 current-head Codex clean, CI successful, and zero unresolved threads before merge
- PR #97 focused tests: OpenCode 9 passed; Antigravity 22 passed; XDG resolver 5 passed; OpenCode scanner 4 passed
- PR #97 fresh outcome verification after complete scanner-sibling coverage: `CONFIRMED`
- Release-note format, PR-link, previous-release, deferred-scope, private-data, escaping-hazard, and cross-format parity audit
- `python3 scripts/check_knowledge.py`
- `git diff --check`

## Release boundary

This PR prepares notes only. It does not create a tag, GitHub Release, appcast item, `latest.json`, Homebrew cask update, or install-count change. After merge, the exact final main SHA must pass required CI and all version-bound bundle, archive, metadata, ad-hoc signature, license, selftest, and checksum gates before `v1.8.1` is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
