### PR TITLE
ci: compile the release configuration on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,19 @@ jobs:
 
       - name: FFI smoke test
         run: swift run TokenBar --smoke
+
+      # Every step above compiles the debug configuration, so nothing here can
+      # see a `#if DEBUG` boundary break. The release configuration was first
+      # compiled by scripts/bundle.sh, which only runs from release.yml on a
+      # `v*` tag — so a call to a DEBUG-only symbol stayed green through local
+      # gates, PR CI and merge, and failed only after the tag was already
+      # pushed. PR #137 hit exactly that.
+      #
+      # Push-only, not on pull_request: this class of break needs someone to
+      # touch a conditional-compilation boundary, which is rare, and a release
+      # build is slow enough that paying for it on every PR iteration is a bad
+      # trade. Running it on main still guarantees the tag is never the first
+      # time this configuration is compiled.
+      - name: Build Swift package (release configuration)
+        if: github.event_name == 'push'
+        run: swift build -c release


### PR DESCRIPTION
Every step this workflow runs today compiles **debug** — `swift build`, the selftest, the FFI smoke test — as do `make build` and `make selftest` locally. The release configuration was first compiled by `scripts/bundle.sh`, which only runs from `release.yml` on a `v*` tag.

```
Makefile:16            swift build                     debug
Makefile:28            swift run TokenBar --selftest   debug
ci.yml:31              swift build                     debug
ci.yml:37              swift run TokenBar --selftest   debug
ci.yml:40              swift run TokenBar --smoke      debug
                       ──────────────────────────────
release.yml:5          on: push: tags: ["v*"]
scripts/bundle.sh:22   swift build -c release          ← the only one
```

## Why that is worth a CI step

`#if DEBUG` is a **compile-time** boundary. A call to a DEBUG-only symbol is a missing-member error under release and simply absent under debug — so it stays green through local gates, PR CI **and merge**, then fails after the tag is already pushed. At that point the tag exists and the release artifact does not, and recovering means deleting the tag and disturbing the appcast and cask chain.

[PR #137](https://github.com/Nanako0129/TokenBar/pull/137) introduced and hit exactly this:

```
SelfTest.swift:3540: error: type 'StatusItemAnimationSurface'
has no member 'rasterizedFrameMetricsForTesting'
```

More tests would not have helped. The symbol is present in every configuration those tests run in.

> Note the asymmetry this closes: the Rust half was **already** covered — `ci.yml:28` runs `cargo build --release`. Only the Swift half had no release coverage.

## Why push-only

| | Cost | Catches it |
|---|---|---|
| Every PR | Release builds are slow; paid on each iteration | At PR |
| **Push to main** | One extra build per merge | Before any tag |
| Manual checklist | Free | Only if someone remembers |

Breaking a conditional-compilation boundary requires someone to deliberately touch one, which is rare. Running on main still guarantees a tag is never the first time this configuration is compiled, without slowing the PR loop.

## No linker work needed

`Package.swift:67` links `target/release/libtb_core_ffi.a` unconditionally, and `cargo build --release` already runs earlier in the job, so the Swift configuration does not change the Rust artifact path. Verified locally on `main`: `swift build -c release` exits 0.

## Note on first exercise

The step is gated on `github.event_name == 'push'`, so **it does not run on this PR** — its first real execution is the merge commit's CI run. That is inherent to the push-only choice; I'll confirm that run rather than assume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wP8hD8TeMBj6HwJMPdV4w