### PR TITLE
docs(repo): add Ko-fi sponsorship details

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: nanako0129

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ The [project knowledge base](docs/knowledge/README.md) is the canonical guide to
 > Run `swift build` from the repo root — the linker's `-L target/release` path
 > in `Package.swift` is relative.
 
+## Support TokenBar
+
+TokenBar is local-first and needs no TokenBar account, but maintaining
+trustworthy numbers across 25+ AI coding agents is a wide compatibility job.
+Parser changes cross Rust, FFI, Swift, and the Windows sibling; live quota cards
+require real OAuth or subscription accounts and provider APIs; releases cover
+native macOS behavior, Sparkle signing and appcasts, Homebrew, and legacy
+migration metadata.
+
+Sponsorship helps cover test accounts, CI and release infrastructure, and the
+maintainer time required to keep readings accurate as upstream formats change.
+If TokenBar helps you understand where your AI budget goes, you can support its
+continued development on Ko-fi.
+
+[![Support TokenBar on Ko-fi](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, change-specific guardrails, verification, and pull-request requirements.


### PR DESCRIPTION
## Summary

- add `.github/FUNDING.yml` for the `nanako0129` Ko-fi page
- add a project-specific README section explaining TokenBar's real compatibility and release-maintenance costs

## Why

TokenBar is local-first, but maintaining trustworthy data across 25+ AI coding agents requires real provider test accounts, Rust/FFI/Swift verification, Windows parity work, CI, and Sparkle/Homebrew release maintenance. The README now gives users a transparent support path without changing product behavior.

## Scope

This changes the product README and GitHub funding metadata only. It does not change runtime code, canonical knowledge contracts, provider behavior, signing, appcasts, Homebrew metadata, or release automation.

## Verification

- `python3 scripts/check_knowledge.py --self-test`
- `python3 -m py_compile scripts/check_knowledge.py`
- `python3 scripts/check_knowledge.py`
- `make check-docs`
- `git diff --check origin/main...HEAD`
- confirmed the commit contains only `README.md` and `.github/FUNDING.yml`

All checks passed. No runtime or live provider PASS is claimed for this documentation-only change.

## Automation disclosure

This documentation change was authored with Codex assistance. The final diff, documentation gates, public-safety boundary, link target, and commit scope were independently checked locally.