### PR TITLE
feat(claude): map model-scoped weekly limits from the usage limits[] array

### DIFF
--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -1079,6 +1079,8 @@ struct ClaudeUsageResponse {
     seven_day_cowork: Option<ClaudeWindow>,
     #[serde(default, deserialize_with = "deserialize_optional_raw")]
     cowork: Option<ClaudeWindow>,
+    #[serde(default, deserialize_with = "deserialize_optional_claude_limits")]
+    limits: Option<Vec<ClaudeLimitEntry>>,
     #[serde(default, deserialize_with = "deserialize_optional_raw")]
     extra_usage: Option<ClaudeExtraUsage>,
 }
@@ -1096,6 +1098,34 @@ impl ClaudeWindow {
         self.utilization
             .is_some_and(|used| used.is_finite() && (0.0..=100.0).contains(&used))
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeLimitEntry {
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty_string")]
+    kind: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty_string")]
+    group: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    percent: Option<f64>,
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty_string")]
+    resets_at: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_raw")]
+    scope: Option<ClaudeLimitScope>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeLimitScope {
+    #[serde(default, deserialize_with = "deserialize_optional_raw")]
+    model: Option<ClaudeLimitModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeLimitModel {
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty_string")]
+    id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_non_empty_string")]
+    display_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3905,6 +3935,7 @@ fn claude_windows(usage: &ClaudeUsageResponse, now: DateTime<Utc>) -> Vec<UsageW
         usage.routines_window(),
         now,
     );
+    append_claude_scoped_windows(&mut windows, usage.limits.as_deref(), now);
     if let Some(extra) = claude_extra_usage_window(usage.extra_usage.as_ref()) {
         windows.push(extra);
     }
@@ -3977,6 +4008,111 @@ fn map_claude_window(
             )
         },
     )
+}
+
+fn append_claude_scoped_windows(
+    windows: &mut Vec<UsageWindow>,
+    limits: Option<&[ClaudeLimitEntry]>,
+    now: DateTime<Utc>,
+) {
+    // Flat labels are the provider's human model names; compare them with the
+    // scoped display name rather than the id slug, which may include a
+    // namespace or version.
+    let flat_model_slugs = windows
+        .iter()
+        .map(|window| claude_slug(&window.label))
+        .collect::<HashSet<_>>();
+    let mut emitted_slugs = HashSet::new();
+    for entry in limits.unwrap_or(&[]) {
+        // Do not filter on `is_active`: live enforceable limits can report false.
+        if entry.group.as_deref() != Some("weekly")
+            || entry.kind.as_deref() != Some("weekly_scoped")
+        {
+            continue;
+        }
+        let Some(percent) = entry
+            .percent
+            .filter(|percent| percent.is_finite() && (0.0..=100.0).contains(percent))
+        else {
+            continue;
+        };
+        let Some(model) = entry.scope.as_ref().and_then(|scope| scope.model.as_ref()) else {
+            continue;
+        };
+        let Some(display_name) = model
+            .display_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|display_name| !display_name.is_empty())
+        else {
+            continue;
+        };
+        let display_name_slug = claude_slug(display_name);
+        let model_id_slug = model
+            .id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(claude_slug);
+        if model_id_slug
+            .as_deref()
+            .is_some_and(claude_is_all_models_slug)
+            || claude_is_all_models_slug(&display_name_slug)
+        {
+            continue;
+        }
+        if flat_model_slugs.contains(&display_name_slug) {
+            continue;
+        }
+        let Some(slug) = model_id_slug
+            .filter(|slug| !slug.is_empty())
+            .or_else(|| (!display_name_slug.is_empty()).then_some(display_name_slug.clone()))
+        else {
+            continue;
+        };
+        if !emitted_slugs.insert(slug.clone()) {
+            continue;
+        }
+        let window_key = format!("weekly_scoped.{slug}.v1");
+        let resets_at = entry.resets_at.as_deref().and_then(parse_datetime);
+        if let Some(window) = UsageWindow::try_from_provider_used_percent(
+            format!("{display_name} only"),
+            percent,
+            resets_at,
+            now,
+        )
+        .map(|window| {
+            window.with_identity(
+                window_key.clone(),
+                Some(window_key),
+                None,
+                Some(DurationEvidence::contract(7 * 24 * 60 * 60)),
+            )
+        }) {
+            windows.push(window);
+        }
+    }
+}
+
+fn claude_is_all_models_slug(slug: &str) -> bool {
+    slug == "all-models" || slug.ends_with("-all-models")
+}
+
+fn claude_slug(value: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_separator = false;
+    for character in value.chars() {
+        if character.is_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.extend(character.to_lowercase());
+            pending_separator = false;
+        } else if !slug.is_empty() {
+            pending_separator = true;
+        }
+    }
+    slug
 }
 
 /// Parse the `anthropic-ratelimit-unified-{5h,7d}-{utilization,reset}` response
