### PR TITLE
feat(usage): show turn-count loading state

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -202,6 +202,7 @@ private struct DashboardSnapshot {
     private(set) var modelReport: ModelReport?
     private(set) var colors = ModelColorMap(report: nil)
     private(set) var hourly: HourlyReport?
+    private(set) var hourlyLoading = false
     private(set) var agents: AgentsReport?
     private(set) var agentUsage: AgentUsagePayload?
     /// True once the first `pollAgentUsage()` attempt has finished, whether it
@@ -344,6 +345,7 @@ private struct DashboardSnapshot {
 
     private func invalidateHourly() {
         hourly = nil
+        hourlyLoading = false
         hourlyClients = nil
         hourlyYear = nil
         _ = beginHourlyRequest()
@@ -630,13 +632,12 @@ private struct DashboardSnapshot {
             hourlyYear = nil
         }
         let requestToken = beginHourlyRequest()
+        hourlyLoading = true
         let report = try? await source.hourlyReport(
             year: year, clients: clients, priority: .userInitiated)
-        guard !Task.isCancelled,
-              self.year == year,
-              hourlyRequestToken == requestToken,
-              let report
-        else { return }
+        guard self.year == year, hourlyRequestToken == requestToken else { return }
+        hourlyLoading = false
+        guard !Task.isCancelled, let report else { return }
         publishHourly(report, year: year, clients: selection)
     }
 

--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -473,12 +473,14 @@ struct PopoverView: View {
                 DailyView(
                     payload: payload, clientIds: clientIds,
                     hourlyReport: model.turnsReport(for: turnClientIds),
-                    turnClientIds: turnClientIds, colors: model.colors)
+                    turnClientIds: turnClientIds, turnsLoading: model.hourlyLoading,
+                    colors: model.colors)
             case .monthly:
                 MonthlyView(
                     payload: payload, clientIds: clientIds,
                     hourlyReport: model.turnsReport(for: turnClientIds),
-                    turnClientIds: turnClientIds, colors: model.colors)
+                    turnClientIds: turnClientIds, turnsLoading: model.hourlyLoading,
+                    colors: model.colors)
             case .hourly:
                 HourlyView(report: model.hourlyReport(for: clientIds), clientIds: clientIds)
             case .stats:

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2225,6 +2225,16 @@ enum SelfTest {
             ) == ["claude", "codex"]
                 && PopoverView.supportedTurnClients(["gemini", "opencode"]).isEmpty,
             "turn scope preserves display order and excludes unsupported clients")
+        expect(
+            TurnCountBuckets.showsLoading(
+                report: nil, requestInFlight: true, clientIds: ["codex", "claude"])
+                && !TurnCountBuckets.showsLoading(
+                    report: turnReport, requestInFlight: true, clientIds: ["codex"])
+                && !TurnCountBuckets.showsLoading(
+                    report: nil, requestInFlight: false, clientIds: ["codex"])
+                && !TurnCountBuckets.showsLoading(
+                    report: nil, requestInFlight: true, clientIds: []),
+            "turn spinner appears only while a supported report is in flight")
         let dailyMessageOnlyView = DailyView(
             payload: messageOnlyPayload, clientIds: ["codex"], hourlyReport: turnReport,
             turnClientIds: ["codex", "claude"], colors: ModelColorMap(report: nil)

--- a/Sources/TokenBar/Views/DailyView.swift
+++ b/Sources/TokenBar/Views/DailyView.swift
@@ -22,6 +22,12 @@ enum TurnCountBuckets {
         }
     }
 
+    static func showsLoading(
+        report: HourlyReport?, requestInFlight: Bool, clientIds: [String]
+    ) -> Bool {
+        report == nil && requestInFlight && !clientIds.isEmpty
+    }
+
     private static func fold(
         _ report: HourlyReport?, key: (String) -> String
     ) -> [String: Int64] {
@@ -69,6 +75,7 @@ struct DailyView: View {
     var clientIds: [String] = []
     let hourlyReport: HourlyReport?
     var turnClientIds: [String] = []
+    var turnsLoading = false
     let colors: ModelColorMap
 
     @State private var openDate: String?
@@ -211,6 +218,14 @@ struct DailyView: View {
                         Text("%@ turns".localized(turns.formatted()))
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
+                    } else if TurnCountBuckets.showsLoading(
+                        report: hourlyReport, requestInFlight: turnsLoading,
+                        clientIds: turnClientIds)
+                    {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .frame(width: 10, height: 10)
+                            .accessibilityLabel("Loading…")
                     }
                     Spacer()
                     Text(Format.compactTokens(row.tokens))

--- a/Sources/TokenBar/Views/MonthlyView.swift
+++ b/Sources/TokenBar/Views/MonthlyView.swift
@@ -16,6 +16,7 @@ struct MonthlyView: View {
     var clientIds: [String] = []
     let hourlyReport: HourlyReport?
     var turnClientIds: [String] = []
+    var turnsLoading = false
     let colors: ModelColorMap
 
     @State private var openMonth: String?
@@ -174,6 +175,14 @@ struct MonthlyView: View {
                         Text("%@ turns".localized(turns.formatted()))
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
+                    } else if TurnCountBuckets.showsLoading(
+                        report: hourlyReport, requestInFlight: turnsLoading,
+                        clientIds: turnClientIds)
+                    {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .frame(width: 10, height: 10)
+                            .accessibilityLabel("Loading…")
                     }
                     Spacer()
                     Text(Format.compactTokens(row.tokens))


### PR DESCRIPTION
## What changed

- track request-scoped hourly loading state
- show a mini spinner beside message counts in Daily and Monthly while turn counts load
- replace the spinner with the turn count after the report arrives
- avoid stale spinners for cached, failed, cancelled, and unsupported slices

## Why

Message rows render before the separate Codex and Claude hourly fold completes. Previously the turn column was blank, so it looked missing rather than still loading.

## Impact

Users see that message usage is ready while turn counts are still being calculated, without blocking the card or hiding cached data.

## Validation

- `make selftest`
- `git diff --cached --check`