### PR TITLE
chore: switch funding link to Patreon

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-ko_fi: nanako0129
+custom: ["https://www.patreon.com/cw/Nanako0129/membership"]

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ migration metadata.
 Sponsorship helps cover test accounts, CI and release infrastructure, and the
 maintainer time required to keep readings accurate as upstream formats change.
 If TokenBar helps you understand where your AI budget goes, you can support its
-continued development on Ko-fi.
+continued development on Patreon.
 
-[![Support TokenBar on Ko-fi](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
+[![Support TokenBar on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- replace the Ko-fi funding entry with the Patreon membership page
- keep the GitHub Sponsor sidebar pointed at the current support channel

## Verification

- `git diff --check`
- confirmed the Patreon membership URL returns HTTP 200