@@ -4432,6 +4568,23 @@ where
         Some(Value::String(s)) => s.parse::<f64>().ok(),
         _ => None,
     })
+}
+
+fn deserialize_optional_claude_limits<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<ClaudeLimitEntry>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| {
+        value.as_array().map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| serde_json::from_value(entry.clone()).ok())
+                .collect()
+        })
+    }))
 }
 
 #[cfg(test)]
@@ -6677,6 +6830,255 @@ mod tests {
         assert_eq!(windows[2].remaining_percent, 97.0);
         assert_eq!(windows[3].label, "Designs");
         assert_eq!(windows[3].remaining_percent, 100.0);
+    }
+
+    #[test]
+    fn maps_claude_fable_scoped_weekly_limit() {
+        let raw = r#"{
+            "limits": [{
+                "kind": "weekly_scoped",
+                "group": "weekly",
+                "percent": 12.5,
+                "resets_at": "2026-08-10T00:00:00Z",
+                "scope": {"model": {
+                    "id": "claude/fable.5:promo",
+                    "display_name": "Fable"
+                }}
+            }]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let windows = claude_windows(&usage, now);
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].label, "Fable only");
+        assert_eq!(windows[0].card_id, "weekly_scoped.claude-fable-5-promo.v1");
+        assert_eq!(windows[0].used_percent, 12.5);
+        assert_eq!(
+            windows[0].resets_at.as_deref(),
+            Some("2026-08-10T00:00:00.000Z")
+        );
+    }
+
+    #[test]
+    fn maps_claude_scoped_limit_even_when_inactive() {
+        let raw = r#"{
+            "limits": [{
+                "kind": "weekly_scoped",
+                "group": "weekly",
+                "percent": 12.5,
+                "resets_at": "2026-08-10T00:00:00Z",
+                "is_active": false,
+                "scope": {"model": {
+                    "id": "claude/fable.5:promo",
+                    "display_name": "Fable"
+                }}
+            }]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        assert_eq!(claude_windows(&usage, now).len(), 1);
+    }
+
+    #[test]
+    fn skips_claude_scoped_all_models_limit() {
+        let raw = r#"{
+            "limits": [{
+                "kind": "weekly_scoped",
+                "group": "weekly",
+                "percent": 12.5,
+                "scope": {"model": {
+                    "id": "claude/all-models",
+                    "display_name": "All Models"
+                }}
+            }]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        assert!(claude_windows(&usage, now).is_empty());
+    }
+
+    #[test]
+    fn deduplicates_claude_scoped_opus_against_flat_window() {
+        let raw = r#"{
+            "seven_day_opus": {"utilization": 25},
+            "limits": [{
+                "kind": "weekly_scoped",
+                "group": "weekly",
+                "percent": 80,
+                "scope": {"model": {
+                    "id": "claude/opus.5",
+                    "display_name": "Opus"
+                }}
+            }]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let windows = claude_windows(&usage, now);
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].label, "Opus");
+        assert!(!windows[0].label.ends_with(" only"));
+        assert_eq!(windows[0].used_percent, 25.0);
+    }
+
+    /// The migration case: once Anthropic drops a flat field, the scoped entry
+    /// must take over rather than leaving the model with no window at all.
+    #[test]
+    fn maps_claude_scoped_opus_when_flat_window_absent() {
+        let raw = r#"{
+            "limits": [{
+                "kind": "weekly_scoped",
+                "group": "weekly",
+                "percent": 80,
+                "scope": {"model": {
+                    "id": "claude/opus.5",
+                    "display_name": "Opus"
+                }}
+            }]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let windows = claude_windows(&usage, now);
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].label, "Opus only");
+        assert_eq!(windows[0].card_id, "weekly_scoped.claude-opus-5.v1");
+        assert_eq!(windows[0].used_percent, 80.0);
+    }
+
+    /// End-to-end shape check against a real `oauth/usage` response captured
+    /// 2026-08-04 (percentages and timestamps replaced with neutral test
+    /// values; every field, including the ones we do not parse, kept verbatim).
+    ///
+    /// This pins three things the synthetic fixtures above cannot, because the
+    /// live payload differs from what the reference implementations led us to
+    /// expect:
+    ///   - the account-wide weekly entry is `kind: "weekly_all"` with a null
+    ///     scope, not an all-models scope, so `kind` is what actually keeps it
+    ///     out of the scoped lane;
+    ///   - the real Fable entry carries `scope.model.id: null`, so identity
+    ///     falls back to the display name;
+    ///   - the real Fable entry carries `resets_at: null` and must still
+    ///     produce a window.
+    #[test]
+    fn maps_live_claude_usage_payload_shape() {
+        let raw = r#"{
+            "five_hour": {"utilization": 55.0, "resets_at": "2026-08-10T20:40:00.197695+00:00",
+                          "limit_dollars": null, "used_dollars": null, "remaining_dollars": null},
+            "seven_day": {"utilization": 33.0, "resets_at": "2026-08-12T10:00:00.197716+00:00",
+                          "limit_dollars": null, "used_dollars": null, "remaining_dollars": null},
+            "seven_day_oauth_apps": null, "seven_day_opus": null, "seven_day_sonnet": null,
+            "seven_day_cowork": null, "seven_day_omelette": null, "tangelo": null,
+            "iguana_necktie": null, "omelette_promotional": null, "nimbus_quill": null,
+            "cinder_cove": null, "amber_ladder": null,
+            "extra_usage": {"is_enabled": false, "monthly_limit": null, "used_credits": null,
+                            "utilization": null, "currency": null, "decimal_places": null,
+                            "disabled_reason": null, "user_disabled": true,
+                            "spend_limit_reached": false, "credits_ever_enabled": true,
+                            "daily": null, "weekly": null},
+            "limits": [
+                {"kind": "session", "group": "session", "percent": 55, "severity": "normal",
+                 "resets_at": "2026-08-10T20:40:00.197695+00:00", "scope": null, "is_active": true},
+                {"kind": "weekly_all", "group": "weekly", "percent": 33, "severity": "normal",
+                 "resets_at": "2026-08-12T10:00:00.197716+00:00", "scope": null, "is_active": false},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 0, "severity": "normal",
+                 "resets_at": null,
+                 "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null},
+                 "is_active": false}
+            ],
+            "spend": {"used": {"amount_minor": 0, "currency": "USD", "exponent": 2},
+                      "limit": null, "percent": 0, "severity": "normal", "enabled": false,
+                      "disabled_reason": null, "cap": null, "balance": null, "auto_reload": null,
+                      "disclaimer": "Usage credits cover you when you hit your plan limits.",
+                      "can_purchase_credits": false, "can_toggle": false},
+            "member_dashboard_available": false
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let windows = claude_windows(&usage, now);
+
+        // Session and Weekly come from the flat fields; the `session` and
+        // `weekly_all` entries in `limits[]` describe the same two quotas and
+        // must not add duplicates.
+        assert_eq!(
+            windows
+                .iter()
+                .map(|window| window.label.as_str())
+                .collect::<Vec<_>>(),
+            ["Session", "Weekly", "Fable only"]
+        );
+        assert_eq!(windows[0].used_percent, 55.0);
+        assert_eq!(windows[1].used_percent, 33.0);
+
+        let fable = &windows[2];
+        assert_eq!(fable.card_id, "weekly_scoped.fable.v1");
+        assert_eq!(fable.used_percent, 0.0);
+        assert_eq!(fable.remaining_percent, 100.0);
+        assert_eq!(fable.resets_at, None);
+    }
+
+    /// Per-entry tolerance: one unusable element must not discard its valid
+    /// siblings, which is what separates element-wise parsing from decoding the
+    /// array as a whole.
+    #[test]
+    fn keeps_valid_claude_scoped_limit_beside_malformed_sibling() {
+        let raw = r#"{
+            "limits": [
+                42,
+                {"kind": "weekly_scoped", "group": "weekly", "percent": "oops",
+                 "scope": {"model": {"display_name": "Broken"}}},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 12.5,
+                 "scope": {"model": {
+                    "id": "claude/fable.5:promo", "display_name": "Fable"
+                 }}}
+            ]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let windows = claude_windows(&usage, now);
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].label, "Fable only");
+        assert_eq!(windows[0].used_percent, 12.5);
+    }
+
+    #[test]
+    fn ignores_malformed_claude_scoped_limits() {
+        let raw = r#"{
+            "limits": [
+                42,
+                {"kind": "session", "group": "weekly", "percent": 10,
+                 "scope": {"model": {"display_name": "Session"}}},
+                {"kind": "weekly_scoped", "group": "monthly", "percent": 10,
+                 "scope": {"model": {"display_name": "Monthly"}}},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": "NaN",
+                 "scope": {"model": {"display_name": "Infinite"}}},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 10,
+                 "scope": {"model": {"display_name": "   "}}}
+            ]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        assert!(claude_windows(&usage, now).is_empty());
+    }
+
+    #[test]
+    fn deduplicates_duplicate_claude_scoped_limit_slugs_first_wins() {
+        let raw = r#"{
+            "limits": [
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 12,
+                 "scope": {"model": {
+                    "id": "claude/fable.5:promo", "display_name": "Fable"
+                 }}},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 99,
+                 "scope": {"model": {
+                    "id": "claude/fable.5:promo", "display_name": "Fable Promo"
+                 }}}
+            ]
+        }"#;
+        let usage: ClaudeUsageResponse = serde_json::from_str(raw).unwrap();
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let windows = claude_windows(&usage, now);
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].used_percent, 12.0);
+        assert_eq!(windows[0].label, "Fable only");
     }
 
     #[test]

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -4064,12 +4064,18 @@ fn append_claude_scoped_windows(
         if flat_model_slugs.contains(&display_name_slug) {
             continue;
         }
-        let Some(slug) = model_id_slug
-            .filter(|slug| !slug.is_empty())
-            .or_else(|| (!display_name_slug.is_empty()).then_some(display_name_slug.clone()))
-        else {
+        // Identity comes from the display name, never the model id, even though
+        // the id looks like the more stable choice. The live payload reports
+        // `scope.model.id: null` while the field exists, so Anthropic populating
+        // it later would silently move this window's `card_id` and window key —
+        // dropping the user's persisted gauge selection (Swift matches
+        // `clientId|cardId` exactly) and restarting its quota-history series —
+        // with no visible change to the label. A display-name rename is the only
+        // way identity moves now, and that one is at least visible to the user.
+        if display_name_slug.is_empty() {
             continue;
-        };
+        }
+        let slug = display_name_slug;
         if !emitted_slugs.insert(slug.clone()) {
             continue;
         }
@@ -6851,7 +6857,7 @@ mod tests {
         let windows = claude_windows(&usage, now);
         assert_eq!(windows.len(), 1);
         assert_eq!(windows[0].label, "Fable only");
-        assert_eq!(windows[0].card_id, "weekly_scoped.claude-fable-5-promo.v1");
+        assert_eq!(windows[0].card_id, "weekly_scoped.fable.v1");
         assert_eq!(windows[0].used_percent, 12.5);
         assert_eq!(
             windows[0].resets_at.as_deref(),
@@ -6940,7 +6946,7 @@ mod tests {
         let windows = claude_windows(&usage, now);
         assert_eq!(windows.len(), 1);
         assert_eq!(windows[0].label, "Opus only");
-        assert_eq!(windows[0].card_id, "weekly_scoped.claude-opus-5.v1");
+        assert_eq!(windows[0].card_id, "weekly_scoped.opus.v1");
         assert_eq!(windows[0].used_percent, 80.0);
     }
 
@@ -7069,7 +7075,7 @@ mod tests {
                  }}},
                 {"kind": "weekly_scoped", "group": "weekly", "percent": 99,
                  "scope": {"model": {
-                    "id": "claude/fable.5:promo", "display_name": "Fable Promo"
+                    "id": "claude/fable.5:promo-v2", "display_name": "Fable"
                  }}}
             ]
         }"#;
