### PR TITLE
feat(usage): add a flat contribution heatmap to the usage chart

### DIFF
--- a/Sources/TokenBar/Charts/ContributionHeatmap.swift
+++ b/Sources/TokenBar/Charts/ContributionHeatmap.swift
@@ -87,14 +87,20 @@ struct ContributionHeatmap: View {
     }
 
     /// Per-metric intensity denominator, computed here rather than reusing
-    /// `GridLayout.maxTokens` (invariant 4) — `maxTokens` only ever tracks
-    /// tokens, so Price needs its own max over the in-year cells.
-    static func maxValue(_ grid: TokenBarCore.GridLayout, metric: ChartMetric) -> Double {
+    /// `GridLayout.maxTokens` (invariant 4 forbids modifying/extending
+    /// `GridLayout.maxTokens`, not forbids simply not using it) — `maxTokens`
+    /// only ever tracks tokens and never applies the future-day cutoff, so
+    /// Price needs its own max regardless, and round 4's FIX 3 makes tokens
+    /// take the same `cutoff`-filtered path: a hidden future cell (clock
+    /// skew, an imported session dated past today) must not sit in the
+    /// denominator any more than it's drawn or hoverable — the same
+    /// `isRenderable` judgment used everywhere else a cell "counts".
+    static func maxValue(_ grid: TokenBarCore.GridLayout, metric: ChartMetric, cutoff: String) -> Double {
         switch metric {
         case .tokens:
-            return Double(grid.maxTokens)
+            return grid.cells.reduce(0.0) { isRenderable($1, cutoff: cutoff) ? max($0, Double($1.tokens)) : $0 }
         case .cost:
-            return grid.cells.reduce(0.0) { $1.inYear ? max($0, $1.cost) : $0 }
+            return grid.cells.reduce(0.0) { isRenderable($1, cutoff: cutoff) ? max($0, $1.cost) : $0 }
         }
     }
 
@@ -152,7 +158,7 @@ struct ContributionHeatmap: View {
             y: cellCenter.y + contentOrigin.y - containerOrigin.y)
     }
 
-    private var metricMax: Double { Self.maxValue(grid, metric: metric) }
+    private var metricMax: Double { Self.maxValue(grid, metric: metric, cutoff: cutoff) }
     private var cutoff: String { Self.cutoffDate(year: year, today: Format.todayKey()) }
 
     private var monthLabelCols: [(col: Int, label: String)] {
@@ -181,8 +187,20 @@ struct ContributionHeatmap: View {
                                 .id(Self.contentID)
                         }
                         // Round 2, item 3(b): land on the most recent columns
-                        // on open, GitHub-style, instead of Jan 1.
+                        // on open, GitHub-style, instead of Jan 1. Round 4,
+                        // FIX 1: `onAppear` alone only fires once — changing
+                        // the dashboard's year filter while already on the
+                        // Heatmap tab updates this same view in place rather
+                        // than re-inserting it, so a stale horizontal offset
+                        // (e.g. left over from a wider current-year layout)
+                        // stuck around after switching to a narrower or wider
+                        // past year. `cutoff`, not `year`, is the trigger: it
+                        // already covers both a year change AND a day
+                        // rollover while the popover happens to stay open.
                         .onAppear { proxy.scrollTo(Self.contentID, anchor: .trailing) }
+                        .onChange(of: cutoff) { _, _ in
+                            proxy.scrollTo(Self.contentID, anchor: .trailing)
+                        }
                     }
                     // Tooltip lives in the ScrollView's overlay, not its
                     // content — an overlay isn't clipped by the view it

--- a/Sources/TokenBar/Charts/ContributionHeatmap.swift
+++ b/Sources/TokenBar/Charts/ContributionHeatmap.swift
@@ -104,12 +104,20 @@ struct ContributionHeatmap: View {
         }
     }
 
-    /// Round 2, item 3(a): the last day this heatmap should draw. Only the
-    /// selected year matching today's year clips to today — any other
-    /// (necessarily past) year still draws through Dec 31. View-level only;
-    /// `buildGrid` still produces the full padded year.
+    /// Round 2, item 3(a): the last day this heatmap should draw. Round 5:
+    /// a single `min` over the ISO date strings (whose lexicographic order
+    /// is chronological order) correctly covers all three year cases at
+    /// once — a past year clips at its own Dec 31, the current year clips at
+    /// today, and a FUTURE year (reachable if clock skew or an imported
+    /// session put data there, making it show up in the year picker) also
+    /// clips at today, i.e. renders nothing. The two-way `year ==
+    /// currentYear ? today : "\(year)-12-31"` this replaced treated any
+    /// non-current year as past, so a future year rendered its entire (blank
+    /// data-wise but still drawn) 12 months — every day of it is, after all,
+    /// still in the future. View-level only; `buildGrid` still produces the
+    /// full padded year.
     static func cutoffDate(year: String, today: String) -> String {
-        year == String(today.prefix(4)) ? today : "\(year)-12-31"
+        min("\(year)-12-31", today)
     }
 
     /// A cell is drawn/hoverable only if it's in-year and on or before the
