### PR TITLE
fix(popover): keep live resizing out of SwiftUI state

### DIFF
--- a/Sources/TokenBar/PopoverChrome.swift
+++ b/Sources/TokenBar/PopoverChrome.swift
@@ -66,9 +66,14 @@ final class PopoverChrome: ObservableObject {
     /// Live drag / slider updates. `persist` writes the value back so it
     /// survives relaunch and syncs the settings slider.
     func setHeight(_ value: CGFloat, persist persistValue: Bool, live: Bool) {
-        rawHeight = min(max(minHeight, value), maxHeight)
+        let next = min(max(minHeight, value), maxHeight)
+        if live {
+            onResize?(next, true)
+            return
+        }
+        rawHeight = next
         if persistValue { UserDefaults.standard.set(Double(rawHeight), forKey: Self.heightKey) }
-        onResize?(height, live)
+        onResize?(height, false)
     }
 
     /// Re-read the value the settings slider wrote (from the other window) and

--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -129,7 +129,11 @@ struct PopoverView: View {
             Divider()
             footer
         }
-        .frame(width: chrome.width, height: chrome.height)
+        // AppKit owns the live drag size. Filling the hosting view avoids
+        // publishing a new environment-object height — and rebuilding this
+        // entire view tree — for every pointer event.
+        .frame(width: chrome.width)
+        .frame(maxHeight: .infinity)
         .animation(.easeOut(duration: 0.16), value: activeViewRaw)
         .animation(.easeOut(duration: 0.16), value: activeTab)
         .background(PopoverBackdrop().ignoresSafeArea())

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -49,6 +49,34 @@ enum SelfTest {
             !AppLanguage.requiresRelaunch(from: "en", to: "unsupported"),
             "invalid language does not prompt for relaunch")
 
+        let popoverResizeResult = MainActor.assumeIsolated { () -> (Bool, Bool) in
+            let defaults = UserDefaults.standard
+            let savedHeight = defaults.object(forKey: PopoverChrome.heightKey)
+            defer {
+                if let savedHeight {
+                    defaults.set(savedHeight, forKey: PopoverChrome.heightKey)
+                } else {
+                    defaults.removeObject(forKey: PopoverChrome.heightKey)
+                }
+            }
+            defaults.set(620.0, forKey: PopoverChrome.heightKey)
+            let chrome = PopoverChrome()
+            chrome.resolve(visibleHeight: 1_000)
+            var liveResize: (CGFloat, Bool)?
+            chrome.onResize = { liveResize = ($0, $1) }
+            chrome.setHeight(700, persist: false, live: true)
+            let liveBypassedPublication =
+                chrome.rawHeight == 620 && liveResize?.0 == 700 && liveResize?.1 == true
+            chrome.setHeight(700, persist: false, live: false)
+            return (liveBypassedPublication, chrome.rawHeight == 700)
+        }
+        expect(
+            popoverResizeResult.0,
+            "live popover resize bypasses environment publication")
+        expect(
+            popoverResizeResult.1,
+            "final popover resize commits published height")
+
         // Tray animation timing: preserve the shipping integer-millisecond
         // cadence while mapping the runner rate from 2 to 40 fps.
         let idleLoad = TrayAnimator.animationLoad(tokensPerMinute: 0)


### PR DESCRIPTION
## Summary

- Route live drag heights directly to the AppKit resize callback without publishing `rawHeight` on every pointer event.
- Let the SwiftUI root fill the AppKit-owned hosting height, then publish and persist the final height when the drag ends.
- Add regression coverage for the live-versus-final resize contract.

## Root cause

Each drag update changed both `NSPopover.contentSize` and the `@Published` height in the shared `PopoverChrome` environment object. That invalidated the complete `PopoverView` tree for every pointer event, so the growing view hierarchy amplified resize lag and delayed footer actions.

## User impact

Popover height changes remain responsive, and Settings and Quit respond normally after resizing. The final height still synchronizes with Settings and survives reopen or relaunch.

## Verification

- `make build`
- `make selftest`
- `swift build -c release`
- Manual Release-demo validation: smooth height dragging; Settings and Quit both respond normally
- Fresh-context verifier: `CONFIRMED`