@@ -7079,6 +7085,41 @@ mod tests {
         assert_eq!(windows.len(), 1);
         assert_eq!(windows[0].used_percent, 12.0);
         assert_eq!(windows[0].label, "Fable only");
+    }
+
+    /// Regression: `scope.model.id` is null in the live payload but the field
+    /// exists, so Anthropic populating it later must not move the window's
+    /// identity. A moved `card_id` silently drops the user's persisted gauge
+    /// selection (Swift matches `clientId|cardId` exactly) and restarts the
+    /// quota-history series, with no visible change to the label.
+    #[test]
+    fn claude_scoped_identity_survives_model_id_appearing() {
+        let with_null_id = r#"{
+            "limits": [{"kind": "weekly_scoped", "group": "weekly", "percent": 7,
+                        "scope": {"model": {"id": null, "display_name": "Fable"}}}]
+        }"#;
+        let with_populated_id = r#"{
+            "limits": [{"kind": "weekly_scoped", "group": "weekly", "percent": 7,
+                        "scope": {"model": {
+                            "id": "claude/fable.5:promo", "display_name": "Fable"
+                        }}}]
+        }"#;
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+
+        let before = claude_windows(
+            &serde_json::from_str::<ClaudeUsageResponse>(with_null_id).unwrap(),
+            now,
+        );
+        let after = claude_windows(
+            &serde_json::from_str::<ClaudeUsageResponse>(with_populated_id).unwrap(),
+            now,
+        );
+
+        assert_eq!(before.len(), 1);
+        assert_eq!(after.len(), 1);
+        assert_eq!(before[0].card_id, "weekly_scoped.fable.v1");
+        assert_eq!(after[0].card_id, before[0].card_id);
+        assert_eq!(after[0].window_key, before[0].window_key);
     }
 
     #[test]

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -4079,13 +4079,28 @@ fn append_claude_scoped_windows(
         if !emitted_slugs.insert(slug.clone()) {
             continue;
         }
-        let window_key = format!("weekly_scoped.{slug}.v1");
+        // A scoped entry that succeeds a legacy flat field inherits that
+        // field's semantic key and label. Anthropic moving a quota out of
+        // `seven_day_*` and into `limits[]` is the migration this mapper exists
+        // to support, and minting a new identity for it would cost the user the
+        // same persisted selection and history the flat lane already owns —
+        // for an otherwise unchanged quota. The flat-window guard above means
+        // this branch only runs once the flat field is actually gone.
+        let (window_key, label) = CLAUDE_SCOPED_FLAT_SUCCESSORS
+            .iter()
+            .find(|(model_slug, _, _)| *model_slug == slug)
+            .map_or_else(
+                || {
+                    (
+                        format!("weekly_scoped.{slug}.v1"),
+                        format!("{display_name} only"),
+                    )
+                },
+                |(_, key, label)| ((*key).to_string(), (*label).to_string()),
+            );
         let resets_at = entry.resets_at.as_deref().and_then(parse_datetime);
         if let Some(window) = UsageWindow::try_from_provider_used_percent(
-            format!("{display_name} only"),
-            percent,
-            resets_at,
-            now,
+            label, percent, resets_at, now,
         )
         .map(|window| {
             window.with_identity(
@@ -4099,6 +4114,18 @@ fn append_claude_scoped_windows(
         }
     }
 }
+
+/// Model-name slugs that already have a flat-field lane, paired with the
+/// semantic key and label that lane owns. Keeping these frozen is what lets a
+/// quota move from `seven_day_*` into `limits[]` without the user losing a
+/// pinned gauge or its learned pace. Entries here must match the identities
+/// emitted by `claude_windows()` for the corresponding flat fields.
+const CLAUDE_SCOPED_FLAT_SUCCESSORS: &[(&str, &str, &str)] = &[
+    ("sonnet", "sonnet.weekly.v1", "Sonnet"),
+    ("opus", "opus.weekly.v1", "Opus"),
+    ("designs", "design.weekly.v1", "Designs"),
+    ("daily-routines", "routines.weekly.v1", "Daily Routines"),
+];
 
 fn claude_is_all_models_slug(slug: &str) -> bool {
     slug == "all-models" || slug.ends_with("-all-models")
@@ -6927,7 +6954,10 @@ mod tests {
     }
 
     /// The migration case: once Anthropic drops a flat field, the scoped entry
-    /// must take over rather than leaving the model with no window at all.
+    /// must take over rather than leaving the model with no window at all — and
+    /// it must inherit the flat lane's identity, or the handover costs the user
+    /// their pinned gauge and the window's learned pace for a quota that never
+    /// actually changed.
     #[test]
     fn maps_claude_scoped_opus_when_flat_window_absent() {
         let raw = r#"{
@@ -6945,9 +6975,62 @@ mod tests {
         let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
         let windows = claude_windows(&usage, now);
         assert_eq!(windows.len(), 1);
-        assert_eq!(windows[0].label, "Opus only");
-        assert_eq!(windows[0].card_id, "weekly_scoped.opus.v1");
+        // Identical to what the flat `seven_day_opus` lane emits, so a pinned
+        // gauge and its history survive the handover untouched.
+        assert_eq!(windows[0].label, "Opus");
+        assert_eq!(windows[0].card_id, "opus.weekly.v1");
+        assert_eq!(windows[0].window_key.as_deref(), Some("opus.weekly.v1"));
         assert_eq!(windows[0].used_percent, 80.0);
+    }
+
+    /// `CLAUDE_SCOPED_FLAT_SUCCESSORS` is hand-written, so it can drift from the
+    /// identities `claude_windows()` actually emits for the flat fields. Drive
+    /// both lanes with the same quota and require the identity to be identical:
+    /// if either side is renamed or re-keyed without the other, this fails.
+    #[test]
+    fn claude_scoped_successors_match_their_flat_lane_identities() {
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let cases = [
+            ("seven_day_sonnet", "Sonnet"),
+            ("seven_day_opus", "Opus"),
+            ("seven_day_design", "Designs"),
+            ("seven_day_routines", "Daily Routines"),
+        ];
+
+        for (flat_field, display_name) in cases {
+            let flat = claude_windows(
+                &serde_json::from_str::<ClaudeUsageResponse>(&format!(
+                    r#"{{"{flat_field}": {{"utilization": 40}}}}"#
+                ))
+                .unwrap(),
+                now,
+            );
+            let scoped = claude_windows(
+                &serde_json::from_str::<ClaudeUsageResponse>(&format!(
+                    r#"{{"limits": [{{"kind": "weekly_scoped", "group": "weekly",
+                         "percent": 40,
+                         "scope": {{"model": {{"id": null,
+                                               "display_name": "{display_name}"}}}}}}]}}"#
+                ))
+                .unwrap(),
+                now,
+            );
+
+            assert_eq!(flat.len(), 1, "flat lane for {flat_field}");
+            assert_eq!(scoped.len(), 1, "scoped lane for {display_name}");
+            assert_eq!(
+                scoped[0].card_id, flat[0].card_id,
+                "card id drifted for {display_name}"
+            );
+            assert_eq!(
+                scoped[0].window_key, flat[0].window_key,
+                "window key drifted for {display_name}"
+            );
+            assert_eq!(
+                scoped[0].label, flat[0].label,
+                "label drifted for {display_name}"
+            );
+        }
     }
 
     /// End-to-end shape check against a real `oauth/usage` response captured

