### PR TITLE
fix(settings): prompt to relaunch after language changes

### DIFF
--- a/Sources/TokenBar/Localization.swift
+++ b/Sources/TokenBar/Localization.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import TokenBarCore
 
@@ -24,6 +25,12 @@ enum AppLanguage: String, CaseIterable {
         case .english: return "English"
         case .traditionalChinese: return "繁體中文"
         }
+    }
+
+    /// A language change needs a relaunch, but selecting the current value
+    /// again (or receiving a malformed raw value) must not prompt.
+    static func requiresRelaunch(from currentRawValue: String, to nextRawValue: String) -> Bool {
+        currentRawValue != nextRawValue && Self(rawValue: nextRawValue) != nil
     }
 
     /// Writes (or clears) the `AppleLanguages` override.
@@ -58,6 +65,37 @@ enum AppLanguage: String, CaseIterable {
                 try? fileManager.removeItem(at: destination)
             }
             try? fileManager.copyItem(at: source, to: destination)
+        }
+    }
+}
+
+@MainActor
+enum AppRelauncher {
+    /// Starts a new app instance before terminating this one. Waiting for
+    /// NSWorkspace's completion keeps a failed launch from quitting the
+    /// currently working app.
+    static func relaunch() {
+        guard Bundle.main.bundleURL.pathExtension == "app" else {
+            NSSound.beep()
+            return
+        }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(
+            at: Bundle.main.bundleURL,
+            configuration: configuration
+        ) { application, error in
+            guard error == nil,
+                  let application,
+                  application.processIdentifier != ProcessInfo.processInfo.processIdentifier
+            else {
+                NSSound.beep()
+                return
+            }
+            Task { @MainActor in
+                NSApp.terminate(nil)
+            }
         }
     }
 }

--- a/Sources/TokenBar/Localization.swift
+++ b/Sources/TokenBar/Localization.swift
@@ -86,14 +86,15 @@ enum AppRelauncher {
             at: Bundle.main.bundleURL,
             configuration: configuration
         ) { application, error in
-            guard error == nil,
-                  let application,
-                  application.processIdentifier != ProcessInfo.processInfo.processIdentifier
-            else {
-                NSSound.beep()
-                return
-            }
+            let openedReplacement =
+                error == nil
+                && application?.processIdentifier != nil
+                && application?.processIdentifier != ProcessInfo.processInfo.processIdentifier
             Task { @MainActor in
+                guard openedReplacement else {
+                    NSSound.beep()
+                    return
+                }
                 NSApp.terminate(nil)
             }
         }

--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -187,6 +187,10 @@
 "Receive beta updates" = "接收 beta 版更新";
 "Live preview — settings apply immediately." = "即時預覽，設定會立即套用。";
 "Takes effect the next time TokenBar starts." = "下次啟動 TokenBar 時生效。";
+"Restart TokenBar?" = "重新啟動 TokenBar？";
+"Restart TokenBar to apply the new language." = "重新啟動 TokenBar 以套用新的語言。";
+"Restart Now" = "立即重新啟動";
+"Later" = "稍後";
 "Dark" = "深色";
 "Light" = "淺色";
 "System" = "跟隨系統";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -39,6 +39,16 @@ enum SelfTest {
             return try? box.result?.get()
         }
 
+        expect(
+            !AppLanguage.requiresRelaunch(from: "en", to: "en"),
+            "language reselect does not prompt for relaunch")
+        expect(
+            AppLanguage.requiresRelaunch(from: "en", to: "zh-Hant"),
+            "language change prompts for relaunch")
+        expect(
+            !AppLanguage.requiresRelaunch(from: "en", to: "unsupported"),
+            "invalid language does not prompt for relaunch")
+
         // Tray animation timing: preserve the shipping integer-millisecond
         // cadence while mapping the runner rate from 2 to 40 fps.
         let idleLoad = TrayAnimator.animationLoad(tokensPerMinute: 0)

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -28,6 +28,7 @@ struct SettingsPanel: View {
     @AppStorage("tokenbar.trace.detailed") private var detailedTrace = false
     @AppStorage("tokenbar.refresh.intervalMin") private var refreshIntervalMin = 30
     @AppStorage(AppLanguage.storageKey) private var languageRaw = AppLanguage.system.rawValue
+    @State private var showLanguageRestartPrompt = false
     /// 0 = auto (≈60% of the screen). The popover's drag handle writes the
     /// same key, so the two stay in sync.
     @AppStorage(PopoverChrome.heightKey) private var popoverHeight = 0.0
@@ -389,8 +390,12 @@ struct SettingsPanel: View {
                     selection: Binding(
                         get: { languageRaw },
                         set: { next in
+                            guard AppLanguage.requiresRelaunch(
+                                from: languageRaw, to: next)
+                            else { return }
                             languageRaw = next
                             AppLanguage(rawValue: next)?.apply()
+                            showLanguageRestartPrompt = true
                         }),
                     options: AppLanguage.allCases.map { ($0.rawValue, $0.label) })
                 hint("Takes effect the next time TokenBar starts.")
@@ -416,6 +421,12 @@ struct SettingsPanel: View {
                 }
                 hint("TokenBar began as a fork of tokcat by handlecusion. Parsing & pricing come from tokscale by Junho Yeo; the menu-bar patterns reference CodexBar by Peter Steinberger; the running cat traces back to RunCat by Takuto Nakamura. MIT licensed.")
             }
+        }
+        .alert("Restart TokenBar?", isPresented: $showLanguageRestartPrompt) {
+            Button("Later", role: .cancel) {}
+            Button("Restart Now") { AppRelauncher.relaunch() }
+        } message: {
+            Text("Restart TokenBar to apply the new language.")
         }
     }
 


### PR DESCRIPTION
## Summary

- Show a localized restart confirmation after the user selects a different supported interface language.
- Let the user defer the restart or relaunch TokenBar immediately through `NSWorkspace`.
- Keep the current app running if the replacement instance cannot be opened.
- Add Traditional Chinese prompt copy and selftest coverage for changed, unchanged, and invalid selections.

## Why

Cocoa resolves `AppleLanguages` during app startup, so the existing setting is persisted immediately but cannot update the mounted interface. The previous hint required users to quit and reopen TokenBar manually without offering a direct action.

## Behavior

Choosing **Later** keeps the selected language for the next launch. Choosing **Restart Now** creates a replacement app instance and terminates the current process only after the replacement launch succeeds.

## Validation

- `make build`
- `make selftest`
- `plutil -lint Sources/TokenBar/Resources/Localizations/en.lproj/Localizable.strings Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings`
- `git diff --check`