### PR TITLE
chore(release): prepare v1.10.0 notes

### DIFF
--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -10,6 +10,6 @@
 ## Fixes
 
 - **Historical quota pace now starts from validated evidence instead of a fixed completed-cycle requirement.** A stable current cycle can qualify earlier; insufficient or low-quality history stays in learning mode, and risk remains hidden until enough evidence exists. [#120](https://github.com/Nanako0129/TokenBar/pull/120)
-- **Claude quota cards now reflect live Pro and Max subscription changes** instead of relying only on a login-time plan snapshot. If the live lookup is unavailable, TokenBar falls back without delaying other quota updates. [#124](https://github.com/Nanako0129/TokenBar/pull/124)
+- **Claude quota cards now reflect live Pro and Max subscription changes** instead of relying only on a login-time plan snapshot. The live lookup is bounded and cached, with stored plan data used as a fallback when needed. [#124](https://github.com/Nanako0129/TokenBar/pull/124)
 - **Grok usage is attributed to models more safely across process restarts and subagents.** Ambiguous or conflicting evidence remains unattributed instead of being guessed. [#123](https://github.com/Nanako0129/TokenBar/pull/123)
 - **Popover height dragging stays responsive,** and Settings and Quit continue responding normally after a resize. [#110](https://github.com/Nanako0129/TokenBar/pull/110)

--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -1,9 +1,15 @@
 ## Highlights
 
-- **TokenBar now includes Traditional Chinese.** Choose System, English, or Traditional Chinese in Settings; when the selection changes, TokenBar offers to restart immediately so the new preference can take effect. Dashboards, settings, menus, charts, quota reset countdowns, usage pace and risk text, and graph controls are localized, with English fallback for missing entries. [#106](https://github.com/Nanako0129/TokenBar/pull/106) [#108](https://github.com/Nanako0129/TokenBar/pull/108)
+- **Add optional menu bar items for individual clients.** Enable eligible clients in Settings to show their brand icon and the remaining quota for Auto or a selected window; clicking an item opens TokenBar on that client. [#119](https://github.com/Nanako0129/TokenBar/pull/119)
+- **Settings now uses native sidebar navigation.** Menu Bar, Dashboard, General, and About each get a focused page while the live preview remains visible, and quota source selection is now organized as Agent then Window. [#117](https://github.com/Nanako0129/TokenBar/pull/117)
+
+## Changes
+
+- **Reorder client tabs directly in the popover.** Drag tabs along the top bar; Overview stays first, and hidden clients keep their saved positions. [#116](https://github.com/Nanako0129/TokenBar/pull/116) — thanks @amikai
 
 ## Fixes
 
-- **Copilot quota and activity data now withstand more imperfect inputs.** An optional reset date with an unexpected type no longer discards otherwise valid quota windows, and duplicate OTEL spans keep the earliest start through the latest endpoint without adding replayed token usage. [#102](https://github.com/Nanako0129/TokenBar/pull/102)
-- **Kimi Code discovery now treats an empty `KIMI_CODE_HOME` as unset,** returning to the default Kimi Code directory instead of scanning an invalid root. Non-empty overrides keep their existing behavior. [#101](https://github.com/Nanako0129/TokenBar/pull/101)
-- **Provider connection errors now retain typed DNS and TLS diagnostics without exposing raw transport text.** Existing timeout and connection-failure precedence remains unchanged. [#102](https://github.com/Nanako0129/TokenBar/pull/102)
+- **Historical quota pace now starts from validated evidence instead of a fixed completed-cycle requirement.** A stable current cycle can qualify earlier; insufficient or low-quality history stays in learning mode, and risk remains hidden until enough evidence exists. [#120](https://github.com/Nanako0129/TokenBar/pull/120)
+- **Claude quota cards now reflect live Pro and Max subscription changes** instead of relying only on a login-time plan snapshot. If the live lookup is unavailable, TokenBar falls back without delaying other quota updates. [#124](https://github.com/Nanako0129/TokenBar/pull/124)
+- **Grok usage is attributed to models more safely across process restarts and subagents.** Ambiguous or conflicting evidence remains unattributed instead of being guessed. [#123](https://github.com/Nanako0129/TokenBar/pull/123)
+- **Popover height dragging stays responsive,** and Settings and Quit continue responding normally after a resize. [#110](https://github.com/Nanako0129/TokenBar/pull/110)

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -1,7 +1,10 @@
 New:
-- TokenBar now includes Traditional Chinese. Choose System, English, or Traditional Chinese in Settings; when the selection changes, TokenBar offers to restart immediately so the new preference can take effect. Dashboards, settings, menus, charts, quota reset countdowns, usage pace and risk text, and graph controls are localized, with English fallback for missing entries.
-
+- Add optional menu bar items for individual clients, showing a brand icon and remaining quota for Auto or a selected window; clicking one opens TokenBar on that client.
+- Settings now uses native sidebar navigation for Menu Bar, Dashboard, General, and About, with the live preview kept visible.
+- Drag client tabs to reorder them directly in the popover; Overview stays first and hidden clients keep their saved positions.
+Improved:
+- Historical quota pace can start once current-cycle evidence passes quality checks; insufficient history remains in learning mode and unvalidated risk stays hidden.
 Fixes:
-- Copilot quota windows survive optional reset dates with unexpected types, and duplicate OTEL spans keep the full observed activity duration without adding replayed token usage.
-- Empty KIMI_CODE_HOME values fall back to the default Kimi Code directory; non-empty overrides keep their existing behavior.
-- Provider connection errors retain typed DNS and TLS diagnostics without exposing raw transport text.
+- Claude quota cards reflect live Pro and Max plan changes instead of a stale login-time label.
+- Grok usage is attributed more safely across process restarts and subagents; ambiguous evidence stays unattributed.
+- Popover height dragging remains responsive, and Settings and Quit continue responding normally after resizing.


### PR DESCRIPTION
## Summary

- replace the shipped v1.9.0 overrides with the reviewed v1.10.0 user-visible change set for GitHub Release and Sparkle
- highlight optional per-client menu bar items and the native Settings sidebar, and credit @amikai for direct client-tab reordering
- cover the quality-gated historical quota pace, live Claude plan label, safer Grok model attribution, and responsive popover resizing
- preserve generator ownership of the Markdown New Contributors / Full Changelog tail and the plain-text contributor Thanks line

## Verification

- `git diff --cached --check`
- contract assertions for Markdown sections, omitted generated tail, `@amikai` credit, plain-text heading order, link-free plain text, and the ten-line override budget

> This PR prepares release text only. It does not create the `v1.10.0` tag, publish a GitHub Release, update the appcast or Homebrew cask, or otherwise authorize the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
