### PR TITLE
fix(usage): preserve message-only activity

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2155,6 +2155,7 @@ enum SelfTest {
         expect(
             messageOnlyStats.activeDays == 1
                 && messageOnlyStats.perDayMap["2026-01-01"]?.tokens == 0
+                && messageOnlyStats.perDayMap["2026-01-01"]?.hasMessages == true
                 && messageOnlyStats.totalTokens == 0 && messageOnlyStats.totalCost == 0,
             "shared usage stats count a selected message-only day as active")
         expect(
@@ -2357,6 +2358,14 @@ enum SelfTest {
               "tokens":{"input":10,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0}}]}
             """
         }
+        func messageOnlyDaily(_ client: String, _ date: String) -> String {
+            """
+            {"date":"\(date)","totals":{"tokens":0,"cost":0,"messages":1},"intensity":0,
+             "tokenBreakdown":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0},
+             "clients":[{"client":"\(client)","modelId":"m","providerId":"p","cost":0,"messages":1,
+              "tokens":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0}}]}
+            """
+        }
         func rangeStatsPayload(end: String, days: [String]) -> UsagePayload {
             let json = """
             {"meta":{"generatedAt":"now","version":"1","dateRange":{"start":"2026-07-01","end":"\(end)"}},
@@ -2391,6 +2400,15 @@ enum SelfTest {
             && visFiltered.dateRange.end == visAlone.dateRange.end,
             "filtered stats equal a payload without the hidden client")
 
+        let messageTailPayload = rangeStatsPayload(end: "2026-07-31", days: [
+            daily("vis", "2026-07-01", 1), messageOnlyDaily("vis", "2026-07-31"),
+        ])
+        let messageTailStats = UsageStats(payload: messageTailPayload, selectedClients: ["vis"])
+        expect(
+            messageTailStats.dateRange.end == "2026-07-31"
+                && messageTailStats.streaks.current == 1,
+            "a trailing message-only day remains current activity instead of resetting the streak")
+
         // DayBars trailing window anchors to the passed range end, not the
         // unfiltered payload range (issue #36 Fix, round 6): the caller passes
         // the selection-derived stats.dateRange.end, so a hidden client active
@@ -2407,13 +2425,21 @@ enum SelfTest {
             "chart window anchors to the filtered range end")
         expect((visBars.last?.totalTokens ?? 0) > 0,
             "visible client's last active day is the last (in-window) bar")
-        // The old unfiltered anchor (meta.dateRange.end = the hidden client's
-        // later day) shifts the window forward, stranding an empty trailing bar.
+        // DayBars derives its token/cost anchor from the selected series, so a
+        // later non-metric range end cannot shift visible usage out of view.
         let shiftedBars = DayBars.build(
             payload: chartPayload, clientIds: ["vis"], stackBy: .agent,
             colors: chartColors, rangeEnd: "2026-07-05", endFallback: "2026-07-09")
-        expect(shiftedBars.last?.date == "2026-07-05" && (shiftedBars.last?.totalTokens ?? 0) == 0,
-            "unfiltered anchor would shift the window past the visible activity")
+        expect(shiftedBars.last?.date == "2026-07-03" && (shiftedBars.last?.totalTokens ?? 0) > 0,
+            "chart derives its range end from selected token/cost activity")
+        let messageTailBars = DayBars.build(
+            payload: messageTailPayload, clientIds: ["vis"], stackBy: .agent,
+            colors: chartColors, rangeEnd: messageTailStats.dateRange.end,
+            endFallback: "2026-07-31")
+        expect(
+            messageTailBars.last?.date == "2026-07-01"
+                && (messageTailBars.last?.totalTokens ?? 0) > 0,
+            "a later message-only day does not shift the token/cost chart window")
 
         // Tooltip placement stays inside the visible ScrollView viewport, not
         // merely inside the source card. Region-dodge (container 0.45) prefers

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2118,20 +2118,20 @@ enum SelfTest {
         // some parsers emit message-count-only rows. Prior guard was
         // `tokens > 0 || cost > 0`, which dropped this month entirely.
         let messageOnlyJSON = """
-        {"meta":{"generatedAt":"now","version":"1","dateRange":{"start":"2026-02-01","end":"2026-02-01"}},
+        {"meta":{"generatedAt":"now","version":"1","dateRange":{"start":"2026-01-01","end":"2026-01-01"}},
          "summary":{"totalTokens":0,"totalCost":0,"totalDays":1,"activeDays":1,"averagePerDay":0,
-                    "maxCostInSingleDay":0,"clients":["a"],"models":[]},
+                    "maxCostInSingleDay":0,"clients":["codex"],"models":[]},
          "years":[],
          "contributions":[
-           {"date":"2026-02-01","totals":{"tokens":0,"cost":0,"messages":5},"intensity":0,
+           {"date":"2026-01-01","totals":{"tokens":0,"cost":0,"messages":5},"intensity":0,
             "tokenBreakdown":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0},
             "clients":[
-              {"client":"a","modelId":"m1","providerId":"p","cost":0,"messages":5,
+              {"client":"codex","modelId":"m1","providerId":"p","cost":0,"messages":5,
                "tokens":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0}}]}
          ]}
         """
         let messageOnlyPayload = try! JSONDecoder().decode(UsagePayload.self, from: Data(messageOnlyJSON.utf8))
-        let moRows = MonthlyView.monthRows(payload: messageOnlyPayload, clientIds: ["a"])
+        let moRows = MonthlyView.monthRows(payload: messageOnlyPayload, clientIds: ["codex"])
         expect(moRows.count == 1 && moRows[0].messages == 5 && moRows[0].tokens == 0 && moRows[0].cost == 0,
             "a message-only month (zero tokens, zero cost) still surfaces in the Monthly lens")
 
@@ -2181,6 +2181,15 @@ enum SelfTest {
             ) == ["claude", "codex"]
                 && PopoverView.supportedTurnClients(["gemini", "opencode"]).isEmpty,
             "turn scope preserves display order and excludes unsupported clients")
+        let dailyMessageOnlyRows = DailyView(
+            payload: messageOnlyPayload, clientIds: ["codex"], hourlyReport: turnReport,
+            turnClientIds: ["codex", "claude"], colors: ModelColorMap(report: nil)
+        ).rows
+        expect(
+            dailyMessageOnlyRows.count == 1 && dailyMessageOnlyRows[0].messages == 5
+                && dailyMessageOnlyRows[0].tokens == 0 && dailyMessageOnlyRows[0].cost == 0
+                && dailyMessageOnlyRows[0].turns == 7,
+            "Daily retains a message-only day and attaches its positive turn count")
 
         let dashboardYearDefaultsKey = "tokenbar.dashboard.year"
         let savedDashboardYear = UserDefaults.standard.object(forKey: dashboardYearDefaultsKey)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2134,6 +2134,22 @@ enum SelfTest {
         let moRows = MonthlyView.monthRows(payload: messageOnlyPayload, clientIds: ["codex"])
         expect(moRows.count == 1 && moRows[0].messages == 5 && moRows[0].tokens == 0 && moRows[0].cost == 0,
             "a message-only month (zero tokens, zero cost) still surfaces in the Monthly lens")
+        let monthlyMessageOnlySlice = moRows.first.flatMap {
+            MonthlyView.modelSlices(
+                for: $0, clientIds: ["codex"], colors: ModelColorMap(report: nil)
+            ).first
+        }
+        expect(
+            monthlyMessageOnlySlice?.key == "m1|p" && monthlyMessageOnlySlice?.tokens == 0
+                && monthlyMessageOnlySlice?.cost == 0,
+            "a message-only month retains its model drill-down")
+        expect(
+            UsageStats.hasVisibleActivity(
+                contributions: messageOnlyPayload.contributions, hidden: []
+            ) && UsageStats.yearsWithVisibleActivity(
+                contributions: messageOnlyPayload.contributions, hidden: []
+            ) == ["2026"],
+            "message-only activity keeps its selected year visible")
 
         // Daily/Monthly turn counts reuse the existing local-hour report, but
         // only after strict calendar-key validation and only for Codex/Claude.
@@ -2181,15 +2197,23 @@ enum SelfTest {
             ) == ["claude", "codex"]
                 && PopoverView.supportedTurnClients(["gemini", "opencode"]).isEmpty,
             "turn scope preserves display order and excludes unsupported clients")
-        let dailyMessageOnlyRows = DailyView(
+        let dailyMessageOnlyView = DailyView(
             payload: messageOnlyPayload, clientIds: ["codex"], hourlyReport: turnReport,
             turnClientIds: ["codex", "claude"], colors: ModelColorMap(report: nil)
-        ).rows
+        )
+        let dailyMessageOnlyRows = dailyMessageOnlyView.rows
         expect(
             dailyMessageOnlyRows.count == 1 && dailyMessageOnlyRows[0].messages == 5
                 && dailyMessageOnlyRows[0].tokens == 0 && dailyMessageOnlyRows[0].cost == 0
                 && dailyMessageOnlyRows[0].turns == 7,
             "Daily retains a message-only day and attaches its positive turn count")
+        let dailyMessageOnlySlice = dailyMessageOnlyRows.first.flatMap {
+            dailyMessageOnlyView.models(for: $0.contribution).first
+        }
+        expect(
+            dailyMessageOnlySlice?.key == "m1|p" && dailyMessageOnlySlice?.tokens == 0
+                && dailyMessageOnlySlice?.cost == 0,
+            "a message-only Daily row retains its model drill-down")
 
         let dashboardYearDefaultsKey = "tokenbar.dashboard.year"
         let savedDashboardYear = UserDefaults.standard.object(forKey: dashboardYearDefaultsKey)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2150,6 +2150,16 @@ enum SelfTest {
                 contributions: messageOnlyPayload.contributions, hidden: []
             ) == ["2026"],
             "message-only activity keeps its selected year visible")