--- a/docs/knowledge/plans/provider-quota-pace.md
+++ b/docs/knowledge/plans/provider-quota-pace.md
@@ -412,6 +412,8 @@ Migration fixtures 必須包含 empty／existing／corrupt v3、valid／corrupt 
 | Claude `seven_day_opus` | Opus | `opus.weekly.v1` | Contract 10,080 minutes |
 | Claude design aliases | Designs | `design.weekly.v1` | Contract 10,080 minutes |
 | Claude routines aliases | Daily Routines | `routines.weekly.v1` | Contract 10,080 minutes |
+| Claude `limits[]` model-scoped weekly（已知 flat 前身） | 沿用該 flat lane 的 card | 沿用該 flat lane 的 key | Contract 10,080 minutes |
+| Claude `limits[]` model-scoped weekly（其他） | `<model> only` | `weekly_scoped.<modelSlug>.v1` | Contract 10,080 minutes |
 | Claude `extra_usage` | Extra usage | `extra_usage.v1` | `unavailable(missingReset)` |
 
 Codex main mapping retains the current role normalization：18,000 seconds always maps Session and 604,800 seconds always maps Weekly，regardless of primary／secondary order。An unrecognized main duration may still render，但 its pace is `unavailable(windowIdentity)` until a semantic key fixture is added。
