### PR TITLE
chore(release): prepare v1.11.0 notes

### DIFF
--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -1,15 +1,7 @@
-## Highlights
-
-- **Add optional menu bar items for individual clients.** Enable eligible clients in Settings to show their brand icon and the remaining quota for Auto or a selected window; clicking an item opens TokenBar on that client. [#119](https://github.com/Nanako0129/TokenBar/pull/119)
-- **Settings now uses native sidebar navigation.** Menu Bar, Dashboard, General, and About each get a focused page while the live preview remains visible, and quota source selection is now organized as Agent then Window. [#117](https://github.com/Nanako0129/TokenBar/pull/117)
-
 ## Changes
 
-- **Reorder client tabs directly in the popover.** Drag tabs along the top bar; Overview stays first, and hidden clients keep their saved positions. [#116](https://github.com/Nanako0129/TokenBar/pull/116) — thanks @amikai
+- **Daily and Monthly usage now show Codex and Claude turn counts alongside message totals.** Turn counts are scoped to the visible supported clients, while message totals continue to include every visible client, making human interactions easier to distinguish from agent and tool-loop activity. [#128](https://github.com/Nanako0129/TokenBar/pull/128)
 
 ## Fixes
 
-- **Historical quota pace now starts from validated evidence instead of a fixed completed-cycle requirement.** A stable current cycle can qualify earlier; insufficient or low-quality history stays in learning mode, and risk remains hidden until enough evidence exists. [#120](https://github.com/Nanako0129/TokenBar/pull/120)
-- **Claude quota cards now reflect live Pro and Max subscription changes** instead of relying only on a login-time plan snapshot. The live lookup is bounded and cached, with stored plan data used as a fallback when needed. [#124](https://github.com/Nanako0129/TokenBar/pull/124)
-- **Grok usage is attributed to models more safely across process restarts and subagents.** Ambiguous or conflicting evidence remains unattributed instead of being guessed. [#123](https://github.com/Nanako0129/TokenBar/pull/123)
-- **Popover height dragging stays responsive,** and Settings and Quit continue responding normally after a resize. [#110](https://github.com/Nanako0129/TokenBar/pull/110)
+- **Message-only activity now remains visible throughout usage history.** Days and months with messages but no tokens or cost are retained in Daily and Monthly views, drill-downs, active-day counts, streaks, and year visibility without distorting token or cost charts. [#129](https://github.com/Nanako0129/TokenBar/pull/129)

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -1,10 +1,4 @@
 New:
-- Add optional menu bar items for individual clients, showing a brand icon and remaining quota for Auto or a selected window; clicking one opens TokenBar on that client.
-- Settings now uses native sidebar navigation for Menu Bar, Dashboard, General, and About, with the live preview kept visible.
-- Drag client tabs to reorder them directly in the popover; Overview stays first and hidden clients keep their saved positions.
-Improved:
-- Historical quota pace can start once current-cycle evidence passes quality checks; insufficient history remains in learning mode and unvalidated risk stays hidden.
+- Daily and Monthly usage now show Codex and Claude turn counts alongside message totals, making human interactions easier to distinguish from agent and tool-loop activity.
 Fixes:
-- Claude quota cards reflect live Pro and Max plan changes instead of a stale login-time label.
-- Grok usage is attributed more safely across process restarts and subagents; ambiguous evidence stays unattributed.
-- Popover height dragging remains responsive, and Settings and Quit continue responding normally after resizing.
+- Message-only activity remains visible in Daily and Monthly history, drill-downs, active-day counts, streaks, and year visibility without distorting token or cost charts.


### PR DESCRIPTION
## Summary

- replace the shipped v1.10.0 overrides with the reviewed v1.11.0 user-visible change set for GitHub Release and Sparkle
- describe scoped Codex and Claude turn counts alongside existing message totals
- cover message-only activity across Daily and Monthly history, drill-downs, activity statistics, streaks, year visibility, and metric charts
- preserve generator ownership of the Markdown Full Changelog tail

## Verification

- `git diff --cached --check`
- focused assertions for exact file scope, PR links, omitted generated tail, plain-text heading order, link-free plain text, and line budget

> This PR prepares release text only. It does not create the `v1.11.0` tag, publish a GitHub Release, update the appcast or Homebrew cask, or otherwise run the release workflow.