### PR TITLE
feat(discord): pure payload builder for opt-in Rich Presence

### DIFF
--- a/Sources/CrossCheckHarness/main.swift
+++ b/Sources/CrossCheckHarness/main.swift
@@ -223,6 +223,22 @@ func runFormat() throws {
         case "todayCost":
             guard let now = nowDate() else { out[c.name] = ["error": "todayCost needs now"]; continue }
             out[c.name] = file.graph.trayTotals(hidden: [], today: Format.todayKey(now: now)).todayCost
+        // The per-client fold, not just the four figures. A C# port that skips
+        // the per-client aggregation and takes the maximum over raw stripes
+        // produces identical `todayTokens`/`todayCost`, so those two cases
+        // cannot detect it — this one can. `NSNull` rather than a sentinel
+        // string because diff.py treats a missing key as null.
+        //
+        // format.json lives in the Windows repo's crosscheck/ directory, so
+        // the fixture case that exercises this arm is added there; this side is
+        // in place so that addition is a one-file change.
+        case "todayTopClient":
+            guard let now = nowDate() else {
+                out[c.name] = ["error": "todayTopClient needs now"]
+                continue
+            }
+            out[c.name] = file.graph.trayTotals(hidden: [], today: Format.todayKey(now: now))
+                .todayTopClient ?? NSNull()
         case "paceDurationText":
             out[c.name] = UsagePace.durationText(c.arg?.asDouble ?? 0)
         default:

--- a/Sources/TokenBar/DiscordPresence.swift
+++ b/Sources/TokenBar/DiscordPresence.swift
@@ -1,0 +1,108 @@
+import Foundation
+import TokenBarCore
+
+/// Pure payload construction for the (opt-in, default-off) Discord Rich
+/// Presence feature. Deliberately UI-free and lifecycle-free: `SelfTest.run()`
+/// returns `Never` before `NSApplication.shared` exists, so anything the
+/// privacy assertions must cover has to be reachable without an `AppDelegate`.
+///
+/// Nothing here opens a socket, touches the network, reads `UserDefaults`, or
+/// performs file I/O — the transport and the opt-in switch land separately.
+/// `hidden` is a parameter, not a lookup, for the same reason.
+enum DiscordPresence {
+    /// Everything, and only what, would be published to a third party and shown
+    /// on a public profile.
+    struct Payload: Equatable {
+        let details: String
+        let state: String
+        let largeImageKey: String
+
+        /// **The published surface.** The transport must serialize this
+        /// dictionary and nothing else — no field assembled at the transport
+        /// layer, no property of this struct that is not in here.
+        ///
+        /// It is a dictionary rather than a list of values so that one
+        /// assertion can pin the key set, and the same assertion is what the
+        /// privacy value-scans read. An earlier revision kept a separate
+        /// `allFields: [String]` for the scans and reflected over the stored
+        /// properties for the key check; that made the published surface and
+        /// the asserted surface two different things, and regressions escaped
+        /// through the gap in both directions (a computed property is invisible
+        /// to `Mirror`; a shrunk list silently narrows every scan). Keep them
+        /// one thing.
+        var fields: [String: String] {
+            ["details": details, "state": state, "largeImageKey": largeImageKey]
+        }
+    }
+
+    /// Shown instead of an unregistered client id.
+    static let neutralClientLabel = "an AI tool"
+    static let largeImageKey = "tokenbar"
+
+    /// Fixed allowlist: a registered id gets its registry display name, anything
+    /// else gets the neutral constant.
+    ///
+    /// The gate is the point. A graph client id can be `cc-mirror/<name>` where
+    /// `<name>` comes straight out of a user's local config file and is only
+    /// character-filtered, never semantically constrained
+    /// (vendor/tokscale-core/src/sessions/claudecode.rs:60-62). Falling through
+    /// to `ClientRegistry.style(id)` would title-case that string and publish an
+    /// employer or internal-tool name on a public Discord profile. Gating first
+    /// means `style()`'s title-case fallback branch is unreachable from here.
+    static func safeClientLabel(_ id: String?) -> String {
+        guard let id, ClientRegistry.allIds.contains(id) else { return neutralClientLabel }
+        return ClientRegistry.style(id).displayName
+    }
+
+    /// Coarse cost band rather than `$%.2f`: the cost ÷ tokens ratio leaks the
+    /// model tier and cache structure in use, and accumulated daily costs leak a
+    /// monthly spend bracket.
+    ///
+    /// Finite input only. A NaN matches no range and falls through to `$100+`,
+    /// which is why `payload(...)` rejects a non-finite cost before it ever gets
+    /// here — keep that guard if you add a second call site.
+    static func costBucket(_ cost: Double) -> String {
+        switch cost {
+        case ..<1: return "<$1"
+        case ..<5: return "$1-5"
+        case ..<10: return "$5-10"
+        case ..<25: return "$10-25"
+        case ..<50: return "$25-50"
+        case ..<100: return "$50-100"
+        default: return "$100+"
+        }
+    }
+
+    /// Coarse token band. `Format.compactTokens` is the shared tray-title
+    /// formatter and returns the exact `Int64` below 1000 (`Format.swift:19`),
+    /// which is correct in the menu bar and wrong here: the published figure
+    /// must never be an exact count. A negative total lands here too — the
+    /// aggregator's per-lane clamping admits pathological negative deltas
+    /// (see `trayTotals`' doc comment), and `String(count)` would publish the
+    /// full signed digits.
+    ///
+    /// Do not "fix" this by changing `Format.compactTokens`; the tray title
+    /// wants the exact small number.
+    static func tokenBand(_ tokens: Int64) -> String {
+        tokens < 1_000 ? "<1K" : Format.compactTokens(tokens)
+    }
+
+    /// The publishable payload for `today`, or nil when nothing may be
+    /// published. `hidden` must be the tab-hidden set (`ClientRegistry
+    /// .hiddenClients()` at the call site) — `trayTotals` applies it to the same
+    /// stripes the top client is folded from.
+    static func payload(graph: UsagePayload, hidden: Set<String>, today: String) -> Payload? {
+        let totals = graph.trayTotals(hidden: hidden, today: today)
+        // Non-finite numbers must never be published — garbage on a public
+        // profile is worse than no presence at all.
+        guard totals.todayCost.isFinite else { return nil }
+        // Zero usage would otherwise publish a "this machine is switched on"
+        // beacon. Nothing is published, and no startTimestamp is ever emitted.
+        // `||`, not `&&`: UsageStats allows a day with cost > 0 and tokens == 0.
+        guard totals.todayTokens > 0 || totals.todayCost > 0 else { return nil }
+        return Payload(
+            details: "\(tokenBand(totals.todayTokens)) tokens today",
+            state: "\(safeClientLabel(totals.todayTopClient)) · \(costBucket(totals.todayCost))",
+            largeImageKey: largeImageKey)
+    }
+}

--- a/Sources/TokenBar/DiscordPresence.swift
+++ b/Sources/TokenBar/DiscordPresence.swift
@@ -17,9 +17,17 @@ enum DiscordPresence {
         let state: String
         let largeImageKey: String
 
-        /// **The published surface.** The transport must serialize this
-        /// dictionary and nothing else — no field assembled at the transport
-        /// layer, no property of this struct that is not in here.
+        /// **The published surface.** These values, and only these, may leave
+        /// the machine: the transport must not add a field, drop one, or alter
+        /// a value, and no property of this struct that is absent here is
+        /// published.
+        ///
+        /// Key *naming* is the transport's concern, not this struct's. Discord
+        /// nests the asset key as `assets.large_image` rather than carrying it
+        /// at the top level, so the transport renames on the way out; that is
+        /// not an addition and does not weaken anything above. The wire shape
+        /// is deliberately not encoded here — this layer knows what may be
+        /// published, not how Discord spells it.
         ///
         /// It is a dictionary rather than a list of values so that one
         /// assertion can pin the key set, and the same assertion is what the

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3552,6 +3552,209 @@ enum SelfTest {
         }
 #endif
 
+        // MARK: - Discord Rich Presence payload (DISCORD-PRESENCE M1)
+        //
+        // This payload is published to a third party and shown on a public
+        // profile, so these are privacy regression guards, not display tests.
+        // Every assertion goes through `DiscordPresence.payload(...)` — the
+        // published bytes — not through the core fold alone.
+        func dpGraph(_ json: String) -> UsagePayload {
+            try! JSONDecoder().decode(UsagePayload.self, from: Data(json.utf8))
+        }
+        func dpDay(_ date: String, _ tokens: Int64, _ cost: Double, _ stripes: String) -> String {
+            """
+            {"date":"\(date)","totals":{"tokens":\(tokens),"cost":\(cost),"messages":1},
+             "intensity":1,
+             "tokenBreakdown":{"input":\(tokens),"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0},
+             "clients":[\(stripes)]}
+            """
+        }
+        func dpStripe(
+            _ client: String, _ tokens: Int64, _ cost: Double,
+            model: String = "m", provider: String = "p"
+        ) -> String {
+            """
+            {"client":"\(client)","modelId":"\(model)","providerId":"\(provider)",
+             "cost":\(cost),"messages":1,
+             "tokens":{"input":\(tokens),"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0}}
+            """
+        }
+        func dpPayload(_ days: String, summaryTokens: Int64 = 0, summaryCost: Double = 0) -> String {
+            """
+            {"meta":{"generatedAt":"now","version":"1",
+                     "dateRange":{"start":"2026-08-04","end":"2026-08-04"}},
+             "summary":{"totalTokens":\(summaryTokens),"totalCost":\(summaryCost),"totalDays":1,
+                        "activeDays":1,"averagePerDay":0,"maxCostInSingleDay":0,
+                        "clients":[],"models":[]},
+             "years":[],"contributions":[\(days)]}
+            """
+        }
+        let dpToday = "2026-08-04"
+
+        // A3a — the hidden set reaches the published payload. The day-level
+        // `totals` here (1.2M) deliberately differs from the visible-only sum
+        // (200K): a builder that read `Contribution.totals`/`tokenBreakdown`
+        // instead of the surviving stripes cannot subtract a client and would
+        // publish "1.2M".
+        let dpHiddenGraph = dpGraph(dpPayload(dpDay(
+            dpToday, 1_200_000, 6.0,
+            dpStripe("claude", 1_000_000, 5.0) + "," + dpStripe("codex", 200_000, 1.0))))
+        let dpHidden = DiscordPresence.payload(
+            graph: dpHiddenGraph, hidden: ["claude"], today: dpToday)
+        expect(dpHidden?.details == "200K tokens today",
+            "discord payload tokens exclude the hidden client (mutation: reading the day-level "
+                + "totals publishes 1.2M)")
+        expect(dpHidden.map { !$0.fields.values.joined().contains("1.2M") } == true,
+            "discord payload never carries the mixed day-level total")
+        expect(dpHidden?.state.contains("Codex CLI") == true
+            && dpHidden?.state.contains("Claude Code") == false,
+            "discord top client skips the hidden client (mutation: dropping the hidden filter "
+                + "from the fold publishes Claude Code)")
+
+        // A4 — outbound label allowlist. The busiest visible client is an
+        // UNREGISTERED id whose suffix comes from a user's local config file;
+        // a second, hidden client carries a sentinel too. Nothing may escape.
+        let dpSecretGraph = dpGraph(dpPayload(dpDay(
+            dpToday, 1_400_000, 12.0,
+            dpStripe("cc-mirror/SECRET_VARIANT", 500_000, 3.0,
+                model: "SECRET_MODEL", provider: "SECRET_PROVIDER")
+                + "," + dpStripe("SECRET_HIDDEN", 900_000, 9.0,
+                    model: "SECRET_MODEL2", provider: "SECRET_PROVIDER2"))))
+        let dpSecret = DiscordPresence.payload(
+            graph: dpSecretGraph, hidden: ["SECRET_HIDDEN"], today: dpToday)
+        let dpSecretText = (dpSecret?.fields.values ?? [:].values).joined(separator: "|")
+        expect(dpSecret != nil && !dpSecretText.contains("SECRET_"),
+            "discord payload redacts an unregistered client id (mutation: using "
+                + "ClientRegistry.style().displayName without the allowlist gate leaks it)")
+        // Literal, not `DiscordPresence.neutralClientLabel`: an assertion whose
+        // expected value is read out of the constant it guards passes no matter
+        // what that constant becomes.
+        expect(dpSecret?.state.contains("an AI tool") == true,
+            "an unregistered top client publishes the neutral label")
+        // A5 — forbidden fields. modelId/providerId values are covered by the
+        // SECRET_ assertion above; these cover shapes rather than values.
+        expect(!dpSecretText.contains("/"),
+            "discord payload carries no path-like segment (mutation: adding any raw-id or path "
+                + "field to Payload.fields fails here)")
+        // Pinned by KEY on the published surface itself. `fields` is what the
+        // transport serializes, so this covers exactly what leaves the machine:
+        // a new outbound field must add a key here and fails, while a property
+        // that is not in `fields` publishes nothing and correctly does not.
+        // Asserting over anything else — a parallel list of values, or
+        // reflection over the stored properties — reintroduces the gap between
+        // the published surface and the asserted one that let a computed
+        // `startTimestamp` through.
+        expect(dpSecret.map { Set($0.fields.keys) } == ["details", "state", "largeImageKey"],
+            "the discord payload publishes exactly three named fields "
+                + "(mutation: adding a key to Payload.fields, or dropping one, fails here)")
+
+        // A11 — published granularity. Exact figures must not survive: neither
+        // the raw token count nor cent-precision cost.
+        let dpGrainGraph = dpGraph(dpPayload(dpDay(
+            dpToday, 1_234_567, 7.89, dpStripe("claude", 1_234_567, 7.89))))
+        let dpGrain = DiscordPresence.payload(graph: dpGrainGraph, hidden: [], today: dpToday)
+        let dpGrainText = (dpGrain?.fields.values ?? [:].values).joined(separator: "|")
+        expect(dpGrain?.details == "1.2M tokens today",
+            "discord tokens publish as a compact string (mutation: String(todayTokens) fails here)")
+        expect(dpGrain != nil && !dpGrainText.contains("1234567"),
+            "discord payload never carries the raw token count")
+        expect(dpGrain != nil && !dpGrainText.contains("7.89"),
+            "discord payload never carries cent-precision cost (mutation: Format.usd fails here)")
+        expect(dpGrain?.state.hasSuffix("$5-10") == true, "cost publishes as a coarse band")
+        // A11 (cont.) — the two inputs where the SHARED tray formatter would
+        // publish an exact figure. `Format.compactTokens` returns `String(count)`
+        // below 1000 and for every negative value, which is right for the menu
+        // bar and wrong on a public profile.
+        let dpSmall = DiscordPresence.payload(
+            graph: dpGraph(dpPayload(dpDay(dpToday, 850, 0.4, dpStripe("claude", 850, 0.4)))),
+            hidden: [], today: dpToday)
+        expect(dpSmall?.details == "<1K tokens today",
+            "a light day publishes a band, not the exact count (mutation: calling "
+                + "Format.compactTokens directly publishes \"850\")")
+        // Negative day totals are reachable: the aggregator clamps per lane, so
+        // the re-summed slow path can go negative (trayTotals' doc comment).
+        // Hiding a non-existent id forces that slow path.
+        let dpNegative = DiscordPresence.payload(
+            graph: dpGraph(dpPayload(dpDay(
+                dpToday, 0, 1.0,
+                dpStripe("claude", -1_234_567, 0.0) + "," + dpStripe("codex", 1_000, 1.0)))),
+            hidden: ["nobody"], today: dpToday)
+        expect(dpNegative.map { !$0.fields.values.joined().contains("1233567") } ?? true,
+            "a negative day total never publishes its signed digits")
+
+        // A12 — zero usage publishes nothing (no "machine is on" beacon), and a
+        // day absent from the graph publishes nothing either.
+        let dpZeroGraph = dpGraph(dpPayload(dpDay(dpToday, 0, 0, dpStripe("claude", 0, 0))))
+        expect(DiscordPresence.payload(graph: dpZeroGraph, hidden: [], today: dpToday) == nil,
+            "zero usage publishes nothing (mutation: dropping the guard publishes an idle beacon)")
+        expect(DiscordPresence.payload(graph: dpGrainGraph, hidden: [], today: "2099-01-01") == nil,
+            "a day with no contribution publishes nothing")
+        // The isFinite guard, made reachable. JSON cannot express NaN, but the
+        // slow path sums Double costs, so two finite stripes overflow to +inf —
+        // which costBucket would happily publish as "$100+".
+        let dpInfinite = DiscordPresence.payload(
+            graph: dpGraph(dpPayload(dpDay(
+                dpToday, 10, 1e308,
+                dpStripe("claude", 10, 1e308) + "," + dpStripe("codex", 10, 1e308)))),
+            hidden: ["nobody"], today: dpToday)
+        expect(dpInfinite == nil,
+            "an overflowed cost publishes nothing (mutation: dropping the isFinite guard "
+                + "publishes $100+)")
+
+        // A14 — the top client is the busiest CLIENT, not the biggest single
+        // stripe. `Contribution.clients` holds per client×model×provider
+        // stripes, so claude's 30+30 must beat codex's single 50.
+        let dpFoldGraph = dpGraph(dpPayload(dpDay(
+            dpToday, 110, 1.1,
+            dpStripe("claude", 30, 0.3, model: "m1") + ","
+                + dpStripe("claude", 30, 0.3, model: "m2") + ","
+                + dpStripe("codex", 50, 0.5, model: "m1"))))
+        let dpFold = DiscordPresence.payload(graph: dpFoldGraph, hidden: [], today: dpToday)
+        expect(dpFold?.state.hasPrefix("Claude Code") == true,
+            "top client folds stripes per client first (mutation: max over raw stripes picks "
+                + "Codex CLI's single 50 over Claude Code's 30+30)")
+        let dpFoldHidden = DiscordPresence.payload(
+            graph: dpFoldGraph, hidden: ["claude"], today: dpToday)
+        expect(dpFoldHidden?.state.hasPrefix("Codex CLI") == true,
+            "hiding the busiest client promotes the next visible one")
+
+        // A15 — deterministic tie-break: tokens, then higher cost, then the
+        // lexicographically smallest id. A wobbling label would flip between
+        // publishes.
+        let dpTieCost = dpGraph(dpPayload(dpDay(
+            dpToday, 200, 3.0, dpStripe("amp", 100, 1.0) + "," + dpStripe("zed", 100, 2.0))))
+        expect(DiscordPresence.payload(graph: dpTieCost, hidden: [], today: dpToday)?.state
+            == "Zed · $1-5",
+            "equal tokens break to the higher cost")
+        // Six-way tie on purpose, and the fixture lists the ids in REVERSE
+        // order so input order cannot supply the answer.
+        //
+        // Two mutations threaten this, and they are not equally provable:
+        //   `>=` in the fold comparison        → picks Zed, fails every run.
+        //   `keys.sorted()` → `keys`           → PROBABILISTIC. Swift seeds
+        //     Dictionary hashing per process, so an unsorted walk lands on the
+        //     right id by luck roughly 1 run in 6. The pair of assertions below
+        //     feed the SAME six clients in opposite orders — a different
+        //     insertion sequence is a different iteration order — so the
+        //     mutation has to get lucky twice to survive. It is still not a
+        //     hard proof, and no in-process check can make it one: repeatedly
+        //     calling the fold inside one run cannot see the wobble, because
+        //     the seed does not change until the process does.
+        let dpTieIds = ["zed", "warp", "goose", "droid", "codex", "amp"]
+        let dpTieId = dpGraph(dpPayload(dpDay(
+            dpToday, 600, 6.0, dpTieIds.map { dpStripe($0, 100, 1.0) }.joined(separator: ","))))
+        expect(
+            DiscordPresence.payload(graph: dpTieId, hidden: [], today: dpToday)?.state
+                == "Amp · $5-10",
+            "a full tie breaks to the lexicographically smallest id")
+        let dpTieIdReversed = dpGraph(dpPayload(dpDay(
+            dpToday, 600, 6.0,
+            dpTieIds.reversed().map { dpStripe($0, 100, 1.0) }.joined(separator: ","))))
+        expect(
+            DiscordPresence.payload(graph: dpTieIdReversed, hidden: [], today: dpToday)?.state
+                == "Amp · $5-10",
+            "the tie-break does not depend on the order the stripes arrive in")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBarCore/Graph.swift
+++ b/Sources/TokenBarCore/Graph.swift
@@ -104,16 +104,68 @@ public struct TrayTotals: Sendable {
     public let todayCost: Double
     public let totalTokens: Int64
     public let totalCost: Double
+    /// Today's visible client with the most tokens, or nil when today has no
+    /// visible stripe. Client **id** only — display labels and the outbound
+    /// allowlist belong to the app layer, not to this cross-platform surface.
+    ///
+    /// Windows port obligation: TokenBar.Core is a file-by-file port of this
+    /// module (docs/knowledge/verification.md "Cross-port fixture cross-check"),
+    /// so this field must be mirrored there on the next sync. The four figures
+    /// above are unchanged, so the existing cross-check cases are unaffected.
+    public let todayTopClient: String?
 
-    public init(todayTokens: Int64, todayCost: Double, totalTokens: Int64, totalCost: Double) {
+    public init(
+        todayTokens: Int64, todayCost: Double, totalTokens: Int64, totalCost: Double,
+        todayTopClient: String?
+    ) {
         self.todayTokens = todayTokens
         self.todayCost = todayCost
         self.totalTokens = totalTokens
         self.totalCost = totalCost
+        self.todayTopClient = todayTopClient
     }
 }
 
 extension UsagePayload {
+    /// Fold per-client×model×provider stripes into per-client totals and return
+    /// the id with the most tokens. `hidden` uses the same membership test as
+    /// `trayTotals`, with no normalization, so both agree by construction.
+    ///
+    /// Two-stage on purpose: taking the max over raw stripes would pick the
+    /// largest single model stripe, not the busiest client — a client that
+    /// spreads its usage across several models would lose to a smaller
+    /// single-model one. This id is displayed publicly, so picking the wrong one
+    /// ships wrong data.
+    ///
+    /// Deterministic tie-break (a wobbling label would flip between publishes):
+    /// tokens, then higher cost, then lexicographically smallest id. The fold
+    /// walks the keys in sorted order because `Dictionary`'s own iteration order
+    /// is unspecified (and per-process seeded).
+    public static func topVisibleClient(
+        in clients: [ContributionClient], hidden: Set<String>
+    ) -> String? {
+        var byClient: [String: (tokens: Int64, cost: Double)] = [:]
+        for cc in clients where !hidden.contains(cc.client) {
+            let prev = byClient[cc.client] ?? (0, 0)
+            byClient[cc.client] = (prev.tokens.saturatingAdding(cc.tokens.total), prev.cost + cc.cost)
+        }
+        var best: (id: String, tokens: Int64, cost: Double)?
+        for id in byClient.keys.sorted() {
+            let entry = byClient[id]!
+            guard let current = best else {
+                best = (id, entry.tokens, entry.cost)
+                continue
+            }
+            // Strict `>` only: on a full tie the earlier (lexicographically
+            // smaller) id already in `best` wins.
+            if entry.tokens > current.tokens
+                || (entry.tokens == current.tokens && entry.cost > current.cost) {
+                best = (id, entry.tokens, entry.cost)
+            }
+        }
+        return best?.id
+    }
+
     /// The four tray-title figures with `hidden` client ids excluded. `today`
     /// is the local-timezone `YYYY-MM-DD` day key (tokscale-core's bucketing).
     ///
@@ -130,13 +182,18 @@ extension UsagePayload {
     /// alone, so we do NOT try to. Smoke's `trayDrift` probe compares the two
     /// on real data every run to catch any vendor-sync regression.
     public func trayTotals(hidden: Set<String>, today: String) -> TrayTotals {
+        let todayEntry = contributions.last(where: { $0.date == today })
+        // Shared by both paths so the published top client can never disagree
+        // with the figures next to it (same stripes, same membership test).
+        let todayTopClient = UsagePayload.topVisibleClient(
+            in: todayEntry?.clients ?? [], hidden: hidden)
         if hidden.isEmpty {
-            let todayEntry = contributions.last(where: { $0.date == today })
             return TrayTotals(
                 todayTokens: todayEntry?.totals.tokens ?? 0,
                 todayCost: todayEntry?.totals.cost ?? 0,
                 totalTokens: summary.totalTokens,
-                totalCost: summary.totalCost)
+                totalCost: summary.totalCost,
+                todayTopClient: todayTopClient)
         }
         var totalTokens: Int64 = 0
         var totalCost = 0.0
@@ -156,6 +213,7 @@ extension UsagePayload {
         }
         return TrayTotals(
             todayTokens: todayTokens, todayCost: todayCost,
-            totalTokens: totalTokens, totalCost: totalCost)
+            totalTokens: totalTokens, totalCost: totalCost,
+            todayTopClient: todayTopClient)
     }
 }


### PR DESCRIPTION
First milestone of the Discord Rich Presence slice: the pure payload builder, plus the core field it needs. **No socket, no network, no preference read, no UI, no `AppDelegate`.** Nothing calls `DiscordPresence.payload` outside SelfTest, so this changes no runtime behaviour.

The split is deliberate. The half of this feature that can leak a user's data is "what do we publish", not "how do we send it". This PR pins that half with assertions before any byte can leave the machine. The transport, the opt-in switch and the consent copy are a separate milestone.

## What it publishes

| Field | Example | Control |
|---|---|---|
| `details` | `1.2M tokens today` | `tokenBand` — coarse; never an exact count |
| `state` | `Claude Code · $5-10` | fixed allowlist + cost band |
| `largeImageKey` | `tokenbar` | constant |

Publishes nothing at all when the day has no tokens and no cost, or when the cost is non-finite.

## The three privacy controls

**Client labels go through a fixed allowlist.** `ClientRegistry.allIds` is checked first, and only then is `style(id).displayName` read — which makes `style()`'s title-case fallback unreachable from this path. A graph client id can be `cc-mirror/<name>`, where `<name>` comes straight out of a user's local config file and is only character-filtered, never semantically constrained. Without the gate, an employer or internal tool name gets published verbatim on a public profile. The reference implementation this feature is modelled on falls back to the raw id; that is the behaviour not adopted here.

**Cost is a band, never `$%.2f`.** The cost-to-tokens ratio leaks model tier and cache structure; accumulated daily cost leaks a monthly spend bracket.

**Token counts go through `tokenBand`.** `Format.compactTokens` returns the exact `Int64` below 1000 and for any negative value — correct for the menu-bar title, wrong for a public profile. It is deliberately left alone; the divergence lives in `DiscordPresence`.

## The load-bearing detail in core

`UsagePayload.topVisibleClient(in:hidden:)` folds in two stages:

```
filter by hidden  ->  sum per cc.client  ->  take the maximum
```

`Contribution.clients` holds per client × model × provider stripes, so one client appears several times in a single day. Taking the max over raw stripes picks *the largest single model stripe*, not the busiest client — a client spreading usage across several models loses to a smaller single-model one. This id is displayed publicly, so that is not a cosmetic difference.

Both `trayTotals` paths call the same fold, which is what makes the published label and the published figures agree by construction: same stripes, same membership test. The four existing figures are untouched — the fast path still reads `summary` and the day-level `totals`, the slow path's loop is unchanged.

## Verification

`make selftest` 450 → **471**. SelfTest diff is a single append hunk, no deletions, per the coordination contract with the branch working the same file.

Every one of the 21 new assertions was proven to fail by breaking the line it guards. Independent review ran three rounds and **refuted the first two**:

| Round | What it broke |
|---|---|
| 1 | `!contains("startTimestamp")` scanned *values*, not field names — no realistic regression could redden it. The hand-written field list was bypassable by omission. |
| 2 | Refuted the `Mirror`-based fix: a computed property escapes reflection entirely, and the value list could shrink silently, narrowing every scan with it. |
| 3 | **CONFIRMED.** 28 mutations; 17 of the 21 assertions have a mutation that reddens that assertion alone. |

Rounds 1 and 2 were the same root cause at different depths: the published surface and the asserted surface were two different objects. The fix was to delete both mechanisms rather than add a third check — `Payload.fields` is now one dictionary that the transport serializes and the assertions read. A field not in it is not published; one assertion pins its keys.

Newly covered: a light day (850 tokens), a negative day total, an overflowed cost reached by summing two `1e308` stripes on the slow path, and an added or removed published field.

Gates: `make build`, `make selftest` (471 ok / 0 FAIL), `swift build -c release`, `swift run TokenBar --smoke` with `trayDrift: match` on real data.

## Known limits — recorded, not solved

1. **Fixture value scans only catch enumerated sentinel strings.** Appending unlisted content to `largeImageKey` is not detected. A one-line equality assertion would close this specific channel; deferred as P3 rather than churn a confirmed candidate.
2. **"The transport serializes `fields` and nothing else" is a doc-comment contract**, not a tested fact, until the transport exists. It needs an assertion on the serialized key set in the next milestone.
3. **Detecting removal of `keys.sorted()` is probabilistic.** Swift seeds `Dictionary` hashing per process, so the two reverse-order fixtures make the mutation get lucky twice, but no in-process check can make it a hard proof.
4. **The Windows port has not mirrored `todayTopClient` yet.** The Swift half of the gate now exists (9e844b2f): the harness emits `todayTopClient`, which matters because `todayTokens`/`todayCost` are sums over the same stripes and are byte-identical whether or not the port aggregates per client — only the argmax differs. The fixture case cannot land here: `format.json` lives in the Windows repository's `crosscheck/`, not in `Fixtures/CrossCheck/`. Until it is added there the arm is unreachable and no existing cross-check case moves.