@@ -419,6 +421,20 @@ Codex main mapping retains the current role normalization：18,000 seconds alway
 For Codex additional limits，`sourceDigest` is lowercase hex SHA-256 of trimmed `metered_feature` when present，otherwise trimmed `limit_name`；`slot` is `primary` or `secondary` before selection。Both identity fields missing means typed `unavailable(windowIdentity)`，not the shared `Codex extra limit` label。Digesting avoids persisting provider display text；different raw identities safely fragment rather than collide。
 
 Claude design aliases are frozen in current first-match order：`seven_day_design`、`seven_day_claude_design`、`claude_design`、`design`、`seven_day_omelette`、`omelette`、`omelette_promotional`。Routines aliases are `seven_day_routines`、`seven_day_claude_routines`、`claude_routines`、`routines`、`routine`、`seven_day_cowork`、`cowork`。Every alias in each group maps to the one semantic key shown above；alias source and display label never enter history。
+
+#### Claude `limits[]` model-scoped weekly windows
+
+Anthropic 的 `oauth/usage` 除了上述 flat 欄位，另有一個 `limits[]` 陣列承載 model-scoped weekly 額度。促銷型模型（2026-08 起的 Fable 5）**只**出現在這裡，沒有對應 flat 欄位；長期而言 Opus／Sonnet 等既有 lane 也可能遷入此處。Flat 欄位是 `Option`，缺席不會報錯，因此不解析 `limits[]` 的話這類 window 會靜默消失。
+
+Eligibility：一筆 entry 必須同時滿足 `group == "weekly"`、`kind == "weekly_scoped"`、`percent` 為有限值且落在 `0..=100`（與 flat 欄位的 `utilization` 同尺度、同為 used percent）、`scope.model.display_name` 去空白後非空，且 scope 不是 account-wide。Account-wide 的排除同時比對 model id slug 與 display-name slug 的 `all-models`／`-all-models` 後綴。陣列以 element-wise 解析，單一 entry 格式錯誤只丟棄該 entry，不影響同陣列的其他 entry。
+
+`is_active` **不解析也不過濾**。2026-08-04 實際 payload 中，真正生效的 Fable window 回報 `is_active: false`；[steipete/codexbar](https://github.com/steipete/codexbar) 與 [stablyai/orca](https://github.com/stablyai/orca)（其 issue #8979）各自獨立踩過同一顆雷。以該欄位過濾會隱藏實際生效的額度。
+
+Identity 來源是 `scope.model.display_name` 的 slug，**不使用 `scope.model.id`**。這是本 lane 對「stable schema key 優先於 display 文字」通則的一項 documented exception，理由是 schema 目前沒有提供可用的 stable id：實際 payload 的 `scope.model.id` 為 `null`，而欄位本身存在。若採 id 優先，Anthropic 日後填入該欄位就會在 label 完全不變的情況下搬移 `cardId` 與 `windowKey`，使 Swift 的 `clientId|cardId` 精確比對失效、既有 history series 中斷。與 Codex additional limits 的 `sourceDigest` 不同的是，那裡 digest 的目的是避免持久化 `metered_feature`／`limit_name` 這類可能夾帶使用者或組織資訊的任意 provider 文字；Claude 這裡的來源是封閉集合中的模型名稱，不含使用者資料，因此保留明文 slug 以維持 history 與診斷的可讀性。Display name 改名仍會搬移 identity，但那一次搬移對使用者是可見的，因為 card label 同時改變。
+
+Flat lane 已擁有的模型不另立 identity。`sonnet`、`opus`、`designs`、`daily-routines` 四個 model slug 凍結對應到既有的 `sonnet.weekly.v1`、`opus.weekly.v1`、`design.weekly.v1`、`routines.weekly.v1` 與其原 label；當 Anthropic 移除 flat 欄位而同一額度改由 `limits[]` 提供時，card 與 history 原地延續。反向的重複則由 flat-window 去重擋下：scoped entry 的 display-name slug 若命中本次已產生的 window label，直接跳過，因此 flat 欄位仍存在時它保有優先權。該去重集合由實際產生的 window 推導，不是硬編碼模型清單，才不會隨 flat 欄位增減而漂移。
+
+Scoped window 一律使用 contract 10,080 minutes；`resets_at` 可能為 `null`（實際 Fable entry 即如此），此時 window 照常產生，只是沒有 reset 時間。
 
 ### Grok, Antigravity, and Copilot mappings
 


### PR DESCRIPTION
Anthropic's `/api/oauth/usage` response now carries model-scoped weekly quotas in a `limits[]` array alongside the legacy flat `seven_day_*` fields. Promotional model windows — currently Claude Fable 5 — appear **only** there. TokenBar never parsed `limits[]`, so those windows were invisible, and a future migration of Opus or Sonnet out of the flat fields would have made those windows silently disappear too (they are `Option`, so absence is not an error).

## What the live payload actually looks like

Captured 2026-08-04 from a Max account. Trimmed to the relevant parts:

```jsonc
{
  "five_hour": { "utilization": 61.0, "resets_at": "..." },
  "seven_day": { "utilization": 39.0, "resets_at": "..." },
  "seven_day_opus": null,
  "seven_day_sonnet": null,
  "limits": [
    { "kind": "session",       "group": "session", "percent": 61, "scope": null, "is_active": true  },
    { "kind": "weekly_all",    "group": "weekly",  "percent": 39, "scope": null, "is_active": false },
    { "kind": "weekly_scoped", "group": "weekly",  "percent": 0,  "resets_at": null,
      "scope": { "model": { "id": null, "display_name": "Fable" } }, "is_active": false }
  ]
}
```

Four things here are worth calling out, because three of them contradict what the reference implementations led us to expect:

| Observation | Consequence |
|---|---|
| The real Fable entry reports **`is_active: false`** | Filtering on `is_active` — the obvious reading of the field — hides live, enforceable quota. Both [steipete/codexbar](https://github.com/steipete/codexbar) and [stablyai/orca](https://github.com/stablyai/orca) independently hit this; orca tracked it as their #8979. This PR neither parses nor filters on it. |
| **`scope.model.id` is `null`** | Identity has to fall back to the display name. This is the path that actually runs in production. |
| The account-wide weekly entry is **`kind: "weekly_all"` with a null scope** | It is not an all-models *scope*, so `kind` is what really keeps it out of the scoped lane. The all-models scope check is kept as defence against the shape the reference implementations documented, but it is not what fires today. |
| `limits[0].percent == five_hour.utilization == 61` | Confirms `percent` is used-percent on the same 0–100 scale as the flat fields. |

## Implementation

`ClaudeUsageResponse` gains a `limits` field decoded **element-wise** — each entry goes through `serde_json::from_value(...).ok()` independently, so one malformed element drops only itself instead of discarding the whole array.

`claude_windows()` appends scoped windows after the flat ones and before extra-usage. An entry produces a window only when all of these hold:

> `group == "weekly"` and `kind == "weekly_scoped"`, a finite `percent` in `0..=100`, a non-blank `scope.model.display_name`, and a scope that is not account-wide.

Identity is the slug of `scope.model.id` when present, falling back to the display-name slug. Label is `"<model> only"`, window key is `weekly_scoped.<slug>.v1`, duration is a 7-day contract — matching the other weekly lanes.

### The dedup guard

Two directions, both needed:

- **Account-wide entries** are excluded when either the id slug or the display-name slug is `all-models` or ends with `-all-models`.
- **Entries colliding with a flat window** are skipped when their display-name slug matches the label of a window already emitted in the same call.

That second guard is not in either reference implementation, and it is the reason the three migration cases all come out right:

| Case | Result |
|---|---|
| Fable only in `limits[]` | New window appears |
| Opus in both `limits[]` and `seven_day_opus` | Exactly one Opus window, the flat one |
| Opus only in `limits[]` | Scoped entry takes over |

codexbar has the latent version of this bug — its mapper excludes only the all-models scope, while its CLI `/status` path separately hardcodes an `opus`/`sonnet` exclusion, which suggests they hit the collision on that path and patched it locally rather than centrally. Here the "already emitted" set is derived from the actual emitted windows rather than a hardcoded model list, so it cannot drift as flat fields come and go.

Swift needs no change: the UI is data-driven and carries no window-key allowlist.

## Verification

Nine tests: Fable mapping, inactive entries, all-models exclusion, both dedup directions, the limits-only migration case, malformed-entry tolerance beside a valid sibling, duplicate slugs, and the end-to-end shape of the real response above (percentages and timestamps replaced with neutral values, every field kept verbatim including the ones we do not parse).

That live-payload fixture earns its place — it is the **only** test pinning the `id: null` fallback and the null-`resets_at` path. The synthetic fixtures all supply an id, so they cannot reach either.

Mutation-verified, each mutation applied and reverted:

| Mutation | Tests that fail |
|---|---|
| Filter on `is_active == true` | 6, including the live payload |
| Drop the display-name identity fallback | Only the live payload |
| Replace the derived dedup set with a hardcoded model list | Only the limits-only migration test |
| Decode `limits[]` as a whole array instead of element-wise | Only the tolerance test |

Gates:

```
cargo test -p tb_core_ffi     333 passed / 0 failed
cargo clippy -D warnings      16 errors — identical to baseline, zero added
cargo fmt --check             agent_usage.rs clean
```

The 16 clippy errors and the `hourly_report.rs` / `model_report.rs` fmt drift are pre-existing on `main` (newer clippy introduced lints the tree does not yet satisfy). Confirmed by stashing this change and re-measuring, not by reading line numbers. Nothing was reformatted outside this change.

Reviewed locally by Codex (`gpt-5.6-sol`, effort high) over two rounds. R1 raised one medium finding on slug-identity collisions; its recommendation to use a digest of the model id was rejected because `window_key` is the persisted quota-history identity and an opaque digest would make history rows unreadable without fixing the underlying sub-claims. Two genuine coverage gaps it identified were closed. R2 returned approve with no findings.
