### PR TITLE
fix(usage): cache hourly reports across popover reopen

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -121,7 +121,10 @@ private struct DashboardSnapshot {
     private static var lastSnapshot: DashboardSnapshot?
     /// Reopen cache for the expensive hourly fold. Multiple slices coexist so
     /// Daily/Monthly's Codex+Claude report cannot evict Hourly's all-client one.
+    // ponytail: FIFO at eight slices bounds memory; use LRU only if churn shows misses.
+    private static let hourlyCacheLimit = 8
     private static var hourlyCache: [HourlyCacheKey: HourlyReport] = [:]
+    private static var hourlyCacheOrder: [HourlyCacheKey] = []
     /// Whether this model owns the shared `lastSnapshot` (true only for the
     /// popover's model, whose teardown/rebuild is what the cache speeds up).
     private let cachesSnapshot: Bool
@@ -354,7 +357,14 @@ private struct DashboardSnapshot {
         hourlyClients = clients
         hourlyYear = yearKey
         if cachesSnapshot {
-            Self.hourlyCache[HourlyCacheKey(year: yearKey, clients: clients)] = report
+            let cacheKey = HourlyCacheKey(year: yearKey, clients: clients)
+            if Self.hourlyCache[cacheKey] == nil {
+                Self.hourlyCacheOrder.append(cacheKey)
+                if Self.hourlyCacheOrder.count > Self.hourlyCacheLimit {
+                    Self.hourlyCache.removeValue(forKey: Self.hourlyCacheOrder.removeFirst())
+                }
+            }
+            Self.hourlyCache[cacheKey] = report
         }
     }
 

--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -80,11 +80,9 @@ enum AgentUsagePublicationCoordinator {
 /// load so a fresh DashboardModel can start in `.ready` state instead of
 /// flashing "Loading usage…" every time the popover reopens.
 ///
-/// Only `hourly`/`agents` are excluded: they are the lazy lenses that
-/// `ensureData(for:)` refetches *solely when nil*, so restoring stale non-nil
-/// values would strand them on a previous year's slice (Codex P2-1/P2-3)
-/// until the 60s pollGraph tick. `agentUsage`/`trace` are NOT lazy lenses —
-/// their pollers (`pollAgentUsage`/`pollTrace`) fetch-first and overwrite
+/// `hourly` is excluded because it has its own year/client-keyed process cache;
+/// `agents` remains uncached. `agentUsage`/`trace` are NOT lazy lenses — their
+/// pollers (`pollAgentUsage`/`pollTrace`) fetch-first and overwrite
 /// unconditionally — so caching them is staleness-free and keeps the Overview
 /// tab's live/quota cards populated on reopen instead of flashing placeholders.
 private struct DashboardSnapshot {
@@ -103,6 +101,11 @@ private struct DashboardSnapshot {
 /// first time their lens becomes active, mirroring the Tauri app's
 /// empty-year short-circuit hooks.
 @MainActor @Observable final class DashboardModel {
+    private struct HourlyCacheKey: Hashable {
+        let year: String
+        let clients: Set<String>
+    }
+
     /// Survives the model's deallocation so the next PopoverView starts with
     /// cached data instead of `.loading`. A deliberate process-lifetime cache
     /// (one COW-shared value snapshot, never invalidated). Every model may
@@ -116,6 +119,9 @@ private struct DashboardSnapshot {
     /// popover open/close — that deletes this static, DashboardSnapshot, and
     /// the year guard while preserving the Phase B CPU win.
     private static var lastSnapshot: DashboardSnapshot?
+    /// Reopen cache for the expensive hourly fold. Multiple slices coexist so
+    /// Daily/Monthly's Codex+Claude report cannot evict Hourly's all-client one.
+    private static var hourlyCache: [HourlyCacheKey: HourlyReport] = [:]
     /// Whether this model owns the shared `lastSnapshot` (true only for the
     /// popover's model, whose teardown/rebuild is what the cache speeds up).
     private let cachesSnapshot: Bool
@@ -340,6 +346,18 @@ private struct DashboardSnapshot {
         _ = beginHourlyRequest()
     }
 
+    private func publishHourly(
+        _ report: HourlyReport, year: String?, clients: Set<String>
+    ) {
+        let yearKey = Self.identityYear(year)
+        hourly = report
+        hourlyClients = clients
+        hourlyYear = yearKey
+        if cachesSnapshot {
+            Self.hourlyCache[HourlyCacheKey(year: yearKey, clients: clients)] = report
+        }
+    }
+
     private func reload(force: Bool) async {
         let year = self.year
         async let payloadTask = force
@@ -386,10 +404,10 @@ private struct DashboardSnapshot {
                self.hourlyClients == captured,
                self.hourlyYear == Self.identityYear(year),
                hourlyRequestToken == requestToken,
-               let report
+               let report,
+               let captured
             {
-                hourly = report
-                hourlyYear = Self.identityYear(year)
+                publishHourly(report, year: year, clients: captured)
             }
         }
         if agents != nil {
@@ -502,10 +520,10 @@ private struct DashboardSnapshot {
                    self.hourlyClients == captured,
                    self.hourlyYear == Self.identityYear(year),
                    hourlyRequestToken == requestToken,
-                   let report
+                   let report,
+                   let captured
                 {
-                    hourly = report
-                    hourlyYear = Self.identityYear(year)
+                    publishHourly(report, year: year, clients: captured)
                 }
             }
             if agents != nil {
@@ -590,10 +608,13 @@ private struct DashboardSnapshot {
         let yearKey = Self.identityYear(year)
         guard hourly == nil || hourlyClients != selection || hourlyYear != yearKey else { return }
 
-        // Suppress a prior report immediately while the new request is in
-        // flight. The request token additionally rejects a source completion
-        // that outlives the cancelled SwiftUI task.
-        if hourly != nil {
+        // Restore the exact slice before refreshing so reopen and lens switches
+        // do not flash a loading state. Non-popover models neither read nor
+        // write this process cache.
+        let cacheKey = HourlyCacheKey(year: yearKey, clients: selection)
+        if cachesSnapshot, let cached = Self.hourlyCache[cacheKey] {
+            publishHourly(cached, year: year, clients: selection)
+        } else if hourly != nil {
             hourly = nil
             hourlyClients = nil
             hourlyYear = nil
@@ -606,9 +627,7 @@ private struct DashboardSnapshot {
               hourlyRequestToken == requestToken,
               let report
         else { return }
-        hourly = report
-        hourlyClients = selection
-        hourlyYear = yearKey
+        publishHourly(report, year: year, clients: selection)
     }
 
     func ensureData(for view: AppView, clients: [String]) async {

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -12,12 +12,22 @@ private final class AsyncResultBox<Value: Sendable>: @unchecked Sendable {
 }
 
 private actor ControlledTurnUsageDataSource: UsageDataSource {
+    private struct PendingHourly {
+        let clients: [String]?
+        let continuation: CheckedContinuation<HourlyReport, Never>
+    }
+
     nonisolated let allowsQuotaCachePersistence = false
 
+    private let hourlyResponseClients: [String]?
     private var blockedGraphYears: Set<String> = []
     private var blockedHourlyYears: Set<String> = []
     private var pendingGraphs: [String: [CheckedContinuation<UsagePayload, Never>]] = [:]
-    private var pendingHourly: [String: [CheckedContinuation<HourlyReport, Never>]] = [:]
+    private var pendingHourly: [String: [PendingHourly]] = [:]
+
+    init(hourlyResponseClients: [String]? = nil) {
+        self.hourlyResponseClients = hourlyResponseClients
+    }
 
     private static func key(_ year: String?) -> String { year ?? "" }
 
@@ -43,9 +53,12 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
     func releaseHourly(year: String?) {
         let key = Self.key(year)
         blockedHourlyYears.remove(key)
-        let continuations = pendingHourly.removeValue(forKey: key) ?? []
-        let report = DemoData.hourlyReport(for: year, clients: ["codex", "claude"])
-        continuations.forEach { $0.resume(returning: report) }
+        let pending = pendingHourly.removeValue(forKey: key) ?? []
+        pending.forEach {
+            let report = DemoData.hourlyReport(
+                for: year, clients: hourlyResponseClients ?? $0.clients)
+            $0.continuation.resume(returning: report)
+        }
     }
 
     func graph(year: String?, priority: TaskPriority) async throws -> UsagePayload {
@@ -72,9 +85,13 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
         _ = priority
         let key = Self.key(year)
         if blockedHourlyYears.contains(key) {
-            return await withCheckedContinuation { pendingHourly[key, default: []].append($0) }
+            return await withCheckedContinuation {
+                pendingHourly[key, default: []].append(
+                    PendingHourly(clients: clients, continuation: $0))
+            }
         }
-        return DemoData.hourlyReport(for: year, clients: clients)
+        return DemoData.hourlyReport(
+            for: year, clients: hourlyResponseClients ?? clients)
     }
 
     func agentsReport(
@@ -2311,6 +2328,163 @@ enum SelfTest {
         expect(
             turnTransitionChecks?["emptyDidNotFetch"] == true,
             "an empty supported turn slice does not invoke the all-client hourly API")
+
+        let hourlyCacheChecks = awaitMainActorValue { () async -> [String: Bool] in
+            let year = "2047"
+            let turnClients = ["codex", "claude"]
+            let hourlyClients = ["codex", "claude", "gemini"]
+
+            func fingerprint(_ report: HourlyReport?) -> String? {
+                guard let report else { return nil }
+                let entries = report.entries.map {
+                    "\($0.hour)|\($0.clients.joined(separator: ","))|\($0.total)|"
+                        + "\($0.messageCount)|\($0.turnCount)|\($0.cost)"
+                }.joined(separator: ";")
+                return "\(entries)|\(report.totalCost)"
+            }
+
+            @MainActor func blockedModel(
+                source: ControlledTurnUsageDataSource,
+                cachesSnapshot: Bool = true,
+                view: AppView,
+                clients: [String]
+            ) async -> (DashboardModel, Task<Void, Never>, Bool) {
+                await source.blockHourly(year: year)
+                let model = DashboardModel(
+                    cachesSnapshot: cachesSnapshot, source: source, initialYear: year)
+                await model.load()
+                let task = Task { await model.ensureData(for: view, clients: clients) }
+                let pending = await waitUntil { await source.hasPendingHourly(year: year) }
+                return (model, task, pending)
+            }
+
+            let originalA = DemoData.hourlyReport(for: year, clients: turnClients)
+            let originalB = DemoData.hourlyReport(for: year, clients: hourlyClients)
+            let refreshedA = DemoData.hourlyReport(for: year, clients: ["claude"])
+            let nonOwnerB = DemoData.hourlyReport(for: year, clients: ["codex"])
+            let fixturesDistinct = Set([
+                fingerprint(originalA), fingerprint(originalB), fingerprint(refreshedA),
+                fingerprint(nonOwnerB),
+            ]).count == 4
+
+            // Seed two distinct popover-owned slices under the same year.
+            let seedSource = ControlledTurnUsageDataSource()
+            let seedModel = DashboardModel(
+                cachesSnapshot: true, source: seedSource, initialYear: year)
+            await seedModel.load()
+            await seedModel.ensureData(for: .monthly, clients: turnClients)
+            let seededA = fingerprint(seedModel.turnsReport(for: turnClients))
+                == fingerprint(originalA)
+            await seedModel.ensureData(for: .hourly, clients: hourlyClients)
+            let seededB = fingerprint(seedModel.hourlyReport(for: hourlyClients))
+                == fingerprint(originalB)
+
+            // A fresh popover restores A before its deliberately blocked
+            // refresh completes, then the accepted newer result replaces A.
+            let refreshSource = ControlledTurnUsageDataSource(
+                hourlyResponseClients: ["claude"])
+            let (refreshModel, refreshTask, refreshPending) = await blockedModel(
+                source: refreshSource, view: .monthly, clients: turnClients)
+            let restoredABeforeRefresh =
+                fingerprint(refreshModel.turnsReport(for: turnClients)) == fingerprint(originalA)
+            await refreshSource.releaseHourly(year: year)
+            await refreshTask.value
+            let acceptedRefreshVisible =
+                fingerprint(refreshModel.turnsReport(for: turnClients)) == fingerprint(refreshedA)
+
+            // Fresh owners prove A's replacement did not overwrite sibling B.
+            let verifyASource = ControlledTurnUsageDataSource(
+                hourlyResponseClients: ["claude"])
+            let (verifyAModel, verifyATask, verifyAPending) = await blockedModel(
+                source: verifyASource, view: .monthly, clients: turnClients)
+            let refreshedARestored =
+                fingerprint(verifyAModel.turnsReport(for: turnClients)) == fingerprint(refreshedA)
+            await verifyASource.releaseHourly(year: year)
+            await verifyATask.value
+
+            let verifyBSource = ControlledTurnUsageDataSource()
+            let (verifyBModel, verifyBTask, verifyBPending) = await blockedModel(
+                source: verifyBSource, view: .hourly, clients: hourlyClients)
+            let siblingBPreserved =
+                fingerprint(verifyBModel.hourlyReport(for: hourlyClients)) == fingerprint(originalB)
+            await verifyBSource.releaseHourly(year: year)
+            await verifyBTask.value
+
+            // An unseen client key cannot borrow either cached slice.
+            let unseenClients = ["codex"]
+            let unseenSource = ControlledTurnUsageDataSource()
+            let (unseenModel, unseenTask, unseenPending) = await blockedModel(
+                source: unseenSource, view: .hourly, clients: unseenClients)
+            let unseenStayedEmpty = unseenModel.hourlyReport(for: unseenClients) == nil
+            await unseenSource.releaseHourly(year: year)
+            await unseenTask.value
+
+            // Non-owners neither read A nor replace it with their local B.
+            let nonOwnerSource = ControlledTurnUsageDataSource(
+                hourlyResponseClients: ["codex"])
+            let (nonOwnerModel, nonOwnerTask, nonOwnerPending) = await blockedModel(
+                source: nonOwnerSource, cachesSnapshot: false,
+                view: .monthly, clients: turnClients)
+            let nonOwnerDidNotRead = nonOwnerModel.turnsReport(for: turnClients) == nil
+            await nonOwnerSource.releaseHourly(year: year)
+            await nonOwnerTask.value
+            let nonOwnerReceivedLocalB =
+                fingerprint(nonOwnerModel.turnsReport(for: turnClients)) == fingerprint(nonOwnerB)
+
+            let ownerAfterSource = ControlledTurnUsageDataSource(
+                hourlyResponseClients: ["claude"])
+            let (ownerAfterModel, ownerAfterTask, ownerAfterPending) = await blockedModel(
+                source: ownerAfterSource, view: .monthly, clients: turnClients)
+            let nonOwnerDidNotWrite =
+                fingerprint(ownerAfterModel.turnsReport(for: turnClients)) == fingerprint(refreshedA)
+            await ownerAfterSource.releaseHourly(year: year)
+            await ownerAfterTask.value
+
+            return [
+                "fixturesDistinct": fixturesDistinct,
+                "seededA": seededA,
+                "seededB": seededB,
+                "refreshPending": refreshPending,
+                "restoredABeforeRefresh": restoredABeforeRefresh,
+                "acceptedRefreshVisible": acceptedRefreshVisible,
+                "verifyAPending": verifyAPending,
+                "refreshedARestored": refreshedARestored,
+                "verifyBPending": verifyBPending,
+                "siblingBPreserved": siblingBPreserved,
+                "unseenPending": unseenPending,
+                "unseenStayedEmpty": unseenStayedEmpty,
+                "nonOwnerPending": nonOwnerPending,
+                "nonOwnerDidNotRead": nonOwnerDidNotRead,
+                "nonOwnerReceivedLocalB": nonOwnerReceivedLocalB,
+                "ownerAfterPending": ownerAfterPending,
+                "nonOwnerDidNotWrite": nonOwnerDidNotWrite,
+            ]
+        }
+        expect(
+            hourlyCacheChecks?["fixturesDistinct"] == true
+                && hourlyCacheChecks?["seededA"] == true
+                && hourlyCacheChecks?["seededB"] == true
+                && hourlyCacheChecks?["refreshPending"] == true
+                && hourlyCacheChecks?["restoredABeforeRefresh"] == true
+                && hourlyCacheChecks?["acceptedRefreshVisible"] == true,
+            "hourly cache restores immediately and an accepted refresh replaces its exact key")
+        expect(
+            hourlyCacheChecks?["verifyAPending"] == true
+                && hourlyCacheChecks?["refreshedARestored"] == true
+                && hourlyCacheChecks?["verifyBPending"] == true
+                && hourlyCacheChecks?["siblingBPreserved"] == true,
+            "hourly cache keeps refreshed turn and all-client slices independent")
+        expect(
+            hourlyCacheChecks?["unseenPending"] == true
+                && hourlyCacheChecks?["unseenStayedEmpty"] == true,
+            "hourly cache never restores a report under an unseen client key")
+        expect(
+            hourlyCacheChecks?["nonOwnerPending"] == true
+                && hourlyCacheChecks?["nonOwnerDidNotRead"] == true
+                && hourlyCacheChecks?["nonOwnerReceivedLocalB"] == true
+                && hourlyCacheChecks?["ownerAfterPending"] == true
+                && hourlyCacheChecks?["nonOwnerDidNotWrite"] == true,
+            "non-owning dashboard models neither read nor replace the popover hourly cache")
 
         // Tab order (plan 2026-07-16): Monthly leads Daily in the tab row.
         expect(AppView.allCases.map(\.rawValue) ==

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -19,14 +19,14 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
 
     nonisolated let allowsQuotaCachePersistence = false
 
-    private let hourlyResponseClients: [String]?
+    private let hourlyResponses: [Set<String>: HourlyReport]
     private var blockedGraphYears: Set<String> = []
     private var blockedHourlyYears: Set<String> = []
     private var pendingGraphs: [String: [CheckedContinuation<UsagePayload, Never>]] = [:]
     private var pendingHourly: [String: [PendingHourly]] = [:]
 
-    init(hourlyResponseClients: [String]? = nil) {
-        self.hourlyResponseClients = hourlyResponseClients
+    init(hourlyResponses: [Set<String>: HourlyReport] = [:]) {
+        self.hourlyResponses = hourlyResponses
     }
 
     private static func key(_ year: String?) -> String { year ?? "" }
@@ -55,8 +55,8 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
         blockedHourlyYears.remove(key)
         let pending = pendingHourly.removeValue(forKey: key) ?? []
         pending.forEach {
-            let report = DemoData.hourlyReport(
-                for: year, clients: hourlyResponseClients ?? $0.clients)
+            let report = hourlyResponses[Set($0.clients ?? [])]
+                ?? DemoData.hourlyReport(for: year, clients: $0.clients)
             $0.continuation.resume(returning: report)
         }
     }
@@ -90,8 +90,8 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
                     PendingHourly(clients: clients, continuation: $0))
             }
         }
-        return DemoData.hourlyReport(
-            for: year, clients: hourlyResponseClients ?? clients)
+        return hourlyResponses[Set(clients ?? [])]
+            ?? DemoData.hourlyReport(for: year, clients: clients)
     }
 
     func agentsReport(
@@ -2343,6 +2343,21 @@ enum SelfTest {
                 return "\(entries)|\(report.totalCost)"
             }
 
+            func report(client: String, turns: Int) -> HourlyReport {
+                let json: [String: Any] = [
+                    "entries": [[
+                        "hour": "2047-01-01 00:00", "clients": [client],
+                        "models": ["fixture"], "input": 0, "output": 0,
+                        "cacheRead": 0, "cacheWrite": 0, "reasoning": 0,
+                        "total": turns, "messageCount": turns, "turnCount": turns,
+                        "cost": Double(turns),
+                    ]],
+                    "totalCost": Double(turns),
+                ]
+                let data = try! JSONSerialization.data(withJSONObject: json)
+                return try! JSONDecoder().decode(HourlyReport.self, from: data)
+            }
+
             @MainActor func blockedModel(
                 source: ControlledTurnUsageDataSource,
                 cachesSnapshot: Bool = true,
@@ -2358,17 +2373,20 @@ enum SelfTest {
                 return (model, task, pending)
             }
 
-            let originalA = DemoData.hourlyReport(for: year, clients: turnClients)
-            let originalB = DemoData.hourlyReport(for: year, clients: hourlyClients)
-            let refreshedA = DemoData.hourlyReport(for: year, clients: ["claude"])
-            let nonOwnerB = DemoData.hourlyReport(for: year, clients: ["codex"])
+            let originalA = report(client: "a", turns: 1)
+            let originalB = report(client: "b", turns: 2)
+            let refreshedA = report(client: "a-new", turns: 3)
+            let nonOwnerB = report(client: "local", turns: 4)
             let fixturesDistinct = Set([
                 fingerprint(originalA), fingerprint(originalB), fingerprint(refreshedA),
                 fingerprint(nonOwnerB),
             ]).count == 4
 
             // Seed two distinct popover-owned slices under the same year.
-            let seedSource = ControlledTurnUsageDataSource()
+            let seedSource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(turnClients): originalA,
+                Set(hourlyClients): originalB,
+            ])
             let seedModel = DashboardModel(
                 cachesSnapshot: true, source: seedSource, initialYear: year)
             await seedModel.load()
@@ -2381,8 +2399,9 @@ enum SelfTest {
 
             // A fresh popover restores A before its deliberately blocked
             // refresh completes, then the accepted newer result replaces A.
-            let refreshSource = ControlledTurnUsageDataSource(
-                hourlyResponseClients: ["claude"])
+            let refreshSource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(turnClients): refreshedA,
+            ])
             let (refreshModel, refreshTask, refreshPending) = await blockedModel(
                 source: refreshSource, view: .monthly, clients: turnClients)
             let restoredABeforeRefresh =
@@ -2393,8 +2412,9 @@ enum SelfTest {
                 fingerprint(refreshModel.turnsReport(for: turnClients)) == fingerprint(refreshedA)
 
             // Fresh owners prove A's replacement did not overwrite sibling B.
-            let verifyASource = ControlledTurnUsageDataSource(
-                hourlyResponseClients: ["claude"])
+            let verifyASource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(turnClients): refreshedA,
+            ])
             let (verifyAModel, verifyATask, verifyAPending) = await blockedModel(
                 source: verifyASource, view: .monthly, clients: turnClients)
             let refreshedARestored =
@@ -2402,7 +2422,9 @@ enum SelfTest {
             await verifyASource.releaseHourly(year: year)
             await verifyATask.value
 
-            let verifyBSource = ControlledTurnUsageDataSource()
+            let verifyBSource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(hourlyClients): originalB,
+            ])
             let (verifyBModel, verifyBTask, verifyBPending) = await blockedModel(
                 source: verifyBSource, view: .hourly, clients: hourlyClients)
             let siblingBPreserved =
@@ -2412,7 +2434,9 @@ enum SelfTest {
 
             // An unseen client key cannot borrow either cached slice.
             let unseenClients = ["codex"]
-            let unseenSource = ControlledTurnUsageDataSource()
+            let unseenSource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(unseenClients): nonOwnerB,
+            ])
             let (unseenModel, unseenTask, unseenPending) = await blockedModel(
                 source: unseenSource, view: .hourly, clients: unseenClients)
             let unseenStayedEmpty = unseenModel.hourlyReport(for: unseenClients) == nil
@@ -2420,8 +2444,9 @@ enum SelfTest {
             await unseenTask.value
 
             // Non-owners neither read A nor replace it with their local B.
-            let nonOwnerSource = ControlledTurnUsageDataSource(
-                hourlyResponseClients: ["codex"])
+            let nonOwnerSource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(turnClients): nonOwnerB,
+            ])
             let (nonOwnerModel, nonOwnerTask, nonOwnerPending) = await blockedModel(
                 source: nonOwnerSource, cachesSnapshot: false,
                 view: .monthly, clients: turnClients)
@@ -2431,14 +2456,41 @@ enum SelfTest {
             let nonOwnerReceivedLocalB =
                 fingerprint(nonOwnerModel.turnsReport(for: turnClients)) == fingerprint(nonOwnerB)
 
-            let ownerAfterSource = ControlledTurnUsageDataSource(
-                hourlyResponseClients: ["claude"])
+            let ownerAfterSource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(turnClients): refreshedA,
+            ])
             let (ownerAfterModel, ownerAfterTask, ownerAfterPending) = await blockedModel(
                 source: ownerAfterSource, view: .monthly, clients: turnClients)
             let nonOwnerDidNotWrite =
                 fingerprint(ownerAfterModel.turnsReport(for: turnClients)) == fingerprint(refreshedA)
             await ownerAfterSource.releaseHourly(year: year)
             await ownerAfterTask.value
+
+            // Six more keys bring the cache to nine total slices; the fixed
+            // eight-entry FIFO must evict A, which was inserted first.
+            for suffix in 0..<6 {
+                let extraYear = "205\(suffix)"
+                let extraModel = DashboardModel(
+                    cachesSnapshot: true, source: seedSource, initialYear: extraYear)
+                await extraModel.load()
+                await extraModel.ensureData(for: .monthly, clients: turnClients)
+            }
+            let evictionSource = ControlledTurnUsageDataSource(hourlyResponses: [
+                Set(turnClients): refreshedA,
+            ])
+            await evictionSource.blockHourly(year: year)
+            let evictionModel = DashboardModel(
+                cachesSnapshot: true, source: evictionSource, initialYear: year)
+            await evictionModel.load()
+            let evictionTask = Task {
+                await evictionModel.ensureData(for: .monthly, clients: turnClients)
+            }
+            let evictionPending = await waitUntil {
+                await evictionSource.hasPendingHourly(year: year)
+            }
+            let oldestEvicted = evictionModel.turnsReport(for: turnClients) == nil
+            await evictionSource.releaseHourly(year: year)
+            await evictionTask.value
 
             return [
                 "fixturesDistinct": fixturesDistinct,
@@ -2458,6 +2510,8 @@ enum SelfTest {
                 "nonOwnerReceivedLocalB": nonOwnerReceivedLocalB,
                 "ownerAfterPending": ownerAfterPending,
                 "nonOwnerDidNotWrite": nonOwnerDidNotWrite,
+                "evictionPending": evictionPending,
+                "oldestEvicted": oldestEvicted,
             ]
         }
         expect(
@@ -2485,6 +2539,10 @@ enum SelfTest {
                 && hourlyCacheChecks?["ownerAfterPending"] == true
                 && hourlyCacheChecks?["nonOwnerDidNotWrite"] == true,
             "non-owning dashboard models neither read nor replace the popover hourly cache")
+        expect(
+            hourlyCacheChecks?["evictionPending"] == true
+                && hourlyCacheChecks?["oldestEvicted"] == true,
+            "hourly cache evicts its oldest slice after reaching eight entries")
 
         // Tab order (plan 2026-07-16): Monthly leads Daily in the tab row.
         expect(AppView.allCases.map(\.rawValue) ==


### PR DESCRIPTION
## What changed

- cache hourly usage reports by normalized year and selected client set
- restore the exact cached slice when a popover-owned dashboard model is recreated
- refresh in the background and replace only the matching cache key
- keep non-popover dashboard models isolated from the shared cache

## Why

Opening the menu bar popover creates a fresh DashboardModel. Hourly data was intentionally excluded from the existing dashboard snapshot, so Daily, Monthly, and Hourly views returned to a loading state and repeated the expensive hourly fold on every reopen. A single retained hourly report would also be incorrect because the turn-count slice (Codex and Claude) differs from the all-client Hourly slice.

## Impact

Reopening the popover or switching back to a previously loaded hourly slice now shows the last accepted report immediately while fresh data loads. Different years and client selections coexist without overwriting one another.

## Validation

- `make selftest`
- `git diff --cached --check`