+        let messageOnlyStats = UsageStats(
+            payload: messageOnlyPayload, selectedClients: ["codex"])
+        expect(
+            messageOnlyStats.activeDays == 1
+                && messageOnlyStats.perDayMap["2026-01-01"]?.tokens == 0
+                && messageOnlyStats.totalTokens == 0 && messageOnlyStats.totalCost == 0,
+            "shared usage stats count a selected message-only day as active")
+        expect(
+            UsageStats(payload: messageOnlyPayload, selectedClients: []).activeDays == 0,
+            "shared usage stats do not count an unselected message-only day")
 
         // Daily/Monthly turn counts reuse the existing local-hour report, but
         // only after strict calendar-key validation and only for Codex/Claude.

--- a/Sources/TokenBar/Views/DailyView.swift
+++ b/Sources/TokenBar/Views/DailyView.swift
@@ -76,7 +76,7 @@ struct DailyView: View {
     @State private var tooltipSize: CGSize = .zero
     @Environment(\.popoverScrollViewport) private var popoverScrollViewport
 
-    private struct DayRow {
+    struct DayRow {
         let date: String
         let tokens: Int64
         let cost: Double
@@ -111,7 +111,7 @@ struct DailyView: View {
         t.total
     }
 
-    private var rows: [DayRow] {
+    var rows: [DayRow] {
         let allow = Set(clientIds)
         let turnsByDay = TurnCountBuckets.byDay(hourlyReport)
         return payload.contributions.compactMap { c -> DayRow? in
@@ -124,7 +124,7 @@ struct DailyView: View {
                 cost += cc.cost
                 messages += cc.messages
             }
-            guard tokens > 0 || cost > 0 else { return nil }
+            guard tokens > 0 || cost > 0 || messages > 0 else { return nil }
             let turns = hourlyReport == nil ? nil : turnsByDay[c.date] ?? 0
             return DayRow(
                 date: c.date, tokens: tokens, cost: cost, messages: messages,

--- a/Sources/TokenBar/Views/DailyView.swift
+++ b/Sources/TokenBar/Views/DailyView.swift
@@ -85,7 +85,7 @@ struct DailyView: View {
         let contribution: Contribution
     }
 
-    private struct ModelSlice {
+    struct ModelSlice {
         let key: String
         let model: String
         let provider: String
@@ -133,13 +133,13 @@ struct DailyView: View {
         .sorted { $0.date > $1.date }
     }
 
-    private func models(for c: Contribution) -> [ModelSlice] {
+    func models(for c: Contribution) -> [ModelSlice] {
         let allow = Set(clientIds)
         var grouped: [String: ModelSlice] = [:]
         for cc in c.clients {
             if !allow.contains(cc.client) { continue }
             let tokens = Self.tokenTotal(cc.tokens)
-            if tokens <= 0 && cc.cost <= 0 { continue }
+            if tokens <= 0 && cc.cost <= 0 && cc.messages <= 0 { continue }
             let model = cc.modelId.isEmpty ? "unknown" : cc.modelId
             let key = "\(model)|\(cc.providerId)"
             var slot = grouped[key] ?? ModelSlice(

--- a/Sources/TokenBar/Views/MonthlyView.swift
+++ b/Sources/TokenBar/Views/MonthlyView.swift
@@ -100,7 +100,7 @@ struct MonthlyView: View {
             for cc in c.clients {
                 if !allow.contains(cc.client) { continue }
                 let tokens = cc.tokens.total
-                if tokens <= 0 && cc.cost <= 0 { continue }
+                if tokens <= 0 && cc.cost <= 0 && cc.messages <= 0 { continue }
                 let model = cc.modelId.isEmpty ? "unknown" : cc.modelId
                 let key = "\(model)|\(cc.providerId)"
                 var slot = grouped[key] ?? ModelSlice(

--- a/Sources/TokenBarCore/DayBars.swift
+++ b/Sources/TokenBarCore/DayBars.swift
@@ -35,15 +35,14 @@ public struct DayBar: Sendable {
 public enum DayBars {
     public static let window = 30
 
-    /// Build the trailing `window`-day series ending at `rangeEnd` (today, via
-    /// `endFallback`, when absent). Days outside the data render as empty bars.
+    /// Build the trailing `window`-day series ending at the last selected
+    /// token/cost day. `rangeEnd` (or `endFallback`) is used when the selected
+    /// slice has no token/cost activity. Days outside the data render as empty bars.
     ///
-    /// `rangeEnd` must be the SELECTED clients' range end (`stats.dateRange.end`,
-    /// selection-derived), NOT the unfiltered `payload.meta.dateRange.end`: a
-    /// hidden client whose activity extends past the visible clients' last day
-    /// would otherwise shift the trailing window forward and push visible
-    /// activity off the chart while the range-filtered headline stats disagree.
-    /// When nothing is hidden the two are equal, so the window is unchanged.
+    /// The token/cost series derives its own end while it has data, preventing
+    /// hidden or message-only activity from shifting metric bars out of view.
+    /// When it has no data, `rangeEnd` must still be the SELECTED clients' end
+    /// (`stats.dateRange.end`), not the unfiltered payload range.
     public static func build(
         payload: UsagePayload,
         clientIds: [String],
@@ -59,7 +58,7 @@ public enum DayBars {
             if day.totalTokens > 0 || day.totalCost > 0 { byDate[day.date] = day }
         }
 
-        let end = rangeEnd.isEmpty ? endFallback : rangeEnd
+        let end = byDate.keys.max() ?? (rangeEnd.isEmpty ? endFallback : rangeEnd)
         guard let endDay = ISODay(end) else { return [] }
         return (0..<window).map { i in
             let date = ISODay(number: endDay.number - (window - 1) + i).iso

--- a/Sources/TokenBarCore/UsageStats.swift
+++ b/Sources/TokenBarCore/UsageStats.swift
@@ -85,6 +85,7 @@ public struct UsageStats: Sendable {
         for c in payload.contributions {
             var dayTokens: Int64 = 0
             var dayCost = 0.0
+            var hasMessages = false
             for cc in c.clients {
                 present.insert(cc.client)
                 guard selectedClients.contains(cc.client) else { continue }
@@ -93,8 +94,9 @@ public struct UsageStats: Sendable {
                 // folds these here — a trapping `+=` would crash the dashboard.
                 dayTokens = dayTokens.saturatingAdding(cc.tokens.total)
                 dayCost += cc.cost
+                hasMessages = hasMessages || cc.messages > 0
             }
-            if dayTokens == 0 && dayCost == 0 { continue }
+            if dayTokens == 0 && dayCost == 0 && !hasMessages { continue }
             let entry = PerDay(date: c.date, tokens: dayTokens, cost: dayCost, intensity: c.intensity)
             perDay.append(entry)
             perDayMap[c.date] = entry

--- a/Sources/TokenBarCore/UsageStats.swift
+++ b/Sources/TokenBarCore/UsageStats.swift
@@ -43,12 +43,18 @@ public struct PerDay: Sendable {
     public let tokens: Int64
     public let cost: Double
     public let intensity: Int
+    public let hasMessages: Bool
+    public var isActive: Bool { tokens > 0 || hasMessages }
 
-    public init(date: String, tokens: Int64, cost: Double, intensity: Int) {
+    public init(
+        date: String, tokens: Int64, cost: Double, intensity: Int,
+        hasMessages: Bool = false
+    ) {
         self.date = date
         self.tokens = tokens
         self.cost = cost
         self.intensity = intensity
+        self.hasMessages = hasMessages
     }
 }
 
@@ -97,7 +103,9 @@ public struct UsageStats: Sendable {
                 hasMessages = hasMessages || cc.messages > 0
             }
             if dayTokens == 0 && dayCost == 0 && !hasMessages { continue }
-            let entry = PerDay(date: c.date, tokens: dayTokens, cost: dayCost, intensity: c.intensity)
+            let entry = PerDay(
+                date: c.date, tokens: dayTokens, cost: dayCost,
+                intensity: c.intensity, hasMessages: hasMessages)
             perDay.append(entry)
             perDayMap[c.date] = entry
             totalTokens = totalTokens.saturatingAdding(dayTokens)
@@ -180,7 +188,7 @@ extension UsageStats {
 
 extension Streaks {
     /// Port of computeStreaks: walk every calendar day in the range; a day is
-    /// active when it has tokens. Current counts back from the range end.
+    /// active when it has tokens or messages. Current counts back from the range end.
     public static func compute(
         perDayMap: [String: PerDay], rangeStart: String, rangeEnd: String
     ) -> Streaks {
@@ -192,7 +200,7 @@ extension Streaks {
         var run = 0
         var current = 0
         for n in start.number...end.number {
-            let active = (perDayMap[ISODay(number: n).iso]?.tokens ?? 0) > 0
+            let active = perDayMap[ISODay(number: n).iso]?.isActive ?? false
             if active {
                 run += 1
                 longest = max(longest, run)
@@ -201,7 +209,7 @@ extension Streaks {
             }
         }
         for n in stride(from: end.number, through: start.number, by: -1) {
-            if (perDayMap[ISODay(number: n).iso]?.tokens ?? 0) > 0 { current += 1 } else { break }
+            if perDayMap[ISODay(number: n).iso]?.isActive == true { current += 1 } else { break }
         }
         return Streaks(longest: longest, current: current)
     }

--- a/Sources/TokenBarCore/UsageStats.swift
+++ b/Sources/TokenBarCore/UsageStats.swift
@@ -138,13 +138,13 @@ public struct UsageStats: Sendable {
 
 extension UsageStats {
     /// A contribution stripe is "visible activity" when its client isn't hidden
-    /// and it carries tokens or cost.
+    /// and it carries tokens, cost, or messages.
     private static func isVisible(_ cc: ContributionClient, hidden: Set<String>) -> Bool {
-        !hidden.contains(cc.client) && (cc.tokens.total > 0 || cc.cost > 0)
+        !hidden.contains(cc.client) && (cc.tokens.total > 0 || cc.cost > 0 || cc.messages > 0)
     }
 
     /// The set of `YYYY` years in which at least one NON-hidden client had
-    /// activity (tokens or cost), derived from a payload's contributions. Used
+    /// activity (tokens, cost, or messages), derived from a payload's contributions. Used
     /// to drop from the year picker years that only hidden clients used. Only
     /// meaningful over an all-time payload (contributions spanning every year);
     /// callers fall back to the unfiltered known-year list when the payload is


### PR DESCRIPTION
## Summary

- retain selected message-only contributions in Daily and Monthly rows and model drill-downs
- count message-only days in shared active-day, year-visibility, and streak semantics
- keep the token/cost chart anchored to its selected metric series when later message-only activity exists

## Context

Follow-up to the unresolved P2 review thread on #128. Monthly already retained message-only contributions, while Daily and several shared activity consumers still filtered them by tokens and cost.

## Verification

- `make selftest`
- `git diff --check`
- Codex review loop: all four #129 threads fixed, replied to, and resolved
- delayed GraphQL review-thread check: no unresolved, non-outdated current-head thread
- GitHub CI `build`: passed