@@ -129,6 +137,15 @@ struct ContributionHeatmap: View {
     /// separate "visible range" concept.
     static func lastRenderableCol(_ grid: TokenBarCore.GridLayout, cutoff: String) -> Int {
         grid.cells.filter { isRenderable($0, cutoff: cutoff) }.map(\.col).max() ?? -1
+    }
+
+    /// Round 5: canvas width for however many columns are actually
+    /// renderable — 0 when nothing is (a future selected year now that
+    /// `cutoffDate` clips it to today), never a negative width from naively
+    /// computing `0 * step - gap`. Static so SelfTest can exercise this edge
+    /// directly instead of instantiating the view.
+    static func contentWidth(visibleCols: Int) -> CGFloat {
+        visibleCols > 0 ? CGFloat(visibleCols) * HeatmapLayout.step - HeatmapLayout.gap : 0
     }
 
     /// The columns that get a month-name header — the same `isRenderable`
@@ -168,9 +185,7 @@ struct ContributionHeatmap: View {
     /// Columns after the last renderable one (round 3) carry no layout width
     /// at all — never derived from `grid.cols`.
     private var visibleCols: Int { max(0, Self.lastRenderableCol(grid, cutoff: cutoff) + 1) }
-    private var contentWidth: CGFloat {
-        visibleCols > 0 ? CGFloat(visibleCols) * HeatmapLayout.step - HeatmapLayout.gap : 0
-    }
+    private var contentWidth: CGFloat { Self.contentWidth(visibleCols: visibleCols) }
     private var gridHeight: CGFloat { 7 * HeatmapLayout.step - HeatmapLayout.gap }
     private var contentHeight: CGFloat { HeatmapLayout.monthLabelHeight + gridHeight }
 

--- a/Sources/TokenBar/Charts/ContributionHeatmap.swift
+++ b/Sources/TokenBar/Charts/ContributionHeatmap.swift
@@ -67,7 +67,16 @@ struct ContributionHeatmap: View {
     /// cutoff (round 2, item 3); `buildGrid` itself is untouched.
     let year: String
 
-    @State private var hoverCell: GridCell?
+    /// The hovered cell's `col * 7 + row` index into `grid.cells` — not the
+    /// `GridCell` value itself. Round 7: `DashboardModel.pollGraph()` re-
+    /// fetches the graph payload every 60s while the popover stays open, so
+    /// `grid` (and the tokens/cost a hovered date carries) can change under
+    /// a mouse that never moves. Storing an index and re-resolving the cell
+    /// fresh on every access (`hoverCell` below) — the same live-lookup shape
+    /// `UsageChartCard`'s own `hoverIndex`-into-`bars` already uses for its
+    /// 2D bar chart — keeps the tooltip's numbers current instead of frozen
+    /// at whatever they were the instant hovering began.
+    @State private var hoverIndex: Int?
     @State private var tooltipSize: CGSize = .zero
     /// The scrolling content's on-screen origin, tracked so the tooltip
     /// (rendered in an overlay *outside* the horizontal ScrollView, see
@@ -197,6 +206,31 @@ struct ContributionHeatmap: View {
         return local >= 0 && local < cell
     }
 
+    /// Round 7: whether a hover should be cleared given the content's old
+    /// and new on-screen origin. True only when it actually moved.
+    ///
+    /// Rejected alternative: re-project the LAST known cursor point through
+    /// the new origin and re-resolve whatever cell now sits under it. That
+    /// needs a second piece of state (the last raw pointer position) and a
+    /// second coordinate-math path alongside `cellAt`'s — one more thing to
+    /// keep in sync and one more place a sign or offset error can hide.
+    /// Clearing is simpler and, for a grid the user is actively scrolling,
+    /// the reasonable behavior anyway: the tooltip disappears while the
+    /// content moves and reappears the instant the pointer moves again
+    /// (which `.onContinuousHover`'s `.active` phase already does).
+    ///
+    /// In production, `onGeometryChange`'s own `action` closure is already
+    /// only invoked when its (`Equatable`) transformed value changes —
+    /// verified against Apple's documentation for `onGeometryChange(for:
+    /// of:action:)`, not assumed — so this is always true whenever that
+    /// action fires at all. It's still factored out and applied explicitly
+    /// (not left as an implicit platform guarantee) so SelfTest can verify
+    /// the "unchanged origin never clears" half on its own, independent of
+    /// that platform behavior.
+    static func shouldClearHoverOnOriginChange(old: CGPoint, new: CGPoint) -> Bool {
+        old != new
+    }
+
     /// Round 2, item 1: the tooltip's anchor in the OUTER (non-scrolling)
     /// container's coordinate space, derived from the hovered cell's
     /// position in the scrolling content plus that content's current
@@ -207,6 +241,18 @@ struct ContributionHeatmap: View {
         CGPoint(
             x: cellCenter.x + contentOrigin.x - containerOrigin.x,
             y: cellCenter.y + contentOrigin.y - containerOrigin.y)
+    }
+
+    /// The hovered cell, resolved fresh from the CURRENT `grid` on every
+    /// access rather than a value snapshotted once at hover-set time — see
+    /// `hoverIndex`'s doc comment. Re-applies `isRenderable`/`hasData` too,
+    /// for the same reason: cheap, and consistent with `cellAt` treating
+    /// them as the one live judgment call for "does this cell count".
+    private var hoverCell: GridCell? {
+        guard let hoverIndex, grid.cells.indices.contains(hoverIndex) else { return nil }
+        let cell = grid.cells[hoverIndex]
+        guard Self.isRenderable(cell, cutoff: cutoff), Self.hasData(cell, metric: metric) else { return nil }
+        return cell
     }
 
     private var metricMax: Double { Self.maxValue(grid, metric: metric, cutoff: cutoff) }
@@ -308,12 +354,27 @@ struct ContributionHeatmap: View {
         .onContinuousHover { phase in
             switch phase {
             case let .active(point):
-                hoverCell = cellAt(point).flatMap { Self.hasData($0, metric: metric) ? $0 : nil }
+                hoverIndex = cellAt(point)
             case .ended:
-                hoverCell = nil
+                hoverIndex = nil
             }
         }
-        .onGeometryChange(for: CGPoint.self) { $0.frame(in: .global).origin } action: { contentOrigin = $0 }
+        // Round 7: clear the hover the instant the content's on-screen
+        // origin actually moves (a redirected mouse-wheel scroll or a
+        // trackpad pan) rather than leaving it pinned to a cell that just
+        // scrolled out from under a stationary cursor — that stale pin was
+        // the actual bug: the tooltip's anchor incorporates `contentOrigin`
+        // (see `tooltipAnchor`), so it kept following the content while
+        // scrolling, landing on screen at a position the cursor was never
+        // over, sometimes naming a date that had scrolled out of view
+        // entirely. `.active` hover events re-populate it the moment the
+        // pointer moves again.
+        .onGeometryChange(for: CGPoint.self) { $0.frame(in: .global).origin } action: { newOrigin in
+            if Self.shouldClearHoverOnOriginChange(old: contentOrigin, new: newOrigin) {
+                hoverIndex = nil
+            }
+            contentOrigin = newOrigin
+        }
         // Round 2, item 2: let a plain vertical mouse wheel scroll this
         // horizontal grid (DashboardTabs.swift's pattern) — placed inside the
         // ScrollView's content, per HorizontalWheelScroll's own doc comment,
@@ -323,10 +384,16 @@ struct ContributionHeatmap: View {
 
     // MARK: - Hit testing
 
+    /// Resolves a screen point to a `grid.cells` index — pure geometry
+    /// (bounds, the gap dead zone, `col * 7 + row` indexing). Whether that
+    /// index is CURRENTLY a countable, renderable, data-bearing cell is
+    /// `hoverCell`'s job, re-checked live on every access rather than baked
+    /// in here at hover-set time (round 7).
+    ///
     /// `grid.cells` is laid out `col * 7 + row` by `buildGrid` (Grid.swift's
     /// nested col/row loop), so direct indexing avoids a lookup dictionary;
     /// the col/row re-check guards against that ordering ever changing.
-    private func cellAt(_ point: CGPoint) -> GridCell? {
+    private func cellAt(_ point: CGPoint) -> Int? {
         guard point.x >= 0, point.y >= HeatmapLayout.monthLabelHeight else { return nil }
         let localY = point.y - HeatmapLayout.monthLabelHeight
         // Reject gap coordinates before resolving an index — see
@@ -341,8 +408,8 @@ struct ContributionHeatmap: View {
         let index = col * 7 + row
         guard grid.cells.indices.contains(index) else { return nil }
         let cell = grid.cells[index]
-        guard cell.col == col, cell.row == row, Self.isRenderable(cell, cutoff: cutoff) else { return nil }
-        return cell
+        guard cell.col == col, cell.row == row else { return nil }
+        return index
     }
 
     private func cellCenter(_ cell: GridCell) -> CGPoint {

--- a/Sources/TokenBar/Charts/ContributionHeatmap.swift
+++ b/Sources/TokenBar/Charts/ContributionHeatmap.swift
@@ -233,14 +233,59 @@ struct ContributionHeatmap: View {
 
     /// Round 2, item 1: the tooltip's anchor in the OUTER (non-scrolling)
     /// container's coordinate space, derived from the hovered cell's
-    /// position in the scrolling content plus that content's current
-    /// on-screen origin. This is what lets the tooltip escape the horizontal
-    /// ScrollView's clip: an anchor pinned to the scrolled content's own
-    /// local frame is exactly the bug being fixed.
-    static func tooltipAnchor(cellCenter: CGPoint, contentOrigin: CGPoint, containerOrigin: CGPoint) -> CGPoint {
-        CGPoint(
-            x: cellCenter.x + contentOrigin.x - containerOrigin.x,
-            y: cellCenter.y + contentOrigin.y - containerOrigin.y)
+    /// position in the scrolling content plus that content's current origin
+    /// RELATIVE TO THE CONTAINER. This is what lets the tooltip escape the
+    /// horizontal ScrollView's clip: an anchor pinned to the scrolled
+    /// content's own local frame is exactly the bug being fixed.
+    ///
+    /// Round 8 (perf): simplified from a 3-argument
+    /// `(cellCenter, contentOrigin, containerOrigin)` — `contentOrigin` is
+    /// now measured directly in a coordinate space anchored to the
+    /// container (see `body`'s `.coordinateSpace`), so it already IS
+    /// "relative to the container"; the separate subtraction this used to
+    /// do is now done for free by the coordinate space itself. The
+    /// 3-argument form required tracking `contentOrigin` in `.global` space,
+    /// which changes on every frame of an ANCESTOR's vertical scroll (not
+    /// just this view's own horizontal one) even though the subtracted
+    /// RESULT never does — see `body`'s `.coordinateSpace` comment for the
+    /// full story.
+    static func tooltipAnchor(cellCenter: CGPoint, contentOrigin: CGPoint) -> CGPoint {
+        CGPoint(x: cellCenter.x + contentOrigin.x, y: cellCenter.y + contentOrigin.y)
+    }
+
+    /// Round 8 (perf): everything derived from `grid`/`metric`/`year`/today
+    /// that's expensive to recompute — `Format.todayKey()` builds a
+    /// `DateFormatter` per call (Format.swift:32-38, not touched here: a
+    /// cached `static let` formatter would freeze `.timeZone = .current`,
+    /// conflicting with issue #127's timezone semantics, out of scope for
+    /// this PR), and `lastRenderableCol`/`monthLabelCols`/`maxValue` each
+    /// walk every cell in `grid.cells` (~371 for a 53-column year). These
+    /// used to be six-plus independent zero-argument computed properties,
+    /// each re-deriving `cutoff` (and therefore rebuilding a
+    /// `DateFormatter`) and re-walking the cell array on every access — and
+    /// `contentWidth` read `monthLabelCols` a SECOND time on top of the
+    /// canvas draw loop's own read. Computed exactly once per `body`
+    /// evaluation via `makeRenderState()` and threaded down as a plain
+    /// value instead. This is NOT a cache — nothing persists between
+    /// renders, no `ObservableObject`, no stored property; it's the same
+    /// work, just grouped into one pass instead of scattered redundant ones.
+    private struct RenderState {
+        let cutoff: String
+        let visibleCols: Int
+        let monthLabelCols: [(col: Int, label: String)]
+        let metricMax: Double
+        let contentWidth: CGFloat
+    }
+
+    private func makeRenderState() -> RenderState {
+        let cutoff = Self.cutoffDate(year: year, today: Format.todayKey())
+        let visibleCols = max(0, Self.lastRenderableCol(grid, cutoff: cutoff) + 1)
+        let monthLabelCols = Self.monthLabelCols(grid: grid, cutoff: cutoff)
+        let metricMax = Self.maxValue(grid, metric: metric, cutoff: cutoff)
+        let contentWidth = Self.contentWidth(visibleCols: visibleCols, monthLabelCols: monthLabelCols)
+        return RenderState(
+            cutoff: cutoff, visibleCols: visibleCols, monthLabelCols: monthLabelCols,
+            metricMax: metricMax, contentWidth: contentWidth)
     }
 
     /// The hovered cell, resolved fresh from the CURRENT `grid` on every
@@ -248,28 +293,36 @@ struct ContributionHeatmap: View {
     /// `hoverIndex`'s doc comment. Re-applies `isRenderable`/`hasData` too,
     /// for the same reason: cheap, and consistent with `cellAt` treating
     /// them as the one live judgment call for "does this cell count".
-    private var hoverCell: GridCell? {
+    private func hoverCell(_ state: RenderState) -> GridCell? {
         guard let hoverIndex, grid.cells.indices.contains(hoverIndex) else { return nil }
         let cell = grid.cells[hoverIndex]
-        guard Self.isRenderable(cell, cutoff: cutoff), Self.hasData(cell, metric: metric) else { return nil }
+        guard Self.isRenderable(cell, cutoff: state.cutoff), Self.hasData(cell, metric: metric) else { return nil }
         return cell
     }
 
-    private var metricMax: Double { Self.maxValue(grid, metric: metric, cutoff: cutoff) }
-    private var cutoff: String { Self.cutoffDate(year: year, today: Format.todayKey()) }
-
-    private var monthLabelCols: [(col: Int, label: String)] {
-        Self.monthLabelCols(grid: grid, cutoff: cutoff)
-    }
-
-    /// Columns after the last renderable one (round 3) carry no layout width
-    /// at all — never derived from `grid.cols`.
-    private var visibleCols: Int { max(0, Self.lastRenderableCol(grid, cutoff: cutoff) + 1) }
-    private var contentWidth: CGFloat {
-        Self.contentWidth(visibleCols: visibleCols, monthLabelCols: monthLabelCols)
-    }
     private var gridHeight: CGFloat { 7 * HeatmapLayout.step - HeatmapLayout.gap }
     private var contentHeight: CGFloat { HeatmapLayout.monthLabelHeight + gridHeight }
+
+    /// Round 8 (perf): named coordinate space anchored to the OUTER
+    /// (non-scrolling) container — the same view `outerGeo` describes.
+    /// `canvasBody`'s `.onGeometryChange` measures the scrolling content's
+    /// origin IN THIS SPACE instead of `.global`.
+    ///
+    /// Why: the dashboard's own vertical ScrollView is an ANCESTOR of this
+    /// entire view. When it scrolls, this heatmap's `.global` position
+    /// shifts every single frame — and so does the outer container's. Their
+    /// DIFFERENCE (all `tooltipAnchor` ever needed) does not change; only
+    /// the two individual `.global` values do. Tracking `.global` meant
+    /// paying full price — a `contentOrigin` write, a `hoverIndex = nil`
+    /// write (round 7's fix, correctly reacting to what looked like a
+    /// change), and the resulting `body` re-evaluation (which used to
+    /// rebuild ~8 `DateFormatter`s via `cutoff` and re-walk ~371 cells
+    /// several times over) — on every frame of a scroll that has nothing to
+    /// do with this view at all. Measuring in a space anchored to the
+    /// container reports the already-subtracted, invariant difference
+    /// directly, so a vertical ancestor scroll no longer changes the
+    /// tracked value, writes no state, and triggers no re-render.
+    private static let coordinateSpaceName = "heatmap-container"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -277,10 +330,11 @@ struct ContributionHeatmap: View {
             if grid.cells.isEmpty {
                 Color.clear
             } else {
+                let state = makeRenderState()
                 GeometryReader { outerGeo in
                     ScrollViewReader { proxy in
                         ScrollView(.horizontal, showsIndicators: false) {
-                            canvasBody
+                            canvasBody(state)
                                 .id(Self.contentID)
                         }
                         // Round 2, item 3(b): land on the most recent columns
@@ -295,7 +349,7 @@ struct ContributionHeatmap: View {
                         // already covers both a year change AND a day
                         // rollover while the popover happens to stay open.
                         .onAppear { proxy.scrollTo(Self.contentID, anchor: .trailing) }
-                        .onChange(of: cutoff) { _, _ in
+                        .onChange(of: state.cutoff) { _, _ in
                             proxy.scrollTo(Self.contentID, anchor: .trailing)
                         }
                     }
@@ -304,14 +358,20 @@ struct ContributionHeatmap: View {
                     // decorates, so this is what stops the tooltip being cut
                     // off at the heatmap's edge (round 2, item 1).
                     .overlay(alignment: .topLeading) {
-                        if let cell = hoverCell {
+                        if let cell = hoverCell(state) {
                             let anchor = Self.tooltipAnchor(
-                                cellCenter: cellCenter(cell),
-                                contentOrigin: contentOrigin,
-                                containerOrigin: outerGeo.frame(in: .global).origin)
+                                cellCenter: cellCenter(cell), contentOrigin: contentOrigin)
                             let measuredSize = tooltipSize == .zero
                                 ? CGSize(width: Self.tooltipWidth, height: 60)
                                 : tooltipSize
+                            // Still `.global` here (unrelated to the
+                            // scroll-perf fix above): `containerFrame` only
+                            // needs to match `popoverScrollViewport`'s space
+                            // for the viewport-clamp math, and reading it
+                            // fresh at render time — rather than storing it
+                            // via `@State`/`onGeometryChange` — costs nothing
+                            // extra; it's not what was driving the
+                            // re-render cascade.
                             let offset = PopoverTooltipPlacement.offset(
                                 anchor: anchor,
                                 tooltipSize: measuredSize,
@@ -322,23 +382,24 @@ struct ContributionHeatmap: View {
                         }
                     }
                 }
+                .coordinateSpace(name: Self.coordinateSpaceName)
                 .frame(height: contentHeight)
             }
             Spacer(minLength: 0)
         }
     }
 
-    private var canvasBody: some View {
+    private func canvasBody(_ state: RenderState) -> some View {
         ZStack(alignment: .topLeading) {
             Canvas { context, _ in
-                for (col, label) in monthLabelCols {
+                for (col, label) in state.monthLabelCols {
                     context.draw(
                         Text(label).font(.caption2).foregroundStyle(.secondary),
                         at: CGPoint(x: CGFloat(col) * HeatmapLayout.step, y: HeatmapLayout.monthLabelHeight / 2),
                         anchor: .leading)
                 }
-                for cell in grid.cells where Self.isRenderable(cell, cutoff: cutoff) {
-                    let level = HeatmapLayout.level(value: Self.value(cell, metric: metric), max: metricMax)
+                for cell in grid.cells where Self.isRenderable(cell, cutoff: state.cutoff) {
+                    let level = HeatmapLayout.level(value: Self.value(cell, metric: metric), max: state.metricMax)
                     let rect = CGRect(
                         x: CGFloat(cell.col) * HeatmapLayout.step,
                         y: HeatmapLayout.monthLabelHeight + CGFloat(cell.row) * HeatmapLayout.step,
@@ -349,27 +410,30 @@ struct ContributionHeatmap: View {
                 }
             }
         }
-        .frame(width: contentWidth, height: contentHeight)
+        .frame(width: state.contentWidth, height: contentHeight)
         .contentShape(Rectangle())
         .onContinuousHover { phase in
             switch phase {
             case let .active(point):
-                hoverIndex = cellAt(point)
+                hoverIndex = cellAt(point, visibleCols: state.visibleCols)
             case .ended:
                 hoverIndex = nil
             }
         }
-        // Round 7: clear the hover the instant the content's on-screen
-        // origin actually moves (a redirected mouse-wheel scroll or a
-        // trackpad pan) rather than leaving it pinned to a cell that just
-        // scrolled out from under a stationary cursor — that stale pin was
-        // the actual bug: the tooltip's anchor incorporates `contentOrigin`
-        // (see `tooltipAnchor`), so it kept following the content while
-        // scrolling, landing on screen at a position the cursor was never
-        // over, sometimes naming a date that had scrolled out of view
-        // entirely. `.active` hover events re-populate it the moment the
-        // pointer moves again.
-        .onGeometryChange(for: CGPoint.self) { $0.frame(in: .global).origin } action: { newOrigin in
+        // Round 7: clear the hover the instant the content's origin
+        // (relative to the container — round 8, see `body`'s
+        // `coordinateSpaceName`) actually moves (a redirected mouse-wheel
+        // scroll or a trackpad pan on THIS grid) rather than leaving it
+        // pinned to a cell that just scrolled out from under a stationary
+        // cursor — that stale pin was the actual bug: the tooltip's anchor
+        // incorporates `contentOrigin` (see `tooltipAnchor`), so it kept
+        // following the content while scrolling, landing on screen at a
+        // position the cursor was never over, sometimes naming a date that
+        // had scrolled out of view entirely. `.active` hover events
+        // re-populate it the moment the pointer moves again.
+        .onGeometryChange(
+            for: CGPoint.self, of: { $0.frame(in: .named(Self.coordinateSpaceName)).origin }
+        ) { newOrigin in
             if Self.shouldClearHoverOnOriginChange(old: contentOrigin, new: newOrigin) {
                 hoverIndex = nil
             }
@@ -393,7 +457,7 @@ struct ContributionHeatmap: View {
     /// `grid.cells` is laid out `col * 7 + row` by `buildGrid` (Grid.swift's
     /// nested col/row loop), so direct indexing avoids a lookup dictionary;
     /// the col/row re-check guards against that ordering ever changing.
-    private func cellAt(_ point: CGPoint) -> Int? {
+    private func cellAt(_ point: CGPoint, visibleCols: Int) -> Int? {
         guard point.x >= 0, point.y >= HeatmapLayout.monthLabelHeight else { return nil }
         let localY = point.y - HeatmapLayout.monthLabelHeight
         // Reject gap coordinates before resolving an index — see

--- a/Sources/TokenBar/Charts/ContributionHeatmap.swift
+++ b/Sources/TokenBar/Charts/ContributionHeatmap.swift
@@ -15,6 +15,14 @@ enum HeatmapLayout {
     static let cornerRadius: CGFloat = 2
     static let monthLabelHeight: CGFloat = 14
     static let step: CGFloat = cell + gap
+    /// Round 6, FIX 2: extra trailing width reserved only when the LAST
+    /// renderable column carries a month label. Labels are leading-aligned
+    /// and wider than an 11pt cell, so a label landing in the very last
+    /// column (any month's first week — happens roughly monthly) would
+    /// otherwise have its trailing half clipped by the ScrollView once
+    /// scrolled to its trailing edge. Sized for the widest localized month
+    /// abbreviation, not just English "Dec" — zh-Hant's "12月" is wider.
+    static let lastColumnLabelMargin: CGFloat = 28
 
     /// Five-level intensity ramp. Thresholds ported from token-monitor's
     /// `heatmapIntensity()` (usageCharts.js:60-65: `>=0.75→4`, `>=0.5→3`,
@@ -142,10 +150,19 @@ struct ContributionHeatmap: View {
     /// Round 5: canvas width for however many columns are actually
     /// renderable — 0 when nothing is (a future selected year now that
     /// `cutoffDate` clips it to today), never a negative width from naively
-    /// computing `0 * step - gap`. Static so SelfTest can exercise this edge
-    /// directly instead of instantiating the view.
-    static func contentWidth(visibleCols: Int) -> CGFloat {
-        visibleCols > 0 ? CGFloat(visibleCols) * HeatmapLayout.step - HeatmapLayout.gap : 0
+    /// computing `0 * step - gap`. Round 6, FIX 2: adds
+    /// `HeatmapLayout.lastColumnLabelMargin` when (and only when) the last
+    /// renderable column itself carries a month label, so that label isn't
+    /// clipped at the trailing edge; every other case is unchanged. Static
+    /// so SelfTest can exercise both edges directly instead of instantiating
+    /// the view.
+    static func contentWidth(visibleCols: Int, monthLabelCols: [(col: Int, label: String)]) -> CGFloat {
+        guard visibleCols > 0 else { return 0 }
+        let base = CGFloat(visibleCols) * HeatmapLayout.step - HeatmapLayout.gap
+        let lastCol = visibleCols - 1
+        return monthLabelCols.contains { $0.col == lastCol }
+            ? base + HeatmapLayout.lastColumnLabelMargin
+            : base
     }
 
     /// The columns that get a month-name header — the same `isRenderable`
@@ -161,6 +178,23 @@ struct ContributionHeatmap: View {
                 guard let month = Int(monthChars), (1...12).contains(month) else { return nil }
                 return (cell.col, monthAbbrev[month - 1].localized)
             }
+    }
+
+    /// Round 6, FIX 3: whether a 1D offset within one column/row's `step`
+    /// (cell + gap) stride lands inside the cell itself rather than the gap
+    /// between cells. Gap coordinates used to fall through to
+    /// `Int(offset / step)`'s floor division, which silently attributed them
+    /// to the PRECEDING cell — putting the cursor on what looks like a blank
+    /// gridline popped a tooltip naming the adjacent day instead. This is
+    /// deliberately different from `UsageChartGeometry.barIndex`, whose doc
+    /// comment says gap pixels attach to the left bar on purpose (a 1D bar
+    /// chart, avoiding a dead zone between tall thin bars); this is a 2D
+    /// discrete date grid where the gaps are visible gridlines and the
+    /// tooltip names one specific date, so the gaps should be dead zones —
+    /// `UsageChartGeometry` itself is untouched.
+    static func withinCell(offset: CGFloat, step: CGFloat, cell: CGFloat) -> Bool {
+        let local = offset.truncatingRemainder(dividingBy: step)
+        return local >= 0 && local < cell
     }
 
     /// Round 2, item 1: the tooltip's anchor in the OUTER (non-scrolling)
@@ -185,7 +219,9 @@ struct ContributionHeatmap: View {
     /// Columns after the last renderable one (round 3) carry no layout width
     /// at all — never derived from `grid.cols`.
     private var visibleCols: Int { max(0, Self.lastRenderableCol(grid, cutoff: cutoff) + 1) }
-    private var contentWidth: CGFloat { Self.contentWidth(visibleCols: visibleCols) }
+    private var contentWidth: CGFloat {
+        Self.contentWidth(visibleCols: visibleCols, monthLabelCols: monthLabelCols)
+    }
     private var gridHeight: CGFloat { 7 * HeatmapLayout.step - HeatmapLayout.gap }
     private var contentHeight: CGFloat { HeatmapLayout.monthLabelHeight + gridHeight }
 
@@ -292,7 +328,14 @@ struct ContributionHeatmap: View {
     /// the col/row re-check guards against that ordering ever changing.
     private func cellAt(_ point: CGPoint) -> GridCell? {
         guard point.x >= 0, point.y >= HeatmapLayout.monthLabelHeight else { return nil }
-        let row = Int((point.y - HeatmapLayout.monthLabelHeight) / HeatmapLayout.step)
+        let localY = point.y - HeatmapLayout.monthLabelHeight
+        // Reject gap coordinates before resolving an index — see
+        // `withinCell`'s doc comment for why this differs from the bar chart.
+        guard
+            Self.withinCell(offset: point.x, step: HeatmapLayout.step, cell: HeatmapLayout.cell),
+            Self.withinCell(offset: localY, step: HeatmapLayout.step, cell: HeatmapLayout.cell)
+        else { return nil }
+        let row = Int(localY / HeatmapLayout.step)
         let col = Int(point.x / HeatmapLayout.step)
         guard (0..<7).contains(row), (0..<visibleCols).contains(col) else { return nil }
         let index = col * 7 + row

--- a/Sources/TokenBar/Charts/ContributionHeatmap.swift
+++ b/Sources/TokenBar/Charts/ContributionHeatmap.swift
@@ -1,0 +1,297 @@
+import SwiftUI
+import TokenBarCore
+
+// Flat, Sunday-first contribution heatmap. Reads the exact same
+// `GridLayout` UsageChartCard builds for ContributionGraph3D (same
+// `buildGrid(year:perDayMap:)` call over `stats.perDayMap`) — this is only a
+// different renderer over identical data (FLAT-HEATMAP invariant 2), not a
+// second aggregation path.
+
+/// Visual parameters as named constants so a design-review pass only touches
+/// one line (FLAT-HEATMAP invariant 9).
+enum HeatmapLayout {
+    static let cell: CGFloat = 11
+    static let gap: CGFloat = 3
+    static let cornerRadius: CGFloat = 2
+    static let monthLabelHeight: CGFloat = 14
+    static let step: CGFloat = cell + gap
+
+    /// Five-level intensity ramp. Thresholds ported from token-monitor's
+    /// `heatmapIntensity()` (usageCharts.js:60-65: `>=0.75→4`, `>=0.5→3`,
+    /// `>=0.25→2`, `>0→1`, else `0`); colors ported from its `.heat.lvl-*`
+    /// rules (dashboard.css:98-102), a blue ramp climbing opacity 0→1.
+    private static let levelFills: [Color] = [
+        Color.primary.opacity(0.05),
+        Color(red: 90 / 255, green: 170 / 255, blue: 255 / 255).opacity(0.22),
+        Color(red: 120 / 255, green: 190 / 255, blue: 255 / 255).opacity(0.5),
+        Color(red: 150 / 255, green: 210 / 255, blue: 255 / 255).opacity(0.82),
+        Color(red: 180 / 255, green: 230 / 255, blue: 255 / 255),
+    ]
+
+    static func level(value: Double, max: Double) -> Int {
+        guard max > 0, value > 0 else { return 0 }
+        let ratio = value / max
+        if ratio >= 0.75 { return 4 }
+        if ratio >= 0.5 { return 3 }
+        if ratio >= 0.25 { return 2 }
+        return 1
+    }
+
+    static func fill(level: Int) -> Color {
+        levelFills[max(0, min(level, levelFills.count - 1))]
+    }
+}
+
+/// Month abbreviations for the header row above the grid. Reuses the same
+/// "Jan"…"Dec" localization keys as `Format.monthDay` (see zh-Hant.lproj)
+/// rather than reaching into Format's private array.
+private let monthAbbrev = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+]
+
+/// The full-year flat heatmap. Tokens/Price only — no Model/Agent stacking
+/// (a single color-ramped cell has nowhere to stack).
+struct ContributionHeatmap: View {
+    let grid: TokenBarCore.GridLayout
+    let metric: ChartMetric
+    /// The year `grid` was built for — needed only to decide the future-day
+    /// cutoff (round 2, item 3); `buildGrid` itself is untouched.
+    let year: String
+
+    @State private var hoverCell: GridCell?
+    @State private var tooltipSize: CGSize = .zero
+    /// The scrolling content's on-screen origin, tracked so the tooltip
+    /// (rendered in an overlay *outside* the horizontal ScrollView, see
+    /// `body`) can find a hovered cell's true screen position instead of one
+    /// pinned to the clipped, scrolled-past content frame.
+    @State private var contentOrigin: CGPoint = .zero
+    @Environment(\.popoverScrollViewport) private var popoverScrollViewport
+
+    private static let tooltipWidth: CGFloat = 170
+    private static let contentID = "heatmap-content"
+
+    // MARK: - Pure per-metric data (no Calendar/TimeZone/Date — ISODay only)
+
+    /// Raw metric value for a cell. Internal (not `private`) so SelfTest can
+    /// exercise it directly.
+    static func value(_ cell: GridCell, metric: ChartMetric) -> Double {
+        metric == .cost ? cell.cost : Double(cell.tokens)
+    }
+
+    /// "This day has data" per metric — FLAT-HEATMAP invariant 3: never
+    /// `cell.active` (that's tokens-only; Grid.swift:49), because a day can
+    /// carry `cost > 0` with `tokens == 0` (UsageStats.swift:105-110).
+    static func hasData(_ cell: GridCell, metric: ChartMetric) -> Bool {
+        cell.inYear && value(cell, metric: metric) > 0
+    }
+
+    /// Per-metric intensity denominator, computed here rather than reusing
+    /// `GridLayout.maxTokens` (invariant 4) — `maxTokens` only ever tracks
+    /// tokens, so Price needs its own max over the in-year cells.
+    static func maxValue(_ grid: TokenBarCore.GridLayout, metric: ChartMetric) -> Double {
+        switch metric {
+        case .tokens:
+            return Double(grid.maxTokens)
+        case .cost:
+            return grid.cells.reduce(0.0) { $1.inYear ? max($0, $1.cost) : $0 }
+        }
+    }
+
+    /// Round 2, item 3(a): the last day this heatmap should draw. Only the
+    /// selected year matching today's year clips to today — any other
+    /// (necessarily past) year still draws through Dec 31. View-level only;
+    /// `buildGrid` still produces the full padded year.
+    static func cutoffDate(year: String, today: String) -> String {
+        year == String(today.prefix(4)) ? today : "\(year)-12-31"
+    }
+
+    /// A cell is drawn/hoverable only if it's in-year and on or before the
+    /// cutoff — i.e. never a future day in the current year.
+    static func isRenderable(_ cell: GridCell, cutoff: String) -> Bool {
+        cell.inYear && cell.date <= cutoff
+    }
+
+    /// Round 3: the last column that has any renderable cell. Layout width,
+    /// month labels, and hit-testing all derive from this — never from
+    /// `grid.cols` — so a future day (round 2's `isRenderable` correctly
+    /// excludes it from drawing/hover, but round 2 left `grid.cols` driving
+    /// the layout width, so cutoff-past columns still ate blank space and
+    /// `scrollTo(.trailing)` landed past the actual last day) occupies no
+    /// layout width at all. `isRenderable` stays the single judgment call;
+    /// this only reduces it to a column number instead of inventing a
+    /// separate "visible range" concept.
+    static func lastRenderableCol(_ grid: TokenBarCore.GridLayout, cutoff: String) -> Int {
+        grid.cells.filter { isRenderable($0, cutoff: cutoff) }.map(\.col).max() ?? -1
+    }
+
+    /// The columns that get a month-name header — the same `isRenderable`
+    /// cutoff as the cell drawing loop, so a month past the cutoff gets no
+    /// label any more than it gets cells. Static (not a private computed
+    /// property) so SelfTest can exercise the exact production filter rather
+    /// than a hand-rebuilt copy of it.
+    static func monthLabelCols(grid: TokenBarCore.GridLayout, cutoff: String) -> [(col: Int, label: String)] {
+        grid.cells
+            .filter { isRenderable($0, cutoff: cutoff) && $0.date.hasSuffix("-01") }
+            .compactMap { cell in
+                let monthChars = cell.date.dropFirst(5).prefix(2)
+                guard let month = Int(monthChars), (1...12).contains(month) else { return nil }
+                return (cell.col, monthAbbrev[month - 1].localized)
+            }
+    }
+
+    /// Round 2, item 1: the tooltip's anchor in the OUTER (non-scrolling)
+    /// container's coordinate space, derived from the hovered cell's
+    /// position in the scrolling content plus that content's current
+    /// on-screen origin. This is what lets the tooltip escape the horizontal
+    /// ScrollView's clip: an anchor pinned to the scrolled content's own
+    /// local frame is exactly the bug being fixed.
+    static func tooltipAnchor(cellCenter: CGPoint, contentOrigin: CGPoint, containerOrigin: CGPoint) -> CGPoint {
+        CGPoint(
+            x: cellCenter.x + contentOrigin.x - containerOrigin.x,
+            y: cellCenter.y + contentOrigin.y - containerOrigin.y)
+    }
+
+    private var metricMax: Double { Self.maxValue(grid, metric: metric) }
+    private var cutoff: String { Self.cutoffDate(year: year, today: Format.todayKey()) }
+
+    private var monthLabelCols: [(col: Int, label: String)] {
+        Self.monthLabelCols(grid: grid, cutoff: cutoff)
+    }
+
+    /// Columns after the last renderable one (round 3) carry no layout width
+    /// at all — never derived from `grid.cols`.
+    private var visibleCols: Int { max(0, Self.lastRenderableCol(grid, cutoff: cutoff) + 1) }
+    private var contentWidth: CGFloat {
+        visibleCols > 0 ? CGFloat(visibleCols) * HeatmapLayout.step - HeatmapLayout.gap : 0
+    }
+    private var gridHeight: CGFloat { 7 * HeatmapLayout.step - HeatmapLayout.gap }
+    private var contentHeight: CGFloat { HeatmapLayout.monthLabelHeight + gridHeight }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            if grid.cells.isEmpty {
+                Color.clear
+            } else {
+                GeometryReader { outerGeo in
+                    ScrollViewReader { proxy in
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            canvasBody
+                                .id(Self.contentID)
+                        }
+                        // Round 2, item 3(b): land on the most recent columns
+                        // on open, GitHub-style, instead of Jan 1.
+                        .onAppear { proxy.scrollTo(Self.contentID, anchor: .trailing) }
+                    }
+                    // Tooltip lives in the ScrollView's overlay, not its
+                    // content — an overlay isn't clipped by the view it
+                    // decorates, so this is what stops the tooltip being cut
+                    // off at the heatmap's edge (round 2, item 1).
+                    .overlay(alignment: .topLeading) {
+                        if let cell = hoverCell {
+                            let anchor = Self.tooltipAnchor(
+                                cellCenter: cellCenter(cell),
+                                contentOrigin: contentOrigin,
+                                containerOrigin: outerGeo.frame(in: .global).origin)
+                            let measuredSize = tooltipSize == .zero
+                                ? CGSize(width: Self.tooltipWidth, height: 60)
+                                : tooltipSize
+                            let offset = PopoverTooltipPlacement.offset(
+                                anchor: anchor,
+                                tooltipSize: measuredSize,
+                                containerFrame: outerGeo.frame(in: .global),
+                                viewport: popoverScrollViewport)
+                            tooltip(cell)
+                                .offset(offset ?? .zero)
+                        }
+                    }
+                }
+                .frame(height: contentHeight)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var canvasBody: some View {
+        ZStack(alignment: .topLeading) {
+            Canvas { context, _ in
+                for (col, label) in monthLabelCols {
+                    context.draw(
+                        Text(label).font(.caption2).foregroundStyle(.secondary),
+                        at: CGPoint(x: CGFloat(col) * HeatmapLayout.step, y: HeatmapLayout.monthLabelHeight / 2),
+                        anchor: .leading)
+                }
+                for cell in grid.cells where Self.isRenderable(cell, cutoff: cutoff) {
+                    let level = HeatmapLayout.level(value: Self.value(cell, metric: metric), max: metricMax)
+                    let rect = CGRect(
+                        x: CGFloat(cell.col) * HeatmapLayout.step,
+                        y: HeatmapLayout.monthLabelHeight + CGFloat(cell.row) * HeatmapLayout.step,
+                        width: HeatmapLayout.cell, height: HeatmapLayout.cell)
+                    context.fill(
+                        Path(roundedRect: rect, cornerRadius: HeatmapLayout.cornerRadius),
+                        with: .color(HeatmapLayout.fill(level: level)))
+                }
+            }
+        }
+        .frame(width: contentWidth, height: contentHeight)
+        .contentShape(Rectangle())
+        .onContinuousHover { phase in
+            switch phase {
+            case let .active(point):
+                hoverCell = cellAt(point).flatMap { Self.hasData($0, metric: metric) ? $0 : nil }
+            case .ended:
+                hoverCell = nil
+            }
+        }
+        .onGeometryChange(for: CGPoint.self) { $0.frame(in: .global).origin } action: { contentOrigin = $0 }
+        // Round 2, item 2: let a plain vertical mouse wheel scroll this
+        // horizontal grid (DashboardTabs.swift's pattern) — placed inside the
+        // ScrollView's content, per HorizontalWheelScroll's own doc comment,
+        // so `enclosingScrollView` resolves to this row's NSScrollView.
+        .background(HorizontalWheelScroll())
+    }
+
+    // MARK: - Hit testing
+
+    /// `grid.cells` is laid out `col * 7 + row` by `buildGrid` (Grid.swift's
+    /// nested col/row loop), so direct indexing avoids a lookup dictionary;
+    /// the col/row re-check guards against that ordering ever changing.
+    private func cellAt(_ point: CGPoint) -> GridCell? {
+        guard point.x >= 0, point.y >= HeatmapLayout.monthLabelHeight else { return nil }
+        let row = Int((point.y - HeatmapLayout.monthLabelHeight) / HeatmapLayout.step)
+        let col = Int(point.x / HeatmapLayout.step)
+        guard (0..<7).contains(row), (0..<visibleCols).contains(col) else { return nil }
+        let index = col * 7 + row
+        guard grid.cells.indices.contains(index) else { return nil }
+        let cell = grid.cells[index]
+        guard cell.col == col, cell.row == row, Self.isRenderable(cell, cutoff: cutoff) else { return nil }
+        return cell
+    }
+
+    private func cellCenter(_ cell: GridCell) -> CGPoint {
+        CGPoint(
+            x: CGFloat(cell.col) * HeatmapLayout.step + HeatmapLayout.cell / 2,
+            y: HeatmapLayout.monthLabelHeight + CGFloat(cell.row) * HeatmapLayout.step + HeatmapLayout.cell / 2)
+    }
+
+    // MARK: - Tooltip
+
+    private func tooltip(_ cell: GridCell) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(Format.monthDay(cell.date)).font(.caption.weight(.semibold))
+            Text("%@ tokens".localized(Format.exactTokens(cell.tokens)))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(Format.usd(cell.cost))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(6)
+        .frame(width: Self.tooltipWidth, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.quaternary))
+        .onGeometryChange(for: CGSize.self) { $0.size } action: { tooltipSize = $0 }
+        .allowsHitTesting(false)
+    }
+}

--- a/Sources/TokenBar/PopoverView.swift
+++ b/Sources/TokenBar/PopoverView.swift
@@ -30,7 +30,10 @@ struct PopoverView: View {
     @State private var keyMonitor: Any?
     @State private var flagsMonitor: Any?
     @State private var cmdHintTask: Task<Void, Never>?
-    @AppStorage("tokenbar.chart.view") private var chartViewRaw = "2d"
+    // Round 6 audit 2: matches the sibling `activeViewRaw` default below —
+    // `ChartView.bars.rawValue`, not the bare "2d" literal this used to
+    // duplicate.
+    @AppStorage("tokenbar.chart.view") private var chartViewRaw = ChartView.bars.rawValue
     @AppStorage(ClientTray.activeViewKey) private var activeViewRaw = AppView.overview.rawValue
     @AppStorage("tokenbar.views.hidden") private var hiddenViewsRaw = ""
     @AppStorage("tokenbar.bridge.dismissed") private var bridgeDismissed = false
@@ -562,7 +565,8 @@ struct PopoverView: View {
 
     /// The web app's Cmd shortcuts (App.tsx onKeyDown), as local NSEvent
     /// monitors scoped to the popover's key window: ⌘1-9 tabs, ⌘[/⌘] cycle,
-    /// ⌘, settings, ⌘R refresh, ⌘G 2D/3D, ⌘W/Esc close, ⌘Q quit. Holding Cmd
+    /// ⌘, settings, ⌘R refresh, ⌘G cycle chart view (Bars/Heatmap/3D), ⌘W/Esc
+    /// close, ⌘Q quit. Holding Cmd
     /// alone for 400ms reveals the tab pins (system chords like ⌘⇧4 don't).
     private func installKeyMonitors() {
         guard keyMonitor == nil else { return }
@@ -628,7 +632,11 @@ struct PopoverView: View {
         case "r":
             Task { await model.refresh() }
         case "g":
-            chartViewRaw = chartViewRaw == "2d" ? "3d" : "2d"
+            // Round 6, FIX 1: cycle order lives on `ChartView` (bars →
+            // heatmap → 3D → bars) — not hardcoded here — so this handler
+            // never again silently drops a view out of the ⌘G cycle when a
+            // new one is added.
+            chartViewRaw = ChartView(raw: chartViewRaw).next.rawValue
         default:
             return false
         }

--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -108,6 +108,8 @@
 "Reasoning" = "推理";
 "Model" = "模型";
 "Agent" = "Agent";
+"Bars" = "長條圖";
+"Heatmap" = "熱點圖";
 "Window" = "時間窗";
 "Price" = "費用";
 "Show less" = "收合";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3197,13 +3197,12 @@ enum SelfTest {
         // is the pure-logic slice of the fix; the actual on-screen clip
         // behavior needs a human looking at the popover (A9-equivalent).
         expect(
-            ContributionHeatmap.tooltipAnchor(
-                cellCenter: CGPoint(x: 50, y: 20), contentOrigin: .zero, containerOrigin: .zero)
+            ContributionHeatmap.tooltipAnchor(cellCenter: CGPoint(x: 50, y: 20), contentOrigin: .zero)
                 == CGPoint(x: 50, y: 20),
             "an unscrolled, unmoved content anchors directly on the cell's own center")
         expect(
             ContributionHeatmap.tooltipAnchor(
-                cellCenter: CGPoint(x: 50, y: 20), contentOrigin: CGPoint(x: -300, y: 0), containerOrigin: .zero)
+                cellCenter: CGPoint(x: 50, y: 20), contentOrigin: CGPoint(x: -300, y: 0))
                 == CGPoint(x: -250, y: 20),
             "scrolling the content 300pt left shifts the anchor by the same 300pt — proving the tooltip "
                 + "tracks the outer container, not a position frozen inside the scrolled/clipped content")
@@ -3442,6 +3441,57 @@ enum SelfTest {
             ContributionHeatmap.shouldClearHoverOnOriginChange(
                 old: CGPoint(x: 10, y: 20), new: CGPoint(x: 10, y: 5)),
             "a vertical-only origin change also clears the hover")
+
+        // MARK: - FLAT-HEATMAP round 8 (perf regression fix; append-only)
+
+        // The scroll-perf fix: measuring `contentOrigin` in a coordinate
+        // space anchored to the OUTER container (instead of `.global`)
+        // means a shared ancestor translation — the dashboard's own
+        // vertical ScrollView scrolling — cancels out, because both the
+        // content's and the container's `.global` positions shift by the
+        // SAME delta. This models that arithmetic directly: two `.global`
+        // snapshots of content/container before an ancestor scroll, and two
+        // after a 150pt vertical shift applied to BOTH.
+        let r8ContentGlobalBefore = CGPoint(x: 40, y: 320)
+        let r8ContainerGlobalBefore = CGPoint(x: 20, y: 300)
+        let r8AncestorScrollDelta: CGFloat = 150
+        let r8ContentGlobalAfter = CGPoint(
+            x: r8ContentGlobalBefore.x, y: r8ContentGlobalBefore.y - r8AncestorScrollDelta)
+        let r8ContainerGlobalAfter = CGPoint(
+            x: r8ContainerGlobalBefore.x, y: r8ContainerGlobalBefore.y - r8AncestorScrollDelta)
+        expect(
+            r8ContentGlobalBefore != r8ContentGlobalAfter,
+            "sanity: the raw `.global` position genuinely changes during the ancestor scroll — this is "
+                + "exactly why tracking `.global` fired `onGeometryChange`'s action, and therefore wrote "
+                + "state, on every single frame of a scroll this view had no other stake in")
+        func relative(content: CGPoint, container: CGPoint) -> CGPoint {
+            CGPoint(x: content.x - container.x, y: content.y - container.y)
+        }
+        let r8RelativeBefore = relative(content: r8ContentGlobalBefore, container: r8ContainerGlobalBefore)
+        let r8RelativeAfter = relative(content: r8ContentGlobalAfter, container: r8ContainerGlobalAfter)
+        expect(
+            r8RelativeBefore == r8RelativeAfter,
+            "content's position relative to its container is invariant under a shared ancestor "
+                + "translation — this is exactly the value a coordinate space anchored to the container "
+                + "reports directly, instead of two independent `.global` values that must be subtracted")
+        expect(
+            !ContributionHeatmap.shouldClearHoverOnOriginChange(old: r8RelativeBefore, new: r8RelativeAfter),
+            "so a pure vertical ancestor scroll correctly does NOT clear the hover or write state "
+                + "(mutation: if the container-relative value were computed wrong — e.g. only the "
+                + "content's delta and not the container's — this would go red)")
+
+        // Contrast: a genuine HORIZONTAL scroll of this grid's own content
+        // (the container does not move) must still change the relative
+        // origin, so hover keeps clearing correctly for the case that
+        // actually matters (round 7's fix).
+        let r8HScrolledContentGlobal = CGPoint(x: r8ContentGlobalBefore.x - 60, y: r8ContentGlobalBefore.y)
+        let r8HScrolledRelative = relative(content: r8HScrolledContentGlobal, container: r8ContainerGlobalBefore)
+        expect(
+            r8HScrolledRelative != r8RelativeBefore,
+            "a genuine horizontal content scroll DOES change the container-relative origin")
+        expect(
+            ContributionHeatmap.shouldClearHoverOnOriginChange(old: r8RelativeBefore, new: r8HScrolledRelative),
+            "...and therefore still clears the hover, same as before this round's fix")
 
         if failures > 0 {
             print("\(failures) selftest check(s) failed")

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3322,6 +3322,41 @@ enum SelfTest {
             "the only visible day still renders at full intensity (mutation: reverting the tokens branch "
                 + "to `grid.maxTokens` or the cost branch to an unfiltered reduce would crush this)")
 
+        // MARK: - FLAT-HEATMAP round 5 (Codex P2 fix + audit; append-only)
+
+        // FIX: a FUTURE selected year (reachable if clock skew or an
+        // imported session put activity there, so it shows up in the year
+        // picker) must render nothing, not the whole year — the old two-way
+        // `year == currentYear ? today : "\(year)-12-31"` treated every
+        // non-current year as past.
+        expect(
+            ContributionHeatmap.cutoffDate(year: "2026", today: "2026-07-29") == "2026-07-29",
+            "the current year still cuts off at today")
+        expect(
+            ContributionHeatmap.cutoffDate(year: "2025", today: "2026-07-29") == "2025-12-31",
+            "a past year still cuts off at its own Dec 31")
+        expect(
+            ContributionHeatmap.cutoffDate(year: "2027", today: "2026-07-29") == "2026-07-29",
+            "a future year cuts off at today too (mutation: the old `year == currentYear ? today : "
+                + "\"\\(year)-12-31\"` two-way branch would return \"2027-12-31\" here and fail this)")
+
+        let r5FutureYearGrid = buildGrid(year: "2027", perDayMap: [:])
+        let r5FutureCutoff = ContributionHeatmap.cutoffDate(year: "2027", today: "2026-07-29")
+        expect(
+            ContributionHeatmap.lastRenderableCol(r5FutureYearGrid, cutoff: r5FutureCutoff) == -1,
+            "a future year has zero renderable columns")
+
+        // Zero renderable columns (the future-year case just established, or
+        // any grid where nothing passes the cutoff) must not produce a
+        // negative canvas width.
+        expect(
+            ContributionHeatmap.contentWidth(visibleCols: 0) == 0,
+            "zero visible columns is zero width, not a negative width from `0 * step - gap` "
+                + "(mutation: dropping the `visibleCols > 0` guard would fail this)")
+        expect(
+            ContributionHeatmap.contentWidth(visibleCols: 3) > 0,
+            "sanity: a normal, nonzero column count still produces a positive width")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3350,12 +3350,75 @@ enum SelfTest {
         // any grid where nothing passes the cutoff) must not produce a
         // negative canvas width.
         expect(
-            ContributionHeatmap.contentWidth(visibleCols: 0) == 0,
+            ContributionHeatmap.contentWidth(visibleCols: 0, monthLabelCols: []) == 0,
             "zero visible columns is zero width, not a negative width from `0 * step - gap` "
                 + "(mutation: dropping the `visibleCols > 0` guard would fail this)")
         expect(
-            ContributionHeatmap.contentWidth(visibleCols: 3) > 0,
+            ContributionHeatmap.contentWidth(visibleCols: 3, monthLabelCols: []) > 0,
             "sanity: a normal, nonzero column count still produces a positive width")
+
+        // MARK: - FLAT-HEATMAP round 6 (Codex round 3 P2 fixes + audit; append-only)
+
+        // FIX 1: `ChartView.next` owns the ⌘G cycle order. The regression
+        // this guards was specifically that Heatmap couldn't be distinguished
+        // from 3D by the old handler, so it's the heatmap→threeD step (not
+        // just "the cycle eventually returns") that matters most here.
+        expect(ChartView.bars.next == .heatmap, "cycle: Bars -> Heatmap")
+        expect(
+            ChartView.heatmap.next == .threeD,
+            "cycle: Heatmap -> 3D, not back to Bars — this is exactly the regression: the old handler's "
+                + "binary `chartViewRaw == \"2d\" ? \"3d\" : \"2d\"` treated Heatmap the same as \"any "
+                + "non-2d value\" and always landed on 3D, then only ever toggled Bars<->3D afterward, so "
+                + "a keyboard user starting on Heatmap could never cycle back to it")
+        expect(ChartView.threeD.next == .bars, "cycle: 3D -> Bars, closing the loop")
+        expect(
+            ChartView.bars.next.next.next == .bars,
+            "three ⌘G presses from any state return to that same state")
+
+        // FIX 2: contentWidth gains the trailing margin ONLY when the LAST
+        // renderable column itself has a month label.
+        let r6BaseWidth = ContributionHeatmap.contentWidth(visibleCols: 5, monthLabelCols: [])
+        let r6TrailingLabelWidth = ContributionHeatmap.contentWidth(
+            visibleCols: 5, monthLabelCols: [(col: 4, label: "Sep")])
+        expect(
+            r6TrailingLabelWidth == r6BaseWidth + HeatmapLayout.lastColumnLabelMargin,
+            "a label landing in the last renderable column adds exactly the named margin")
+        let r6MidLabelWidth = ContributionHeatmap.contentWidth(
+            visibleCols: 5, monthLabelCols: [(col: 2, label: "Jul")])
+        expect(
+            r6MidLabelWidth == r6BaseWidth,
+            "a label on a column that ISN'T the last one adds no margin (mutation: adding the margin "
+                + "whenever monthLabelCols is merely non-empty, instead of checking the last column "
+                + "specifically, would fail this)")
+
+        // FIX 3: gap coordinates are dead zones (unlike the bar chart's
+        // intentional gap-attaches-to-the-left-bar rule); horizontal and
+        // vertical boundaries both tested at the cell's last valid pixel and
+        // the gap's first pixel.
+        let r6Cell = HeatmapLayout.cell
+        let r6Step = HeatmapLayout.step
+        expect(
+            ContributionHeatmap.withinCell(offset: 0, step: r6Step, cell: r6Cell),
+            "the first pixel of a cell is inside it")
+        expect(
+            ContributionHeatmap.withinCell(offset: r6Cell - 0.1, step: r6Step, cell: r6Cell),
+            "the last valid pixel just before the gap is still inside the cell")
+        expect(
+            !ContributionHeatmap.withinCell(offset: r6Cell, step: r6Step, cell: r6Cell),
+            "the first pixel of the gap is rejected (mutation: dropping the `< cell` check, i.e. always "
+                + "returning true, would fail this)")
+        expect(
+            !ContributionHeatmap.withinCell(offset: r6Step - 0.1, step: r6Step, cell: r6Cell),
+            "the last pixel of the gap, right before the next cell, is still rejected")
+        expect(
+            ContributionHeatmap.withinCell(offset: r6Step, step: r6Step, cell: r6Cell),
+            "the first pixel of the NEXT cell is inside it again")
+        expect(
+            ContributionHeatmap.withinCell(offset: r6Step + r6Cell - 0.1, step: r6Step, cell: r6Cell),
+            "the second cell's last valid pixel is inside it")
+        expect(
+            !ContributionHeatmap.withinCell(offset: r6Step + r6Cell, step: r6Step, cell: r6Cell),
+            "the second cell's gap is rejected too")
 
         if failures > 0 {
             print("\(failures) selftest check(s) failed")

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3420,6 +3420,29 @@ enum SelfTest {
             !ContributionHeatmap.withinCell(offset: r6Step + r6Cell, step: r6Step, cell: r6Cell),
             "the second cell's gap is rejected too")
 
+        // MARK: - FLAT-HEATMAP round 7 (Codex round 4 P2 fix + audit; append-only)
+
+        // FIX: `shouldClearHoverOnOriginChange` is the pure half of "clear
+        // hover when the content actually scrolled, not on every incidental
+        // re-layout". The `onGeometryChange` → `hoverIndex = nil` wiring
+        // itself firing at the right moment during a live scroll has no
+        // headless SwiftUI harness here and is manual-verification-only.
+        expect(
+            !ContributionHeatmap.shouldClearHoverOnOriginChange(
+                old: CGPoint(x: 10, y: 20), new: CGPoint(x: 10, y: 20)),
+            "an unchanged origin never clears the hover (mutation: always returning true here would "
+                + "make hover impossible to establish at all, since the geometry modifier's initial call "
+                + "would immediately clear it)")
+        expect(
+            ContributionHeatmap.shouldClearHoverOnOriginChange(
+                old: CGPoint(x: 10, y: 20), new: CGPoint(x: 40, y: 20)),
+            "a changed origin (e.g. a redirected wheel scroll) clears the hover (mutation: always "
+                + "returning false would leave a stale tooltip pinned through a scroll — the original bug)")
+        expect(
+            ContributionHeatmap.shouldClearHoverOnOriginChange(
+                old: CGPoint(x: 10, y: 20), new: CGPoint(x: 10, y: 5)),
+            "a vertical-only origin change also clears the hover")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3044,6 +3044,217 @@ enum SelfTest {
             expect(passed, "filter parity: \(label)")
         }
 
+        // MARK: - FLAT-HEATMAP (append-only section; do not reorder/edit above)
+
+        // A1/A2: the heatmap grid must read the exact same, already-filtered
+        // `stats.perDayMap` UsageChartCard hands ContributionGraph3D — same
+        // pipeline, same values, and NOT the unfiltered payload total.
+        let heatJSON = """
+        {"meta":{"generatedAt":"now","version":"1","dateRange":{"start":"2026-01-01","end":"2026-01-01"}},
+         "summary":{"totalTokens":0,"totalCost":0,"totalDays":1,"activeDays":1,"averagePerDay":0,
+                    "maxCostInSingleDay":0,"clients":["a","b"],"models":[]},
+         "years":[],
+         "contributions":[
+           {"date":"2026-01-01","totals":{"tokens":0,"cost":0,"messages":0},"intensity":1,
+            "tokenBreakdown":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0},
+            "clients":[
+              {"client":"a","modelId":"m","providerId":"p","cost":2,"messages":1,
+               "tokens":{"input":100,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0}},
+              {"client":"b","modelId":"m","providerId":"p","cost":3,"messages":1,
+               "tokens":{"input":50,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0}}]}
+         ]}
+        """
+        let heatPayload = try! JSONDecoder().decode(UsagePayload.self, from: Data(heatJSON.utf8))
+        let heatStatsA = UsageStats(payload: heatPayload, selectedClients: ["a"])
+        let heatGridA = buildGrid(year: "2026", perDayMap: heatStatsA.perDayMap)
+        let heatCellA = heatGridA.cells.first { $0.date == "2026-01-01" }
+        expect(
+            heatCellA?.tokens == 100 && heatCellA?.cost == 2,
+            "heatmap grid cell matches the filtered UsageStats value for the selected client")
+        expect(
+            (heatCellA?.tokens ?? 0) != 150 && (heatCellA?.cost ?? 0) != 5,
+            "heatmap grid cell for one client is not the two-client total")
+
+        // A3 (invariant 3): a `tokens == 0, cost > 0` day must count as "has
+        // data" under the Price metric. This is reachable (UsageStats.swift
+        // 105-110) and `cell.active` (Grid.swift:49) is tokens-only — using
+        // it here would wrongly blank this day out.
+        let costOnlyGrid = buildGrid(
+            year: "2026",
+            perDayMap: ["2026-05-05": PerDay(date: "2026-05-05", tokens: 0, cost: 5, intensity: 1)])
+        let costOnlyCell = costOnlyGrid.cells.first { $0.date == "2026-05-05" }!
+        expect(costOnlyCell.active == false, "sanity: a cost-only day is not `active` (tokens-only flag)")
+        expect(
+            ContributionHeatmap.hasData(costOnlyCell, metric: .cost) == true,
+            "Price metric treats cost>0 as data even when active==false")
+        expect(
+            ContributionHeatmap.hasData(costOnlyCell, metric: .tokens) == false,
+            "Tokens metric still has no data on a cost-only day")
+        let costOnlyMax = ContributionHeatmap.maxValue(costOnlyGrid, metric: .cost)
+        expect(
+            HeatmapLayout.level(
+                value: ContributionHeatmap.value(costOnlyCell, metric: .cost), max: costOnlyMax) >= 1,
+            "cost-only day renders at a non-zero heatmap intensity level")
+
+        // A4 (invariant 4): Tokens and Price take their intensity denominator
+        // independently — the day with the most tokens need not be the day
+        // with the highest cost, and each metric's own top day must still
+        // reach the top intensity level under its own max.
+        let dualMetricGrid = buildGrid(
+            year: "2026",
+            perDayMap: [
+                "2026-03-01": PerDay(date: "2026-03-01", tokens: 1000, cost: 1, intensity: 1),
+                "2026-03-08": PerDay(date: "2026-03-08", tokens: 10, cost: 100, intensity: 1),
+            ])
+        let dayHighTokens = dualMetricGrid.cells.first { $0.date == "2026-03-01" }!
+        let dayHighCost = dualMetricGrid.cells.first { $0.date == "2026-03-08" }!
+        let dualMaxTokens = ContributionHeatmap.maxValue(dualMetricGrid, metric: .tokens)
+        let dualMaxCost = ContributionHeatmap.maxValue(dualMetricGrid, metric: .cost)
+        expect(
+            dualMaxTokens == 1000 && dualMaxCost == 100,
+            "tokens and cost maxima are computed independently, from different days")
+        expect(
+            HeatmapLayout.level(
+                value: ContributionHeatmap.value(dayHighTokens, metric: .tokens), max: dualMaxTokens) == 4
+                && HeatmapLayout.level(
+                    value: ContributionHeatmap.value(dayHighCost, metric: .cost), max: dualMaxCost) == 4,
+            "each metric's own top day reaches the highest intensity level")
+        expect(
+            HeatmapLayout.level(
+                value: ContributionHeatmap.value(dayHighCost, metric: .tokens), max: dualMaxTokens) < 4,
+            "the cost-max day is not also the tokens-max day (cost wrongly reusing maxTokens would fail this)")
+
+        // Five-level threshold boundaries (invariant 9): >=0.75/0.5/0.25/>0/else.
+        expect(
+            HeatmapLayout.level(value: 75, max: 100) == 4
+                && HeatmapLayout.level(value: 50, max: 100) == 3
+                && HeatmapLayout.level(value: 25, max: 100) == 2
+                && HeatmapLayout.level(value: 1, max: 100) == 1
+                && HeatmapLayout.level(value: 0, max: 100) == 0
+                && HeatmapLayout.level(value: 10, max: 0) == 0,
+            "five-level intensity thresholds match >=0.75/0.5/0.25/>0/else")
+
+        // A5/A6: calendar boundaries across years, including a leap day.
+        // `buildGrid` clamps to `max(53, …)`, so every real year lands on 53
+        // or 54 columns; 2028 is the nearest 54-column year to today.
+        expect(buildGrid(year: "2026", perDayMap: [:]).cols == 53, "2026 uses the standard 53 columns")
+        expect(buildGrid(year: "2028", perDayMap: [:]).cols == 54, "2028 needs a 54th column")
+        let leapGrid = buildGrid(
+            year: "2028",
+            perDayMap: ["2028-02-29": PerDay(date: "2028-02-29", tokens: 1, cost: 0, intensity: 1)])
+        let leapCell = leapGrid.cells.first { $0.date == "2028-02-29" }
+        expect(
+            leapCell?.inYear == true && leapCell?.active == true,
+            "2028-02-29 is a valid in-year, active cell (pure ISODay stepping, no Calendar)")
+
+        // A7 (invariant 7): `chartViewRaw` fallback is exhaustive, not an
+        // ad hoc `!is3D && !isHeatmap` chain — any unknown value, not just
+        // the ones tested here, falls back to Bars.
+        expect(ChartView(raw: "2d") == .bars, "legacy '2d' still maps to Bars (no migration needed)")
+        expect(ChartView(raw: "3d") == .threeD, "legacy '3d' still maps to 3D")
+        expect(ChartView(raw: "heat") == .heatmap, "new 'heat' value maps to Heatmap")
+        expect(ChartView(raw: "garbage") == .bars, "an unknown chartViewRaw falls back to Bars, not a crash")
+
+        // MARK: - FLAT-HEATMAP round 2 (append-only; do not reorder/edit above)
+
+        // Item 3(a): future-day cutoff. Current year clips to today; any
+        // other (necessarily past) year still runs through Dec 31.
+        expect(
+            ContributionHeatmap.cutoffDate(year: "2026", today: "2026-07-29") == "2026-07-29",
+            "the selected year matching today's year cuts off at today")
+        expect(
+            ContributionHeatmap.cutoffDate(year: "2025", today: "2026-07-29") == "2025-12-31",
+            "a past selected year still runs through Dec 31, not today's date")
+
+        let cutoffCurrent = ContributionHeatmap.cutoffDate(year: "2026", today: "2026-07-29")
+        let currentYearGrid = buildGrid(year: "2026", perDayMap: [:])
+        let renderableCurrent = currentYearGrid.cells
+            .filter { ContributionHeatmap.isRenderable($0, cutoff: cutoffCurrent) }
+            .map(\.date)
+        expect(
+            renderableCurrent.max() == "2026-07-29" && !renderableCurrent.contains("2026-07-30"),
+            "the current year renders through today and no further (a `<` vs `<=` slip would fail this)")
+
+        let cutoffPast = ContributionHeatmap.cutoffDate(year: "2025", today: "2026-07-29")
+        let pastYearGrid = buildGrid(year: "2025", perDayMap: [:])
+        let renderablePast = pastYearGrid.cells
+            .filter { ContributionHeatmap.isRenderable($0, cutoff: cutoffPast) }
+            .map(\.date)
+        expect(
+            renderablePast.max() == "2025-12-31",
+            "a past year still renders all the way to Dec 31 (forgetting the year check would clip it to today's date)")
+
+        // Item 1: the tooltip's anchor must be derived from the scrolling
+        // content's *current* on-screen origin, not pinned to the cell's
+        // position within that content alone — that pin is exactly the old
+        // clipping bug (tooltip position never accounted for scroll, so it
+        // rendered inside the ScrollView's own clipped content layer). This
+        // is the pure-logic slice of the fix; the actual on-screen clip
+        // behavior needs a human looking at the popover (A9-equivalent).
+        expect(
+            ContributionHeatmap.tooltipAnchor(
+                cellCenter: CGPoint(x: 50, y: 20), contentOrigin: .zero, containerOrigin: .zero)
+                == CGPoint(x: 50, y: 20),
+            "an unscrolled, unmoved content anchors directly on the cell's own center")
+        expect(
+            ContributionHeatmap.tooltipAnchor(
+                cellCenter: CGPoint(x: 50, y: 20), contentOrigin: CGPoint(x: -300, y: 0), containerOrigin: .zero)
+                == CGPoint(x: -250, y: 20),
+            "scrolling the content 300pt left shifts the anchor by the same 300pt — proving the tooltip "
+                + "tracks the outer container, not a position frozen inside the scrolled/clipped content")
+
+        // MARK: - FLAT-HEATMAP round 3 (append-only; do not reorder/edit above)
+
+        // Layout width (and hit-testing) must derive from the last
+        // RENDERABLE column, not `grid.cols` — round 2 correctly stopped
+        // drawing/hovering future days but left `grid.cols` driving the
+        // layout width, so the blank cutoff-past columns still ate width and
+        // `scrollTo(.trailing)` landed on empty space instead of today.
+        let r3Today = "2026-07-29"
+        let r3CurrentYearGrid = buildGrid(year: "2026", perDayMap: [:])
+        let r3TodayCell = r3CurrentYearGrid.cells.first { $0.date == r3Today }!
+        // September, not August: July 29 (a Wednesday) and Aug 1 fall in the
+        // same Sunday-Saturday week/column, which would make the "later
+        // column" assertion below vacuously true regardless of the fix.
+        let r3SeptemberCell = r3CurrentYearGrid.cells.first { $0.date == "2026-09-01" }!
+        let r3LastColCurrent = ContributionHeatmap.lastRenderableCol(r3CurrentYearGrid, cutoff: r3Today)
+        expect(
+            r3LastColCurrent == r3TodayCell.col,
+            "the current year's last renderable column is today's column, not the last column of the year")
+        expect(
+            r3LastColCurrent < r3SeptemberCell.col,
+            "a column after today contributes no width (using grid.cols here would fail this)")
+
+        // Note: a mutated `cutoffDate` that always returns `today` regardless
+        // of year (the round-2 mutation target) does NOT fail this specific
+        // assertion — a past year's dates all lexicographically precede a
+        // current-year "today" string, so that particular bug still yields
+        // full width here by coincidence; it's caught instead by round 2's
+        // own "past selected year still runs through Dec 31" test above. This
+        // assertion's real mutation target is a wrong past-year end date
+        // (e.g. `"\(year)-01-01"` instead of `"\(year)-12-31"`), which does
+        // narrow the width and does fail here.
+        let r3PastCutoff = ContributionHeatmap.cutoffDate(year: "2025", today: r3Today)
+        let r3PastYearGrid = buildGrid(year: "2025", perDayMap: [:])
+        let r3LastColPast = ContributionHeatmap.lastRenderableCol(r3PastYearGrid, cutoff: r3PastCutoff)
+        expect(
+            r3LastColPast == r3PastYearGrid.cols - 1,
+            "a past year still spans the full grid width (a wrong past-year cutoff end date would narrow it)")
+
+        // Month labels must stop at the same cutoff as the cells — calling
+        // the real `monthLabelCols(grid:cutoff:)`, not a hand-rebuilt copy of
+        // its filter, so dropping the cutoff filter inside it would be caught.
+        let r3JulyFirstCell = r3CurrentYearGrid.cells.first { $0.date == "2026-07-01" }!
+        let r3MonthLabelCols = ContributionHeatmap.monthLabelCols(grid: r3CurrentYearGrid, cutoff: r3Today)
+            .map(\.col)
+        expect(
+            r3MonthLabelCols.contains(r3JulyFirstCell.col),
+            "July's label (on or before the cutoff) is still present")
+        expect(
+            !r3MonthLabelCols.contains(r3SeptemberCell.col),
+            "September's label (after the cutoff) is dropped (mutation: skipping the isRenderable filter "
+                + "inside monthLabelCols would fail this)")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3075,6 +3075,11 @@ enum SelfTest {
             (heatCellA?.tokens ?? 0) != 150 && (heatCellA?.cost ?? 0) != 5,
             "heatmap grid cell for one client is not the two-client total")
 
+        // `maxValue` gained a `cutoff` parameter in round 4 (FIX 3); this
+        // constant preserves every existing A3/A4 fixture's original
+        // semantics (nothing excluded) rather than weakening what they test.
+        let noCutoffFilter = "9999-12-31"
+
         // A3 (invariant 3): a `tokens == 0, cost > 0` day must count as "has
         // data" under the Price metric. This is reachable (UsageStats.swift
         // 105-110) and `cell.active` (Grid.swift:49) is tokens-only — using
@@ -3090,7 +3095,7 @@ enum SelfTest {
         expect(
             ContributionHeatmap.hasData(costOnlyCell, metric: .tokens) == false,
             "Tokens metric still has no data on a cost-only day")
-        let costOnlyMax = ContributionHeatmap.maxValue(costOnlyGrid, metric: .cost)
+        let costOnlyMax = ContributionHeatmap.maxValue(costOnlyGrid, metric: .cost, cutoff: noCutoffFilter)
         expect(
             HeatmapLayout.level(
                 value: ContributionHeatmap.value(costOnlyCell, metric: .cost), max: costOnlyMax) >= 1,
@@ -3108,8 +3113,8 @@ enum SelfTest {
             ])
         let dayHighTokens = dualMetricGrid.cells.first { $0.date == "2026-03-01" }!
         let dayHighCost = dualMetricGrid.cells.first { $0.date == "2026-03-08" }!
-        let dualMaxTokens = ContributionHeatmap.maxValue(dualMetricGrid, metric: .tokens)
-        let dualMaxCost = ContributionHeatmap.maxValue(dualMetricGrid, metric: .cost)
+        let dualMaxTokens = ContributionHeatmap.maxValue(dualMetricGrid, metric: .tokens, cutoff: noCutoffFilter)
+        let dualMaxCost = ContributionHeatmap.maxValue(dualMetricGrid, metric: .cost, cutoff: noCutoffFilter)
         expect(
             dualMaxTokens == 1000 && dualMaxCost == 100,
             "tokens and cost maxima are computed independently, from different days")
@@ -3254,6 +3259,68 @@ enum SelfTest {
             !r3MonthLabelCols.contains(r3SeptemberCell.col),
             "September's label (after the cutoff) is dropped (mutation: skipping the isRenderable filter "
                 + "inside monthLabelCols would fail this)")
+
+        // MARK: - FLAT-HEATMAP round 4 (Codex P2 fixes; append-only)
+
+        // FIX 1: the re-scroll-to-trailing trigger is `cutoff`, which changes
+        // on both a year-filter change and a day rollover — this is the pure,
+        // testable half of the fix. The actual SwiftUI `onChange(of:
+        // cutoff)` → `proxy.scrollTo` wiring firing at the right time needs a
+        // human watching the popover switch years while on the Heatmap tab;
+        // there's no headless SwiftUI view-update harness here to automate
+        // that half.
+        expect(
+            ContributionHeatmap.cutoffDate(year: "2026", today: "2026-07-29")
+                != ContributionHeatmap.cutoffDate(year: "2025", today: "2026-07-29"),
+            "cutoff changes across a year-filter switch (the re-scroll trigger fires)")
+        expect(
+            ContributionHeatmap.cutoffDate(year: "2026", today: "2026-07-29")
+                != ContributionHeatmap.cutoffDate(year: "2026", today: "2026-07-30"),
+            "cutoff also changes across a day rollover while the popover stays open")
+
+        // FIX 2: a horizontal wheel-redirect already parked at an edge must
+        // report "not consumed" so the dashboard's vertical ScrollView still
+        // sees the wheel tick — the pre-fix code clamped and unconditionally
+        // reported the event as handled even when the clamped origin was
+        // identical to the one it started with.
+        let r4RightEdge = HorizontalWheelScroll.clampedScroll(originX: 500, step: -20, maxX: 500)
+        expect(
+            r4RightEdge.newOriginX == 500 && r4RightEdge.moved == false,
+            "already at the trailing edge: origin doesn't move, so the event is not consumed "
+                + "(mutation: always returning moved=true would fail this)")
+        let r4LeftEdge = HorizontalWheelScroll.clampedScroll(originX: 0, step: 20, maxX: 500)
+        expect(
+            r4LeftEdge.newOriginX == 0 && r4LeftEdge.moved == false,
+            "already at the leading edge: origin doesn't move, so the event is not consumed")
+        let r4MidScroll = HorizontalWheelScroll.clampedScroll(originX: 100, step: 20, maxX: 500)
+        expect(
+            r4MidScroll.newOriginX == 80 && r4MidScroll.moved == true,
+            "a scroll that actually changes the origin IS consumed")
+
+        // FIX 3: a hidden future cell (clock skew, an imported session dated
+        // past today) must not sit in either metric's intensity denominator
+        // — the same `isRenderable` cutoff that keeps it from being drawn or
+        // hoverable must also keep it out of `maxValue`.
+        let r4FutureShockGrid = buildGrid(
+            year: "2026",
+            perDayMap: [
+                "2026-07-10": PerDay(date: "2026-07-10", tokens: 100, cost: 5, intensity: 1),
+                "2026-08-15": PerDay(date: "2026-08-15", tokens: 999_999, cost: 9999, intensity: 1),
+            ])
+        let r4Cutoff = "2026-07-29"
+        let r4VisibleCell = r4FutureShockGrid.cells.first { $0.date == "2026-07-10" }!
+        let r4TokensMax = ContributionHeatmap.maxValue(r4FutureShockGrid, metric: .tokens, cutoff: r4Cutoff)
+        let r4CostMax = ContributionHeatmap.maxValue(r4FutureShockGrid, metric: .cost, cutoff: r4Cutoff)
+        expect(
+            r4TokensMax == 100 && r4CostMax == 5,
+            "a hidden future day's huge values don't enter either metric's intensity denominator")
+        expect(
+            HeatmapLayout.level(
+                value: ContributionHeatmap.value(r4VisibleCell, metric: .tokens), max: r4TokensMax) == 4
+                && HeatmapLayout.level(
+                    value: ContributionHeatmap.value(r4VisibleCell, metric: .cost), max: r4CostMax) == 4,
+            "the only visible day still renders at full intensity (mutation: reverting the tokens branch "
+                + "to `grid.maxTokens` or the cost branch to an unfiltered reduce would crush this)")
 
         if failures > 0 {
             print("\(failures) selftest check(s) failed")

--- a/Sources/TokenBar/Views/HorizontalWheelScroll.swift
+++ b/Sources/TokenBar/Views/HorizontalWheelScroll.swift
@@ -13,6 +13,21 @@ struct HorizontalWheelScroll: NSViewRepresentable {
     func makeNSView(context: Context) -> WheelRedirectView { WheelRedirectView() }
     func updateNSView(_ view: WheelRedirectView, context: Context) {}
 
+    /// The clamped horizontal origin after stepping by `step`, and whether it
+    /// actually moved. Pure so tests can exercise the boundary case (already
+    /// scrolled all the way to an edge) without simulating an `NSEvent`.
+    ///
+    /// FLAT-HEATMAP round 4, FIX 2: at either scroll edge (e.g. the heatmap's
+    /// default trailing-scrolled position) the old code clamped the origin
+    /// and unconditionally reported the event as consumed, even when the
+    /// clamped value was identical to the current one — swallowing the
+    /// dashboard's *vertical* scroll on the very first wheel tick over a
+    /// heatmap already parked at its right edge.
+    static func clampedScroll(originX: CGFloat, step: CGFloat, maxX: CGFloat) -> (newOriginX: CGFloat, moved: Bool) {
+        let newOriginX = min(max(0, originX - step), maxX)
+        return (newOriginX, newOriginX != originX)
+    }
+
     @MainActor
     final class WheelRedirectView: NSView {
         private var monitor: Any?
@@ -56,8 +71,13 @@ struct HorizontalWheelScroll: NSViewRepresentable {
             // Precise (smooth) deltas are already in points; coarse wheel deltas
             // are in lines and need scaling for a comfortable step.
             let step = event.hasPreciseScrollingDeltas ? dy : dy * 16
+            let (newOriginX, moved) = HorizontalWheelScroll.clampedScroll(
+                originX: clip.bounds.origin.x, step: step, maxX: maxX)
+            // Already at this edge — let the event fall through to the parent
+            // (vertical) scroll view instead of silently eating it.
+            guard moved else { return false }
             var origin = clip.bounds.origin
-            origin.x = min(max(0, origin.x - step), maxX)
+            origin.x = newOriginX
             clip.setBoundsOrigin(origin)
             scroll.reflectScrolledClipView(clip)
             return true

--- a/Sources/TokenBar/Views/UsageChartCard.swift
+++ b/Sources/TokenBar/Views/UsageChartCard.swift
@@ -38,6 +38,23 @@ enum ChartView: String {
     init(raw: String) {
         self = ChartView(rawValue: raw) ?? .bars
     }
+
+    /// ⌘G's cycle order — matches the header picker's left-to-right order
+    /// (bars → heatmap → 3D → bars). Round 6, FIX 1: `PopoverView`'s ⌘G
+    /// handler used to hardcode a binary `"2d" <-> "3d"` toggle; once
+    /// Heatmap became a third state, pressing ⌘G while on Heatmap jumped to
+    /// Bars and then cycled Bars↔3D forever — a keyboard user could never
+    /// get back to Heatmap. `ChartView` is the only place that knows the
+    /// full state set and its order now, so a future fourth view only needs
+    /// one edit here, not a second copy of the cycle logic in the key
+    /// handler.
+    var next: ChartView {
+        switch self {
+        case .bars: return .heatmap
+        case .heatmap: return .threeD
+        case .threeD: return .bars
+        }
+    }
 }
 
 /// The "Token Usage" card, port of UsageBarGraph2D.tsx: trailing-30-day
@@ -56,8 +73,11 @@ struct UsageChartCard: View {
 
     @AppStorage("tokenbar.chart.stackBy") private var stackByRaw = StackBy.model.rawValue
     @AppStorage("tokenbar.chart.metric") private var metricRaw = ChartMetric.tokens.rawValue
-    /// "2d" = trailing-30-day stacked bars, "3d" = full-year contribution grid.
-    @AppStorage("tokenbar.chart.view") private var chartViewRaw = "2d"
+    /// Round 6 audit 2: matches the sibling `stackByRaw`/`metricRaw` defaults
+    /// right above — `ChartView.bars.rawValue`, not the bare "2d" literal
+    /// this used to duplicate (the exact kind of hardcoded state-name string
+    /// this round's audit went looking for).
+    @AppStorage("tokenbar.chart.view") private var chartViewRaw = ChartView.bars.rawValue
     @State private var hoverIndex: Int?
     @State private var hoverPoint: CGPoint = .zero
     @State private var tooltipSize: CGSize = .zero

--- a/Sources/TokenBar/Views/UsageChartCard.swift
+++ b/Sources/TokenBar/Views/UsageChartCard.swift
@@ -25,9 +25,25 @@ enum UsageChartGeometry {
     }
 }
 
+/// Pure resolution of the stored `chartViewRaw` string into a view case, kept
+/// outside the View body (and outside `@AppStorage`/MainActor state) so
+/// SelfTest can exercise the unknown-value fallback directly
+/// (FLAT-HEATMAP invariant 7: any value besides "heat"/"3d" — including the
+/// legacy "2d" and anything unrecognized — falls back to Bars, no migration).
+enum ChartView: String {
+    case bars = "2d"
+    case heatmap = "heat"
+    case threeD = "3d"
+
+    init(raw: String) {
+        self = ChartView(rawValue: raw) ?? .bars
+    }
+}
+
 /// The "Token Usage" card, port of UsageBarGraph2D.tsx: trailing-30-day
 /// stacked bars (Model/Agent stacking, Tokens/Price metric, wrapping legend,
-/// rich hover tooltip) toggling with the full-year 3D contribution grid.
+/// rich hover tooltip) toggling with the full-year 3D contribution grid or
+/// the flat year heatmap — the latter two share one `buildGrid` call.
 struct UsageChartCard: View {
     let payload: UsagePayload
     /// Clients included in the stack (the active tab's slice).
@@ -61,7 +77,14 @@ struct UsageChartCard: View {
             colors: colors, rangeEnd: stats.dateRange.end, endFallback: Format.todayKey())
     }
 
-    private var is3D: Bool { chartViewRaw == "3d" }
+    private var chartView: ChartView { ChartView(raw: chartViewRaw) }
+    private var is3D: Bool { chartView == .threeD }
+    private var isHeatmap: Bool { chartView == .heatmap }
+
+    /// Dashboard year filter, falling back to the current year — shared
+    /// verbatim by the 3D grid and the heatmap so they read identical data
+    /// (FLAT-HEATMAP invariant 2).
+    private var gridYear: String { year ?? String(Format.todayKey().prefix(4)) }
 
     var body: some View {
         let bars = self.bars
@@ -71,7 +94,7 @@ struct UsageChartCard: View {
         } ?? false
         DashCard(
             "Token Usage",
-            subtitle: is3D
+            subtitle: (is3D || isHeatmap)
                 ? "Full year"
                 : (stackBy == .model ? "Stacked by model" : "Stacked by agent"),
             trailing: { toggles }
@@ -81,12 +104,17 @@ struct UsageChartCard: View {
             if is3D {
                 // Year grid over the same client slice; sized to match the 2D
                 // legend + chart + axis block so the card doesn't jump.
-                ContributionGraph3D(
-                    grid: buildGrid(
-                        year: year ?? String(Format.todayKey().prefix(4)),
-                        perDayMap: stats.perDayMap)
-                )
-                .frame(height: 196)
+                ContributionGraph3D(grid: buildGrid(year: gridYear, perDayMap: stats.perDayMap))
+                    .frame(height: 196)
+            } else if isHeatmap {
+                // Shorter than the 3D slot (196) — the flat grid's own
+                // content is ~109pt tall; round 2 narrows its top/bottom
+                // whitespace instead of matching 3D's height (design call,
+                // costs a card-height jump when toggling from Bars/3D).
+                ContributionHeatmap(
+                    grid: buildGrid(year: gridYear, perDayMap: stats.perDayMap), metric: metric,
+                    year: gridYear)
+                    .frame(height: 130)
             } else {
                 legendView(legend)
                 chart(bars)
@@ -102,23 +130,32 @@ struct UsageChartCard: View {
 
     // MARK: - Header toggles
 
-    /// The 2D/3D view switch rides the header; the 2D-only group/metric
-    /// toggles get their own slim row below — stacked in the header they made
-    /// it three rows tall and left the card top mostly whitespace, and all
-    /// three don't fit beside the title without wrapping.
+    /// The Bars/Heatmap/3D view switch rides the header; the bar-only
+    /// stacking toggle and the shared metric toggle get their own slim row
+    /// below — stacked in the header they made it three rows tall and left
+    /// the card top mostly whitespace, and all three don't fit beside the
+    /// title without wrapping.
     private var toggles: some View {
-        picker(selection: $chartViewRaw, options: [("2d", "2D"), ("3d", "3D")])
+        picker(selection: $chartViewRaw, options: [
+            (ChartView.bars.rawValue, "Bars"),
+            (ChartView.heatmap.rawValue, "Heatmap"),
+            (ChartView.threeD.rawValue, "3D"),
+        ])
     }
 
     @ViewBuilder private var togglesRow: some View {
-        // Stacking and bar metric are 2D-only concepts — the 3D view is the
-        // year heatmap (web hides these the same way).
+        // Model/Agent stacking only makes sense for stacked bars — a single
+        // color-ramped heatmap cell or a 3D box has nowhere to stack
+        // (FLAT-HEATMAP invariant 8). The Tokens/Price metric still applies
+        // to both Bars and Heatmap; 3D has neither toggle.
         if !is3D {
             HStack(spacing: 4) {
                 Spacer()
-                picker(selection: $stackByRaw, options: [
-                    (StackBy.model.rawValue, "Model"), (StackBy.agent.rawValue, "Agent"),
-                ])
+                if !isHeatmap {
+                    picker(selection: $stackByRaw, options: [
+                        (StackBy.model.rawValue, "Model"), (StackBy.agent.rawValue, "Agent"),
+                    ])
+                }
                 picker(selection: $metricRaw, options: [
                     (ChartMetric.tokens.rawValue, "Tokens"), (ChartMetric.cost.rawValue, "Price"),
                 ])


### PR DESCRIPTION
The Token Usage card's view switch becomes **Bars / Heatmap / 3D**. The new Heatmap is a second SwiftUI renderer over data the card already builds — it receives the exact same `buildGrid(year:perDayMap:)` result the 3D grid gets, from the same selected-client `UsageStats.perDayMap` and the same dashboard year.

> No Rust, C ABI, cache schema, persistence, or aggregation changes. The diff is four Swift/strings files.

## Why a second renderer rather than new data

Everything the flat heatmap needs already exists: `Grid.swift` produces a Sunday-first `cols × 7` layout with per-cell `tokens`, `cost`, and `inYear`; `UsageStats` supplies the client-filtered per-day map. Only the renderer was missing.

## Two rules the tokens-only grid contract cannot supply

| Rule | Why |
|---|---|
| "Has data" under the Price metric is `cell.cost > 0`, never `cell.active` | `GridLayout` sets `active = inYear && tokens > 0` (`Grid.swift:49`), while `UsageStats` admits a day with `cost > 0` and `tokens == 0` (`UsageStats.swift:105-110`). Reusing `active` would blank those days out of the Price view. |
| The Price intensity denominator is reduced over the in-year cells in the view | `GridLayout.maxTokens` tracks tokens only. Each metric takes its own five-level ramp; `maxTokens` is left untouched. |

## Future days occupy no layout

One `cutoffDate(year:today:)` — today when the selected year is the current year, otherwise December 31 — feeds a single `isRenderable` predicate consumed by **four** call sites: the draw loop, hit testing, the content width (via `lastRenderableCol`), and the month labels.

Filtering only the draw loop would leave the trailing months holding width and labels, so `scrollTo(anchor: .trailing)` would land on empty space instead of the most recent day.

## Reused rather than rebuilt

- **`HorizontalWheelScroll`** (`DashboardTabs.swift:79`) — a mouse without a horizontal-scroll device emits vertical deltas only and could otherwise not pan the row. That helper already separates phase-less mouse wheels from trackpad gestures, so no new wheel handling was written.
- **`PopoverTooltipPlacement.offset`** — the existing dodge logic, unchanged.
- **`TokenBarCore.GridLayout`** is fully qualified, matching `ContributionGraph3D.swift`, because SwiftUI ships its own `GridLayout`.

## Tooltip escapes the scroll clip

A `ScrollView` clips its content, so a tooltip rendered inside it was cut off. It now renders as an overlay on the ScrollView, with `tooltipAnchor(cellCenter:contentOrigin:containerOrigin:)` re-expressing the hovered cell against the outer container from the content's tracked global origin — it escapes the clip and still follows the correct cell while scrolling.

## Compatibility

Stored `"2d"` and `"3d"` keep working and **no migration is needed**. A `ChartView` enum resolves the raw `@AppStorage` string with a Bars fallback, so an unknown value renders Bars instead of crashing. Resolution lives outside the View body so it is testable without MainActor isolation.

Bars and 3D behaviour is unchanged, `ContributionGraph3D.swift` is untouched, and both keep their 196pt slot. The heatmap uses 130pt: its content is roughly 109pt tall and the extra padding read as empty space, at the cost of a card-height change when toggling.

## Not addressed here

Grid stepping stays pure `ISODay` civil-date string math — no `Calendar`, `TimeZone`, or `DateFormatter` in the layout path. This does **not** fix [#127](https://github.com/Nanako0129/TokenBar/issues/127): the heatmap consumes the same `perDayMap` as the existing views and inherits that timezone provenance gap rather than introducing a new one.

Also out of scope: a GitHub clone, rolling 12 months, click-through drilldown, and any change to the colour ramp beyond naming its constants.

## Verification

`make build` and `make selftest` pass — 411 checks, three consecutive clean runs.

Every new assertion was confirmed to **fail** when the line it guards is broken, then restored:

| Mutation | Assertion that turns red |
|---|---|
| `hasData` → `cell.active` | Price metric treats `cost > 0` as data |
| Cost denominator → `grid.maxTokens` | tokens and cost maxima are independent (plus two more) |
| `lastRenderableCol` → `grid.cols - 1` | today is the last renderable column; later columns add no width |
| Month labels drop the `isRenderable` filter | a label after the cutoff is dropped |
| `tooltipAnchor` ignores the scroll offset | a 300pt scroll shifts the anchor by 300pt |
| Unknown-value fallback → `.threeD` | an unknown `chartViewRaw` falls back to Bars |

On-screen clip behaviour and the visual review are manual and were completed against real local data over three feedback rounds; the test comments say so rather than claiming automated coverage.

`SelfTest.swift` is appended to as a single hunk, so branches sharing that file rebase cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wP8hD8TeMBj6HwJMPdV4w