### PR TITLE
fix(tray): fit non-square animation art instead of stretching it

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3493,6 +3493,56 @@ enum SelfTest {
             ContributionHeatmap.shouldClearHoverOnOriginChange(old: r8RelativeBefore, new: r8HScrolledRelative),
             "...and therefore still clears the hover, same as before this round's fix")
 
+        // MARK: - Tray frame aspect (append-only section)
+
+        // `anim-parrot` art is 48x36. `loadFrames` used to assign 18x18
+        // unconditionally, stretching it vertically wherever `NSImage.size`
+        // is what renders — `button.image`, i.e. static tray mode and the
+        // Settings preview. The animation never showed it, because
+        // `rasterizedFrame` fits by the representation's PIXEL size and
+        // ignores the logical size, so the two paths disagreed about the
+        // same asset. These assert the two now agree.
+        func trayArt(_ directory: String) -> NSImage? {
+            Bundle.tokenBarResources.url(
+                forResource: "frame-00", withExtension: "png", subdirectory: directory
+            ).flatMap(NSImage.init(contentsOf:))
+        }
+        let parrotArt = trayArt("anim-parrot")
+        let catArt = trayArt("anim-cat2")
+        expect(parrotArt != nil && catArt != nil, "tray frame art loads")
+
+        if let parrot = parrotArt.map({ art -> NSImage in
+            art.size = TrayAnimator.barSize(for: art)
+            return art
+        }) {
+            // 48x36 fitted into 18x18 is 18x13.5, not 18x18.
+            expect(
+                abs(parrot.size.width - 18) < 0.01 && abs(parrot.size.height - 13.5) < 0.01,
+                "non-square tray art keeps its aspect ratio (mutation: assigning the 18x18 box "
+                    + "unconditionally, as before, makes this 18x18 and fails)")
+            // The distortion this guards against: a stretched frame reports a
+            // 1:1 logical box for art that is 4:3.
+            expect(
+                abs(parrot.size.width / parrot.size.height - 48.0 / 36.0) < 0.01,
+                "the logical box matches the art's own 4:3 ratio")
+        }
+        if let cat = catArt {
+            // Square art is unchanged by the fix — a no-trigger guard case.
+            let size = TrayAnimator.barSize(for: cat)
+            expect(
+                abs(size.width - 18) < 0.01 && abs(size.height - 18) < 0.01,
+                "square tray art still fills the full 18x18 box")
+        }
+        // The raster path must stay driven by pixels, not by the logical size
+        // we just changed — otherwise this fix would silently resize the
+        // animation too.
+        if let parrot = parrotArt {
+            let raster = StatusItemAnimationSurface.rasterizedFrameMetricsForTesting(parrot, scale: 2)
+            expect(
+                raster?.pixelSize == CGSize(width: 36, height: 36),
+                "the animation raster is still a square 18pt box at 2x, unaffected by the logical size")
+        }
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3536,12 +3536,21 @@ enum SelfTest {
         // The raster path must stay driven by pixels, not by the logical size
         // we just changed — otherwise this fix would silently resize the
         // animation too.
+        //
+        // `rasterizedFrameMetricsForTesting` is declared `#if DEBUG`, and
+        // `scripts/bundle.sh` builds with `swift build -c release`, so an
+        // unguarded call here compiles under `make build`/`make selftest`/CI
+        // — all debug — and then fails the release build at tag time. The
+        // older raster assertions above sit in their own `#if DEBUG` block
+        // for exactly this reason.
+#if DEBUG
         if let parrot = parrotArt {
             let raster = StatusItemAnimationSurface.rasterizedFrameMetricsForTesting(parrot, scale: 2)
             expect(
                 raster?.pixelSize == CGSize(width: 36, height: 36),
                 "the animation raster is still a square 18pt box at 2x, unaffected by the logical size")
         }
+#endif
 
         if failures > 0 {
             print("\(failures) selftest check(s) failed")

--- a/Sources/TokenBar/TrayAnimator.swift
+++ b/Sources/TokenBar/TrayAnimator.swift
@@ -78,6 +78,9 @@ final class TrayAnimator {
         frames = sets
     }
 
+    /// The bar's frame box. Art is fitted into it, never stretched to it.
+    nonisolated static let frameBox = NSSize(width: 18, height: 18)
+
     /// PNG frames sorted by name (frame-00 … frame-NN), sized for the bar.
     /// Internal so the settings window's menu-bar mock can render the same
     /// frame sets.
@@ -88,9 +91,32 @@ final class TrayAnimator {
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
             .compactMap { url in
                 guard let image = NSImage(contentsOf: url) else { return nil }
-                image.size = NSSize(width: 18, height: 18)
+                image.size = barSize(for: image)
                 return image
             }
+    }
+
+    /// `frameBox`-bounded logical size preserving the art's own aspect ratio.
+    ///
+    /// This used to assign `frameBox` unconditionally, which is only correct
+    /// for square art. `anim-parrot` is 48x36, so forcing 18x18 stretched it
+    /// vertically — and only on the paths that render `NSImage.size`:
+    /// `button.image` (what static tray mode and the Settings preview show).
+    /// The animation itself was never affected, because
+    /// `StatusItemAnimationSurface.rasterizedFrame` fits by the *pixel*
+    /// dimensions of the representation and ignores the logical size, so the
+    /// two paths disagreed about the same asset.
+    ///
+    /// Pixel data is deliberately untouched: the raster path reads
+    /// `representations`, so re-drawing frames here would change what it
+    /// sees. Only the logical size is corrected.
+    nonisolated static func barSize(for image: NSImage) -> NSSize {
+        let pixels = image.representations
+            .max(by: { $0.pixelsWide * $0.pixelsHigh < $1.pixelsWide * $1.pixelsHigh })
+            .map { NSSize(width: $0.pixelsWide, height: $0.pixelsHigh) } ?? image.size
+        guard pixels.width > 0, pixels.height > 0 else { return frameBox }
+        let fit = min(frameBox.width / pixels.width, frameBox.height / pixels.height)
+        return NSSize(width: pixels.width * fit, height: pixels.height * fit)
     }
 
     private var defaultsObserver: NSObjectProtocol?


### PR DESCRIPTION
`TrayAnimator.loadFrames` assigned every frame a flat `18x18` logical size. That is only correct for square art.

| Asset | Canvas | Horizontal compression under the old code |
|---|---|---|
| `anim-cat2` | 48×48 | **1.000** — no distortion |
| `anim-parrot` | 48×36 | **0.750** — squeezed to 75% of its own ratio |

The default animation is the cat, whose canvas is already square, so the assignment happened to be right for it. That is why this went unnoticed: **the default configuration cannot exhibit the defect.**

## Where it was visible

Only on the paths that render `NSImage.size`:

- **Static tray mode** — the animate-disabled branch feeds the first frame straight to `setStaticIcon`.
- **The Settings menu-bar preview** — it loads the same frame sets.

The animation itself was never wrong. `StatusItemAnimationSurface.rasterizedFrame` fits by the **pixel** dimensions of the largest representation and ignores the logical size, so the two paths disagreed about the same asset.

## The fix

`barSize(for:)` applies the same fit the raster path already uses — largest representation's pixel size scaled by `min(box.width / w, box.height / h)` — so the two agree.

> Pixel data is deliberately untouched. The raster path reads `representations`, so redrawing frames here would change what it sees. Only the logical size is corrected, which leaves the status item at 18pt wide and alters no geometry the animation depends on.

`barSize` and `frameBox` become `nonisolated`. Neither touches actor state; the isolation was inherited from `TrayAnimator` and only served to keep a pure geometric calculation out of reach of the tests.

## Verification

`make build` and `make selftest` pass at **450** checks. Five new assertions:

| Assertion | Guards |
|---|---|
| Parrot keeps its 4:3 ratio (18 × 13.5) | The defect itself |
| The logical box matches the art's own ratio | The same, stated as a ratio rather than a literal |
| Cat still fills the full 18×18 box | No-trigger guard — square art must be unchanged |
| Raster is still a square 18pt box at 2x | This change cannot silently resize the animation |

Replacing `barSize` with the previous unconditional box was run and **verified to turn the two parrot assertions red**; restoring it returns to 450 green.

## Out of scope

This does **not** address the separate macOS 14 report of a leftover base image appearing beside the animation. That artifact is the status-item cutout failing to erase `button.image`, which is untouched here — a machine exhibiting it would still show two shapes after this change, only with the right-hand one correctly proportioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wP8hD8TeMBj6HwJMPdV4w