### PR TITLE
feat(discord): the Rich Presence transport, reachable from nothing yet

### DIFF
--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -287,7 +287,14 @@ final class DiscordIPCClient: @unchecked Sendable {
     private let queue = DispatchQueue(label: "com.nyanako.tokenbar.discord-ipc", qos: .utility)
 
     private var fd: Int32 = -1
+    /// The user's intent: `start()` sets it, `stop()` clears it. Deliberately
+    /// NOT cleared by `giveUp()` — a spent retry budget is a connection state,
+    /// not the user changing their mind, and conflating the two meant producer
+    /// updates were dropped while the client sat abandoned.
     private var running = false
+    /// Connection state: retries are spent and nothing is scheduled. A later
+    /// `start()` clears it and tries again.
+    private var abandoned = false
     private var ready = false
     private var buffer = Data()
     private var source: DispatchSourceRead?
@@ -297,9 +304,14 @@ final class DiscordIPCClient: @unchecked Sendable {
     private var attempts = 0
     private var lastSent: DispatchTime?
     private var pending: DiscordPresence.Payload?
-    /// What Discord currently holds, so `flush` can tell a fresh sample from a
-    /// restore of bytes it already has.
-    private var lastSentPayload: DiscordPresence.Payload?
+    /// The last payload actually sampled from the producer, across
+    /// connections. `flush` compares against it to tell a fresh sample from a
+    /// restore of bytes Discord already had.
+    private var lastSampledPayload: DiscordPresence.Payload?
+    /// What the CURRENT connection has been given. Cleared by `teardown`, which
+    /// is what makes a restore after a reconnect distinguishable from a
+    /// duplicate publish on a connection that already holds it.
+    private var deliveredOnThisConnection: DiscordPresence.Payload?
     private var hasPending = false
     private var inboundToken = ""
     private var writeErrno: Int32 = 0
@@ -313,8 +325,12 @@ final class DiscordIPCClient: @unchecked Sendable {
     /// Idempotent: a second call while running is a no-op, not a second socket.
     func start() {
         queue.async {
-            guard !self.running else { return }
+            // Idempotent while live, but an abandoned client must be able to
+            // try again — that is the whole point of not calling `stop()` when
+            // the budget runs out.
+            guard !self.running || self.abandoned else { return }
             self.running = true
+            self.abandoned = false
             self.attempts = 0
             self.openConnection()
         }
@@ -327,6 +343,7 @@ final class DiscordIPCClient: @unchecked Sendable {
         queue.async {
             let wasRunning = self.running
             self.running = false
+            self.abandoned = false
             self.reconnectWork?.cancel()
             self.throttleWork?.cancel()
             self.readyWork?.cancel()
@@ -337,7 +354,8 @@ final class DiscordIPCClient: @unchecked Sendable {
             // alive to be republished after the user turned the feature off.
             self.hasPending = false
             self.pending = nil
-            self.lastSentPayload = nil
+            self.lastSampledPayload = nil
+            self.deliveredOnThisConnection = nil
             if wasRunning, self.fd >= 0 {
                 self.writeFrame(
                     .frame,
@@ -351,6 +369,9 @@ final class DiscordIPCClient: @unchecked Sendable {
     /// payload is ever published.
     func publish(_ payload: DiscordPresence.Payload?) {
         queue.async {
+            // Recorded even while abandoned: the producer's latest intent is
+            // what a later `start()` should restore, not whatever happened to
+            // be current when the retries ran out.
             guard self.running else { return }
             self.pending = payload
             self.hasPending = true
@@ -418,6 +439,13 @@ final class DiscordIPCClient: @unchecked Sendable {
             scheduleReconnect()
             return
         }
+        // Before anything else on this descriptor. The app's Rust core spawns
+        // helpers (`/usr/bin/security`, a login shell, `claude --version`), and
+        // a child that inherits this socket keeps Discord seeing the connection
+        // open after we have torn it down — stale presence outliving the app's
+        // own teardown. Applied here rather than in `connectToDiscord` so it
+        // covers every descriptor the client adopts, injected ones included.
+        _ = fcntl(newFD, F_SETFD, FD_CLOEXEC)
         // Immediately, before any write can happen: Darwin's default for a
         // write to a closed socket is SIGPIPE, which kills the whole app, and
         // Discord quitting mid-session is ordinary.
@@ -491,7 +519,7 @@ final class DiscordIPCClient: @unchecked Sendable {
     /// not the user asking to stop. It only returns the client to a state a
     /// later `start()` can act on.
     private func giveUp() {
-        running = false
+        abandoned = true
         attempts = 0
         throttleWork?.cancel()
         throttleWork = nil
@@ -502,6 +530,8 @@ final class DiscordIPCClient: @unchecked Sendable {
 
     private func teardown() {
         ready = false
+        // A replacement connection holds nothing yet.
+        deliveredOnThisConnection = nil
         readyWork?.cancel()
         readyWork = nil
         buffer.removeAll()
@@ -590,7 +620,14 @@ final class DiscordIPCClient: @unchecked Sendable {
         //     hid the clients that produced it;
         //   - a restore after a reconnect re-sends bytes Discord already had,
         //     so it discloses nothing a fresh sample would.
-        let carriesNewInformation = pending != nil && pending != lastSentPayload
+        // Already on the wire for this connection: not a restore, not a new
+        // sample, just a repeat. Sending it would spam Discord and reset the
+        // floor's clock, pushing the next real payload behind a no-op.
+        if pending == deliveredOnThisConnection {
+            hasPending = false
+            return
+        }
+        let carriesNewInformation = pending != nil && pending != lastSampledPayload
         if carriesNewInformation, let lastSent {
             let elapsed = Double(DispatchTime.now().uptimeNanoseconds - lastSent.uptimeNanoseconds)
                 / 1_000_000_000
@@ -616,7 +653,8 @@ final class DiscordIPCClient: @unchecked Sendable {
         if writeFrame(.frame, DiscordIPC.activityJSON(pending, pid: pid(), nonce: nonce())) {
             hasPending = false
             lastSent = .now()
-            lastSentPayload = pending
+            lastSampledPayload = pending
+            deliveredOnThisConnection = pending
         }
     }
 

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -220,13 +220,37 @@ enum DiscordIPC {
 
     /// Only `discord-ipc-0`. Probing `discord-ipc-1..9` would widen the set of
     /// endpoints a same-user process can squat on for no user-visible gain.
+    /// A socket that is close-on-exec from birth.
+    ///
+    /// Darwin has no `SOCK_CLOEXEC`, so this is the closest to atomic the
+    /// platform allows — and it matters that the `fcntl` is here rather than
+    /// after `connect()` returns. The app's Rust core spawns helpers
+    /// (`/usr/bin/security`, a login shell, `claude --version`), and every
+    /// instruction between `socket()` and the flag being set is a window in
+    /// which one of those execs inherits the descriptor and keeps Discord
+    /// seeing this connection long after the app has torn it down.
+    static func makeSocket() -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return -1 }
+        _ = fcntl(fd, F_SETFD, FD_CLOEXEC)
+        return fd
+    }
+
+    /// No deadline machinery here on purpose. A blocking `connect()` to a Unix
+    /// socket cannot park the caller on Darwin: measured against a listener
+    /// with `listen(fd, 1)` that never accepts, the first connect succeeds and
+    /// every subsequent one returns `ECONNREFUSED` in under a millisecond.
+    /// There is no round trip to wait on. Non-blocking connect plus `poll`
+    /// would be machinery for a state this platform does not produce, and its
+    /// only possible assertion — that the call returns quickly — passes
+    /// whether or not the machinery is there.
     static func connectToDiscord() throws -> Int32 {
         guard let dir = ProcessInfo.processInfo.environment["TMPDIR"] else {
             throw Failure.unavailable
         }
         let path = (dir as NSString).appendingPathComponent("discord-ipc-0")
         guard var addr = unixSocketAddress(path: path) else { throw Failure.unavailable }
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        let fd = makeSocket()
         guard fd >= 0 else { throw Failure.unavailable }
         let result = withUnsafePointer(to: &addr) { pointer in
             pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
@@ -472,7 +496,15 @@ final class DiscordIPCClient: @unchecked Sendable {
         ready = false
 
         let readSource = DispatchSource.makeReadSource(fileDescriptor: newFD, queue: queue)
-        readSource.setEventHandler { [weak self] in self?.readAvailable() }
+        // Bound to `newFD`, not just to `self`. A source that has already
+        // queued a readability event can run after this client has torn down
+        // and reconnected, and an unbound handler would then read from the
+        // *new* socket before its own source has fired — blocking the serial
+        // queue on a descriptor with nothing to give.
+        readSource.setEventHandler { [weak self] in
+            guard let self, self.fd == newFD else { return }
+            self.readAvailable()
+        }
         // Closing in the cancel handler, not beside `cancel()`: the source may
         // still be about to run its event handler on this fd.
         readSource.setCancelHandler { close(newFD) }

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -265,8 +265,23 @@ final class DiscordIPCClient: @unchecked Sendable {
     /// accepts and immediately drops.
     static let maxReconnectAttempts = 5
 
+    /// A peer that accepts the socket and then says nothing must not hold the
+    /// client connected-but-never-ready forever. `SO_RCVTIMEO` cannot cover
+    /// this: the read source only calls `readAvailable()` when bytes arrive,
+    /// so a silent endpoint never triggers a `recv()` and the socket timeout
+    /// is never observed. Discord answers a handshake in milliseconds.
+    static let readyTimeoutSeconds: TimeInterval = 10
+
     /// Instance-level so the selftest can shrink it. Production never assigns.
     var reconnectDelay: TimeInterval = DiscordIPCClient.reconnectDelaySeconds
+    /// Instance-level so the selftest can assert on the bytes that reach the
+    /// socket rather than on an internal flag. **Production never assigns**,
+    /// and this is not a knob: the static it defaults to is a privacy floor,
+    /// because publish frequency is what turns a presence into a working-hours
+    /// trace. Lowering it in shipping code is a privacy regression, not tuning.
+    var publishInterval: TimeInterval = DiscordIPCClient.minPublishInterval
+    /// Instance-level for the same reason.
+    var readyTimeout: TimeInterval = DiscordIPCClient.readyTimeoutSeconds
 
     private let connectFD: @Sendable () throws -> Int32
     private let queue = DispatchQueue(label: "com.nyanako.tokenbar.discord-ipc", qos: .utility)
@@ -278,6 +293,7 @@ final class DiscordIPCClient: @unchecked Sendable {
     private var source: DispatchSourceRead?
     private var reconnectWork: DispatchWorkItem?
     private var throttleWork: DispatchWorkItem?
+    private var readyWork: DispatchWorkItem?
     private var attempts = 0
     private var lastSent: DispatchTime?
     private var pending: DiscordPresence.Payload?
@@ -426,18 +442,58 @@ final class DiscordIPCClient: @unchecked Sendable {
         readSource.resume()
 
         writeFrame(.handshake, DiscordIPC.handshakeJSON())
+        armReadyDeadline()
+    }
+
+    /// An endpoint that accepts the socket and then stays silent would
+    /// otherwise hold the client connected-but-never-ready forever, with every
+    /// publish parked behind `ready`. `SO_RCVTIMEO` does not cover it: the read
+    /// source only fires when bytes arrive, so no `recv()` ever runs on an idle
+    /// socket and its timeout is never observed.
+    private func armReadyDeadline() {
+        readyWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.running, !self.ready, self.fd >= 0 else { return }
+            self.handleDisconnect()
+        }
+        readyWork = work
+        queue.asyncAfter(deadline: .now() + readyTimeout, execute: work)
     }
 
     private func scheduleReconnect() {
-        guard attempts < Self.maxReconnectAttempts else { return }
+        guard attempts < Self.maxReconnectAttempts else {
+            // The budget is spent, so go back to the stopped state instead of
+            // sitting in `running` with nothing scheduled. Leaving it true
+            // made a later `start()` hit the idempotence guard and silently do
+            // nothing, which turned a bounded retry into a permanent dead
+            // client for anything started once at launch. `pending` is kept:
+            // a later `start()` should republish what was last intended.
+            giveUp()
+            return
+        }
         attempts += 1
         let work = DispatchWorkItem { [weak self] in self?.openConnection() }
         reconnectWork = work
         queue.asyncAfter(deadline: .now() + reconnectDelay, execute: work)
     }
 
+    /// Not `stop()`: there is no socket left to send a clear on, and this is
+    /// not the user asking to stop. It only returns the client to a state a
+    /// later `start()` can act on.
+    private func giveUp() {
+        running = false
+        attempts = 0
+        throttleWork?.cancel()
+        throttleWork = nil
+        reconnectWork?.cancel()
+        reconnectWork = nil
+        teardown()
+    }
+
     private func teardown() {
         ready = false
+        readyWork?.cancel()
+        readyWork = nil
         buffer.removeAll()
         fd = -1
         if let source {
@@ -497,6 +553,14 @@ final class DiscordIPCClient: @unchecked Sendable {
                         // which is the unbounded background loop
                         // `maxReconnectAttempts` exists to prevent.
                         attempts = 0
+                        readyWork?.cancel()
+                        readyWork = nil
+                        // A replacement connection starts with no activity on
+                        // Discord's side, so whatever we last intended has to
+                        // go out again. Without this the presence stays
+                        // missing after a Discord restart until some later
+                        // producer update — up to the tray's 5-minute poll.
+                        if pending != nil { hasPending = true }
                         flush()
                     }
                 }
@@ -511,7 +575,7 @@ final class DiscordIPCClient: @unchecked Sendable {
         if let lastSent {
             let elapsed = Double(DispatchTime.now().uptimeNanoseconds - lastSent.uptimeNanoseconds)
                 / 1_000_000_000
-            if elapsed < Self.minPublishInterval {
+            if elapsed < publishInterval {
                 // Deferred, not dropped: hiding a client has to reach the
                 // published presence in the same turn, and dropping the update
                 // would leave it visible until the next poll.
@@ -519,17 +583,26 @@ final class DiscordIPCClient: @unchecked Sendable {
                 throttleWork?.cancel()
                 throttleWork = work
                 queue.asyncAfter(
-                    deadline: .now() + (Self.minPublishInterval - elapsed), execute: work)
+                    deadline: .now() + (publishInterval - elapsed), execute: work)
                 return
             }
         }
-        hasPending = false
-        lastSent = .now()
-        writeFrame(.frame, DiscordIPC.activityJSON(pending, pid: pid(), nonce: nonce()))
+        // Cleared only once the bytes are actually out. A write that fails
+        // tears the connection down, and marking the payload sent beforehand
+        // meant the newest activity was lost with the socket: the next READY
+        // saw `hasPending == false` and published nothing, leaving the
+        // presence stale until some later producer update. The throttle clock
+        // only advances on success for the same reason — a failed send must
+        // not consume the 15s window.
+        if writeFrame(.frame, DiscordIPC.activityJSON(pending, pid: pid(), nonce: nonce())) {
+            hasPending = false
+            lastSent = .now()
+        }
     }
 
-    private func writeFrame(_ op: DiscordIPC.Opcode, _ body: Data) {
-        guard fd >= 0 else { return }
+    @discardableResult
+    private func writeFrame(_ op: DiscordIPC.Opcode, _ body: Data) -> Bool {
+        guard fd >= 0 else { return false }
         let frame = DiscordIPC.encode(op, body)
         let socketFD = fd
         var failed = false
@@ -548,6 +621,7 @@ final class DiscordIPCClient: @unchecked Sendable {
             }
         }
         if failed { handleDisconnect() }
+        return !failed
     }
 
     private func pid() -> Int32 { ProcessInfo.processInfo.processIdentifier }

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -684,7 +684,13 @@ final class DiscordIPCClient: @unchecked Sendable {
         // not consume the 15s window.
         if writeFrame(.frame, DiscordIPC.activityJSON(pending, pid: pid(), nonce: nonce())) {
             hasPending = false
-            lastSent = .now()
+            // Only a new sample consumes the interval. A restore or a clear
+            // skips the floor on the way out precisely because it carries no
+            // new information, so letting it advance the clock would throttle
+            // the next genuinely changed payload from the moment of the
+            // restore rather than from the last real sample — the same stale
+            // presence the bypass exists to avoid, arriving by the other door.
+            if carriesNewInformation { lastSent = .now() }
             lastSampledPayload = pending
             deliveredOnThisConnection = pending
         }

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -297,6 +297,9 @@ final class DiscordIPCClient: @unchecked Sendable {
     private var attempts = 0
     private var lastSent: DispatchTime?
     private var pending: DiscordPresence.Payload?
+    /// What Discord currently holds, so `flush` can tell a fresh sample from a
+    /// restore of bytes it already has.
+    private var lastSentPayload: DiscordPresence.Payload?
     private var hasPending = false
     private var inboundToken = ""
     private var writeErrno: Int32 = 0
@@ -322,13 +325,20 @@ final class DiscordIPCClient: @unchecked Sendable {
     /// clear cannot be sent through a closed socket.
     func stop() {
         queue.async {
-            guard self.running else { return }
+            let wasRunning = self.running
             self.running = false
             self.reconnectWork?.cancel()
             self.throttleWork?.cancel()
+            self.readyWork?.cancel()
+            self.readyWork = nil
+            // Cleared whether or not it was running. `giveUp()` deliberately
+            // leaves `pending` behind so a later `start()` can restore, and a
+            // `stop()` that bailed on `!running` would leave that payload
+            // alive to be republished after the user turned the feature off.
             self.hasPending = false
             self.pending = nil
-            if self.fd >= 0 {
+            self.lastSentPayload = nil
+            if wasRunning, self.fd >= 0 {
                 self.writeFrame(
                     .frame,
                     DiscordIPC.activityJSON(nil, pid: self.pid(), nonce: self.nonce()))
@@ -572,7 +582,16 @@ final class DiscordIPCClient: @unchecked Sendable {
 
     private func flush() {
         guard running, ready, hasPending, fd >= 0 else { return }
-        if let lastSent {
+        // The floor limits how often NEW information is published — sampling
+        // frequency is what turns a presence into a working-hours trace. Two
+        // cases carry none, and making them wait points the rule backwards:
+        //   - a clear removes information rather than adding it, and delaying
+        //     one keeps a stale presence public for up to 15s after the user
+        //     hid the clients that produced it;
+        //   - a restore after a reconnect re-sends bytes Discord already had,
+        //     so it discloses nothing a fresh sample would.
+        let carriesNewInformation = pending != nil && pending != lastSentPayload
+        if carriesNewInformation, let lastSent {
             let elapsed = Double(DispatchTime.now().uptimeNanoseconds - lastSent.uptimeNanoseconds)
                 / 1_000_000_000
             if elapsed < publishInterval {
@@ -597,6 +616,7 @@ final class DiscordIPCClient: @unchecked Sendable {
         if writeFrame(.frame, DiscordIPC.activityJSON(pending, pid: pid(), nonce: nonce())) {
             hasPending = false
             lastSent = .now()
+            lastSentPayload = pending
         }
     }
 

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -1,0 +1,555 @@
+import Darwin
+import Foundation
+
+/// Transport for the (opt-in, default-off) Discord Rich Presence feature:
+/// framing codec, wire serialization, and the socket lifecycle.
+///
+/// Nothing in this file is wired into the app yet — no production path
+/// constructs a `DiscordIPCClient`, and the opt-in switch does not exist. The
+/// transport ships one milestone ahead of the wiring on purpose: everything
+/// here is hermetically testable, while "can it leak" only becomes answerable
+/// once there is a switch to flip.
+///
+/// `DiscordPresence.Payload.fields` is the published surface. This file may
+/// rename a key on the way out (Discord nests the asset key as
+/// `assets.large_image`); it may not add a field, drop one, or alter a value.
+/// `leafStrings(_:)` exists so that contract is asserted against the actual
+/// serialized bytes rather than a hand-maintained list.
+enum DiscordIPC {
+    /// Public constant, not a secret. A Discord application id is visible to
+    /// anyone who sees the presence; the client secret and bot token this
+    /// feature does not need must never enter the repo or the bundle.
+    static let applicationID = "1534085299163107348"
+
+    /// Discord does not document a frame length limit, so this is ours. 64 KiB
+    /// is ~50x the largest frame this client can provoke (a READY carrying a
+    /// user object is well under 1 KiB) and small enough that a hostile
+    /// endpoint cannot make us allocate anything interesting. The bound is
+    /// checked before any allocation sized from the wire.
+    static let maxFrameLength: UInt32 = 64 * 1024
+
+    enum Opcode: UInt32 {
+        case handshake = 0, frame = 1, close = 2, ping = 3, pong = 4
+    }
+
+    enum Failure: Error {
+        /// Deliberately the only case: this error is not logged, and a richer
+        /// one would only invite putting a path or an errno somewhere.
+        case unavailable
+    }
+
+    // MARK: - Framing
+
+    /// 4-byte little-endian opcode, 4-byte little-endian length, then `body`.
+    static func encode(_ op: Opcode, _ body: Data) -> Data {
+        var out = Data(capacity: 8 + body.count)
+        withUnsafeBytes(of: op.rawValue.littleEndian) { out.append(contentsOf: $0) }
+        withUnsafeBytes(of: UInt32(body.count).littleEndian) { out.append(contentsOf: $0) }
+        out.append(body)
+        return out
+    }
+
+    enum DecodeResult: Equatable {
+        /// Not a whole frame yet; `buffer` is untouched.
+        case needMore
+        /// A complete frame with a known opcode and a parseable JSON body.
+        case frame(Opcode, Data)
+        /// Consumed and dropped: unknown opcode, or a body that is not valid
+        /// UTF-8 JSON. Silent by design — logging the content of a frame from
+        /// an endpoint we do not control is the thing we are avoiding.
+        case discard
+        /// The stream is not trustworthy; the caller must disconnect.
+        case fatal
+    }
+
+    /// Consume one frame from the front of `buffer`.
+    static func decode(from buffer: inout Data) -> DecodeResult {
+        guard buffer.count >= 8 else { return .needMore }
+        let base = buffer.startIndex
+        let rawOpcode = readLE32(buffer, at: base)
+        let length = readLE32(buffer, at: base + 4)
+        // Before the buffer-completeness check, and before any allocation: a
+        // 4 GiB length must be refused outright, not waited on.
+        guard length <= maxFrameLength else { return .fatal }
+        let total = 8 + Int(length)
+        guard buffer.count >= total else { return .needMore }
+        let body = Data(buffer[(base + 8)..<(base + total)])
+        buffer.removeFirst(total)
+        guard let op = Opcode(rawValue: rawOpcode) else { return .discard }
+        // One validity check covers both malformed JSON and malformed UTF-8:
+        // JSONSerialization rejects a body that is not valid UTF-8 as well.
+        // A separate encoding check would be unreachable code pretending to be
+        // a second guard.
+        guard (try? JSONSerialization.jsonObject(with: body)) != nil else { return .discard }
+        return .frame(op, body)
+    }
+
+    private static func readLE32(_ data: Data, at index: Data.Index) -> UInt32 {
+        UInt32(data[index])
+            | UInt32(data[index + 1]) << 8
+            | UInt32(data[index + 2]) << 16
+            | UInt32(data[index + 3]) << 24
+    }
+
+    // MARK: - Serialization
+
+    static func handshakeJSON() -> Data {
+        serialize(["v": 1, "client_id": applicationID])
+    }
+
+    /// Map the published surface onto Discord's activity wire shape. `nil`
+    /// clears the activity (`"activity":null`), which is what `stop()` sends
+    /// before closing the socket.
+    static func activityJSON(
+        _ payload: DiscordPresence.Payload?, pid: Int32, nonce: String
+    ) -> Data {
+        var activity: Any = NSNull()
+        if let payload {
+            var fields: [String: Any] = [:]
+            for (key, value) in payload.fields {
+                // Renaming is allowed, adding is not. An unrecognized key goes
+                // out under its own name rather than being dropped: the
+                // contract says the transport must not drop a published field.
+                if key == "largeImageKey" {
+                    fields["assets"] = ["large_image": value]
+                } else {
+                    fields[key] = value
+                }
+            }
+            activity = fields
+        }
+        return serialize([
+            "cmd": "SET_ACTIVITY",
+            "args": ["pid": Int(pid), "activity": activity],
+            "nonce": nonce,
+        ])
+    }
+
+    /// Every scalar leaf of a serialized frame, rendered as a string — numbers
+    /// and booleans included, so that a field smuggled in as a number (a
+    /// `startTimestamp`, a pid, a hostname hash) is just as visible to the
+    /// privacy assertions as a string would be. Keys are not leaves, which is
+    /// what keeps renaming a field legal — see `leafKeys` for the channel that
+    /// costs, and why "adding is visible" is only true with both.
+    ///
+    /// It walks the real JSON, including nesting. A hand-written list of what
+    /// "should" be in there asserts the author's memory, not the bytes.
+    static func leafStrings(_ json: Data) -> [String] {
+        guard let root = try? JSONSerialization.jsonObject(
+            with: json, options: [.fragmentsAllowed]) else { return [] }
+        var out: [String] = []
+        func walk(_ any: Any) {
+            switch any {
+            case let dict as [String: Any]:
+                for key in dict.keys.sorted() { walk(dict[key]!) }
+            case let array as [Any]:
+                for element in array { walk(element) }
+            case let string as String:
+                out.append(string)
+            case is NSNull:
+                out.append("null")
+            default:
+                out.append(String(describing: any))
+            }
+        }
+        walk(root)
+        return out
+    }
+
+    /// Every object key in a serialized frame, nesting included.
+    ///
+    /// `leafStrings` ignores keys on purpose, and that leaves the key itself as
+    /// an unwatched channel: a frame carrying `"x-<hostname>": [:]` adds no
+    /// leaf (an empty object has none) and changes no count at the levels that
+    /// are counted, so every value-side assertion stays green while the
+    /// hostname ships. Pinning the key set is what closes it, which is why
+    /// both functions exist rather than one.
+    static func leafKeys(_ json: Data) -> [String] {
+        guard let root = try? JSONSerialization.jsonObject(
+            with: json, options: [.fragmentsAllowed]) else { return [] }
+        var out: [String] = []
+        func walk(_ any: Any) {
+            switch any {
+            case let dict as [String: Any]:
+                for key in dict.keys.sorted() {
+                    out.append(key)
+                    walk(dict[key]!)
+                }
+            case let array as [Any]:
+                for element in array { walk(element) }
+            default:
+                break
+            }
+        }
+        walk(root)
+        return out
+    }
+
+    static let readyEvent = "ready"
+
+    /// The only thing ever read out of an inbound frame, and the only string it
+    /// can produce. A READY frame carries the Discord account's username, id
+    /// and avatar; none of it may enter this process's state, its logs, or
+    /// anything persisted. Returning a fixed token rather than the parsed
+    /// object is the mechanism, not a stylistic choice.
+    static func inbound(_ body: Data) -> String {
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              object["evt"] as? String == "READY" else { return "other" }
+        return readyEvent
+    }
+
+    private static func serialize(_ object: [String: Any]) -> Data {
+        (try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])) ?? Data()
+    }
+
+    // MARK: - Socket
+
+    /// `nil` when the path does not fit in `sun_path`. Truncation must never be
+    /// the fallback: a truncated `sun_path` does not fail, it connects to a
+    /// *different* path.
+    static func unixSocketAddress(path: String) -> sockaddr_un? {
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        addr.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        let bytes = Array(path.utf8)
+        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
+        guard bytes.count < capacity else { return nil }
+        withUnsafeMutableBytes(of: &addr.sun_path) { $0.copyBytes(from: bytes) }
+        return addr
+    }
+
+    /// Only `discord-ipc-0`. Probing `discord-ipc-1..9` would widen the set of
+    /// endpoints a same-user process can squat on for no user-visible gain.
+    static func connectToDiscord() throws -> Int32 {
+        guard let dir = ProcessInfo.processInfo.environment["TMPDIR"] else {
+            throw Failure.unavailable
+        }
+        let path = (dir as NSString).appendingPathComponent("discord-ipc-0")
+        guard var addr = unixSocketAddress(path: path) else { throw Failure.unavailable }
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw Failure.unavailable }
+        let result = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard result == 0 else {
+            close(fd)
+            throw Failure.unavailable
+        }
+        return fd
+    }
+}
+
+/// Owns one Discord IPC connection: handshake, throttled publishing, bounded
+/// reconnection, and a single kill switch.
+///
+/// All mutable state lives on `queue`, a serial utility queue — hence
+/// `@unchecked Sendable`. Socket I/O must never run on the main thread or share
+/// the tray's refresh Task.
+final class DiscordIPCClient: @unchecked Sendable {
+    /// Matches the reference implementation's `UPDATE_MIN_INTERVAL_MS`. Also a
+    /// privacy floor: sampling frequency is what turns a presence into a
+    /// working-hours trace, so this is not a performance knob to tune down.
+    static let minPublishInterval: TimeInterval = 15
+    /// `RECONNECT_DELAY_MS` in the reference implementation. Discord not
+    /// running is the normal case, not an error worth retrying quickly.
+    static let reconnectDelaySeconds: TimeInterval = 30
+    /// Bounded on purpose: after ~2.5 minutes of CONSECUTIVE failures, stop. A
+    /// presence is not worth a background loop that outlives the user's
+    /// interest in it. The counter resets once a connection reaches READY, so
+    /// a long session that watches Discord restart six times still reconnects.
+    /// Without any reset the budget was per `start()` lifetime, which the user
+    /// would experience as the presence silently never coming back; resetting
+    /// on the socket open instead would reconnect forever against a peer that
+    /// accepts and immediately drops.
+    static let maxReconnectAttempts = 5
+
+    /// Instance-level so the selftest can shrink it. Production never assigns.
+    var reconnectDelay: TimeInterval = DiscordIPCClient.reconnectDelaySeconds
+
+    private let connectFD: @Sendable () throws -> Int32
+    private let queue = DispatchQueue(label: "com.nyanako.tokenbar.discord-ipc", qos: .utility)
+
+    private var fd: Int32 = -1
+    private var running = false
+    private var ready = false
+    private var buffer = Data()
+    private var source: DispatchSourceRead?
+    private var reconnectWork: DispatchWorkItem?
+    private var throttleWork: DispatchWorkItem?
+    private var attempts = 0
+    private var lastSent: DispatchTime?
+    private var pending: DiscordPresence.Payload?
+    private var hasPending = false
+    private var inboundToken = ""
+    private var writeErrno: Int32 = 0
+
+    init(connect: @escaping @Sendable () throws -> Int32) {
+        self.connectFD = connect
+    }
+
+    // MARK: - Public surface
+
+    /// Idempotent: a second call while running is a no-op, not a second socket.
+    func start() {
+        queue.async {
+            guard !self.running else { return }
+            self.running = true
+            self.attempts = 0
+            self.openConnection()
+        }
+    }
+
+    /// The single kill switch: cancel every scheduled wake-up, clear the
+    /// activity on Discord's side, then close the socket. Order matters — the
+    /// clear cannot be sent through a closed socket.
+    func stop() {
+        queue.async {
+            guard self.running else { return }
+            self.running = false
+            self.reconnectWork?.cancel()
+            self.throttleWork?.cancel()
+            self.hasPending = false
+            self.pending = nil
+            if self.fd >= 0 {
+                self.writeFrame(
+                    .frame,
+                    DiscordIPC.activityJSON(nil, pid: self.pid(), nonce: self.nonce()))
+            }
+            self.teardown()
+        }
+    }
+
+    /// `nil` clears the activity. Coalescing, not queueing: only the newest
+    /// payload is ever published.
+    func publish(_ payload: DiscordPresence.Payload?) {
+        queue.async {
+            guard self.running else { return }
+            self.pending = payload
+            self.hasPending = true
+            self.flush()
+        }
+    }
+
+    // MARK: - Selftest seams
+    //
+    // Internal, not `#if DEBUG`: a symbol that exists only in one configuration
+    // is a symbol that breaks the release build the first time someone calls it
+    // without the guard.
+
+    /// Blocks until everything already queued has run.
+    func drainForTesting() { queue.sync {} }
+
+    var isConnectedForTesting: Bool { queue.sync { fd >= 0 } }
+    var inboundTokenForTesting: String { queue.sync { inboundToken } }
+    var writeErrnoForTesting: Int32 { queue.sync { writeErrno } }
+    var reconnectPendingForTesting: Bool {
+        queue.sync { reconnectWork.map { !$0.isCancelled } ?? false }
+    }
+
+    /// Runs `breakPeer` and writes on the *same* queue item, so the read
+    /// source's EOF handler cannot tear the connection down in between. That
+    /// makes "write to a socket whose peer is gone" — the SIGPIPE case —
+    /// deterministic instead of a race.
+    ///
+    /// Takes a closure rather than a descriptor: an earlier signature accepted
+    /// an `Int32` and closed it, which is a `close()` on whatever number the
+    /// caller passed. Ordering is the only thing this seam needs to own.
+    func probeWriteForTesting(after breakPeer: @Sendable () -> Void) {
+        queue.sync {
+            breakPeer()
+            writeFrame(.frame, DiscordIPC.activityJSON(nil, pid: pid(), nonce: nonce()))
+        }
+    }
+
+    /// Drives the reconnect path directly so the "stopped means stopped"
+    /// assertion does not have to wait for a real disconnect it can no longer
+    /// provoke (after `stop()` there is no socket left to break).
+    func scheduleReconnectForTesting() {
+        queue.async { self.scheduleReconnect() }
+    }
+
+    // MARK: - Connection
+
+    private func openConnection() {
+        // The one place a connection can come into existence, and therefore the
+        // one place that has to honour "after stop(), no path reconnects".
+        //
+        // There is deliberately no second `fd < 0` *guard* here: `start()`'s
+        // `!running` guard is what keeps a live connection from being replaced,
+        // and two guards for one invariant means neither can be shown to fail
+        // on its own.
+        guard running else { return }
+        // Not a guard — a precondition made true. Reaching here with a live fd
+        // would overwrite `fd` and `source` without cancelling the old source,
+        // leaking the descriptor while libdispatch kept firing on it. That was
+        // reachable from `scheduleReconnectForTesting`, and would be reachable
+        // from any future caller too, so it is closed here at the one place a
+        // connection is born rather than at each call site.
+        if fd >= 0 { teardown() }
+        guard let newFD = try? connectFD() else {
+            scheduleReconnect()
+            return
+        }
+        // Immediately, before any write can happen: Darwin's default for a
+        // write to a closed socket is SIGPIPE, which kills the whole app, and
+        // Discord quitting mid-session is ordinary.
+        //
+        // The return value is checked because this call really can fail — it
+        // returns EINVAL on a socket whose peer has already gone away, which is
+        // reachable if Discord dies between `connect()` and here. A socket we
+        // could not make SIGPIPE-safe is not one we are willing to write to, so
+        // it is dropped rather than used.
+        var on: Int32 = 1
+        guard setsockopt(
+            newFD, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size)) == 0
+        else {
+            close(newFD)
+            scheduleReconnect()
+            return
+        }
+        // Backstop against a peer that opens the socket and then says nothing.
+        var timeout = timeval(tv_sec: 2, tv_usec: 0)
+        setsockopt(newFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(newFD, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        fd = newFD
+        buffer.removeAll()
+        ready = false
+
+        let readSource = DispatchSource.makeReadSource(fileDescriptor: newFD, queue: queue)
+        readSource.setEventHandler { [weak self] in self?.readAvailable() }
+        // Closing in the cancel handler, not beside `cancel()`: the source may
+        // still be about to run its event handler on this fd.
+        readSource.setCancelHandler { close(newFD) }
+        source = readSource
+        readSource.resume()
+
+        writeFrame(.handshake, DiscordIPC.handshakeJSON())
+    }
+
+    private func scheduleReconnect() {
+        guard attempts < Self.maxReconnectAttempts else { return }
+        attempts += 1
+        let work = DispatchWorkItem { [weak self] in self?.openConnection() }
+        reconnectWork = work
+        queue.asyncAfter(deadline: .now() + reconnectDelay, execute: work)
+    }
+
+    private func teardown() {
+        ready = false
+        buffer.removeAll()
+        fd = -1
+        if let source {
+            source.cancel()
+            self.source = nil
+        }
+    }
+
+    private func handleDisconnect() {
+        teardown()
+        if running { scheduleReconnect() }
+    }
+
+    // MARK: - Reading
+
+    private func readAvailable() {
+        guard fd >= 0 else { return }
+        var chunk = [UInt8](repeating: 0, count: 4096)
+        let count = recv(fd, &chunk, chunk.count, 0)
+        if count == 0 { handleDisconnect(); return }
+        if count < 0 {
+            if errno == EINTR || errno == EAGAIN { return }
+            handleDisconnect()
+            return
+        }
+        buffer.append(contentsOf: chunk[0..<count])
+        while true {
+            switch DiscordIPC.decode(from: &buffer) {
+            case .needMore:
+                return
+            case .discard:
+                continue
+            case .fatal:
+                handleDisconnect()
+                return
+            case .frame(let op, let body):
+                switch op {
+                case .ping:
+                    // The protocol wants the ping's own body echoed back. These
+                    // are the peer's bytes going to the peer that sent them:
+                    // nothing local is added, nothing is retained, and the
+                    // length is already bounded by `maxFrameLength`. Do not
+                    // "improve" this into something that reads or logs `body`.
+                    writeFrame(.pong, body)
+                case .close:
+                    handleDisconnect()
+                    return
+                default:
+                    inboundToken = DiscordIPC.inbound(body)
+                    if inboundToken == DiscordIPC.readyEvent {
+                        ready = true
+                        // The retry budget resets HERE, not when `connect()`
+                        // returns. A socket that opens and dies before the
+                        // handshake — Discord running but refusing us — is
+                        // still a failed attempt; resetting on the open would
+                        // let that case reconnect at `reconnectDelay` forever,
+                        // which is the unbounded background loop
+                        // `maxReconnectAttempts` exists to prevent.
+                        attempts = 0
+                        flush()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Writing
+
+    private func flush() {
+        guard running, ready, hasPending, fd >= 0 else { return }
+        if let lastSent {
+            let elapsed = Double(DispatchTime.now().uptimeNanoseconds - lastSent.uptimeNanoseconds)
+                / 1_000_000_000
+            if elapsed < Self.minPublishInterval {
+                // Deferred, not dropped: hiding a client has to reach the
+                // published presence in the same turn, and dropping the update
+                // would leave it visible until the next poll.
+                let work = DispatchWorkItem { [weak self] in self?.flush() }
+                throttleWork?.cancel()
+                throttleWork = work
+                queue.asyncAfter(
+                    deadline: .now() + (Self.minPublishInterval - elapsed), execute: work)
+                return
+            }
+        }
+        hasPending = false
+        lastSent = .now()
+        writeFrame(.frame, DiscordIPC.activityJSON(pending, pid: pid(), nonce: nonce()))
+    }
+
+    private func writeFrame(_ op: DiscordIPC.Opcode, _ body: Data) {
+        guard fd >= 0 else { return }
+        let frame = DiscordIPC.encode(op, body)
+        let socketFD = fd
+        var failed = false
+        frame.withUnsafeBytes { raw in
+            var offset = 0
+            while offset < raw.count {
+                let written = send(socketFD, raw.baseAddress! + offset, raw.count - offset, 0)
+                if written > 0 {
+                    offset += written
+                    continue
+                }
+                if written < 0 && errno == EINTR { continue }
+                writeErrno = errno
+                failed = true
+                return
+            }
+        }
+        if failed { handleDisconnect() }
+    }
+
+    private func pid() -> Int32 { ProcessInfo.processInfo.processIdentifier }
+    private func nonce() -> String { UUID().uuidString }
+}

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3755,6 +3755,524 @@ enum SelfTest {
                 == "Amp · $5-10",
             "the tie-break does not depend on the order the stripes arrive in")
 
+        // MARK: - Discord Rich Presence transport (DISCORD-PRESENCE M2a)
+        //
+        // Nothing in the app calls this transport yet. These are the framing,
+        // lifecycle and privacy guards for the code that will carry the payload
+        // off the machine, and they run against real syscalls: the client's
+        // connect factory is handed one end of a `socketpair(AF_UNIX,
+        // SOCK_STREAM)`, so the framing, the fd lifetime and the SIGPIPE
+        // behaviour are the production ones, not a mock's.
+
+        /// Frames built independently of `DiscordIPC.encode`, so the decoder is
+        /// never checked against its own mirror image.
+        func dpRaw(_ op: UInt32, _ length: UInt32, _ body: Data) -> Data {
+            var out = Data()
+            withUnsafeBytes(of: op.littleEndian) { out.append(contentsOf: $0) }
+            withUnsafeBytes(of: length.littleEndian) { out.append(contentsOf: $0) }
+            out.append(body)
+            return out
+        }
+        func dpFrameBytes(_ op: UInt32, _ text: String) -> Data {
+            let body = Data(text.utf8)
+            return dpRaw(op, UInt32(body.count), body)
+        }
+        func dpSocketPair() -> (Int32, Int32) {
+            var fds: [Int32] = [-1, -1]
+            _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+            // The peer end is only ever read by the test; the timeout keeps a
+            // missing frame a FAIL rather than a hung selftest, and
+            // SO_NOSIGPIPE keeps a write after the client closes from killing
+            // the harness itself.
+            var timeout = timeval(tv_sec: 1, tv_usec: 0)
+            setsockopt(fds[1], SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+            var on: Int32 = 1
+            setsockopt(fds[1], SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+            return (fds[0], fds[1])
+        }
+        func dpRecv(_ fd: Int32) -> Data {
+            var buf = [UInt8](repeating: 0, count: 4096)
+            let count = recv(fd, &buf, buf.count, 0)
+            return count > 0 ? Data(buf[0..<count]) : Data()
+        }
+        func dpDrainToEOF(_ fd: Int32) -> Data {
+            var out = Data()
+            while true {
+                let chunk = dpRecv(fd)
+                if chunk.isEmpty { return out }
+                out.append(chunk)
+            }
+        }
+        func dpWaitUntil(_ ready: () -> Bool) -> Bool {
+            for _ in 0..<400 {
+                if ready() { return true }
+                usleep(5_000)
+            }
+            return ready()
+        }
+        /// Counts calls to an injected connect factory. Mutated on the client's
+        /// serial queue and read after `drainForTesting()`/`dpWaitUntil`, which
+        /// is what orders the two.
+        final class DPCounter: @unchecked Sendable {
+            var value = 0
+        }
+
+        // A6 — framing resilience. `encode` is pinned against an independently
+        // built frame first, so a byte-order regression cannot hide behind a
+        // symmetric decoder.
+        expect(DiscordIPC.encode(.handshake, Data("{}".utf8)) == dpRaw(0, 2, Data("{}".utf8)),
+            "the frame encoder emits LE opcode, LE length, then body")
+
+        // A6a — an absurd length is refused before the completeness check, so
+        // no allocation is ever sized from the wire. Dropping the bound check
+        // does not blow up here; it silently turns this into `needMore`, which
+        // is a connection that waits forever for 4 GiB that will never arrive.
+        var dpOversize = dpRaw(1, 0xFFFF_FFFF, Data())
+        expect(DiscordIPC.decode(from: &dpOversize) == .fatal && dpOversize.count == 8,
+            "A6a: an oversized frame length is fatal and consumes nothing "
+                + "(mutation: dropping the maxFrameLength check yields needMore)")
+        // Literal bounds, not the constant they guard: 64 KiB is the contract.
+        var dpAtCap = dpRaw(1, 65_536, Data())
+        expect(DiscordIPC.decode(from: &dpAtCap) == .needMore,
+            "a length exactly at the 64 KiB cap is allowed")
+        var dpOverCap = dpRaw(1, 65_537, Data())
+        expect(DiscordIPC.decode(from: &dpOverCap) == .fatal,
+            "one byte over the 64 KiB cap is fatal")
+
+        // A6b — opcode allowlist.
+        var dpOpFive = dpFrameBytes(5, "{}")
+        expect(DiscordIPC.decode(from: &dpOpFive) == .discard && dpOpFive.isEmpty,
+            "A6b: opcode 5 is discarded and consumed "
+                + "(mutation: dropping the Opcode allowlist surfaces it as a frame)")
+        var dpOpMax = dpFrameBytes(0xFFFF_FFFF, "{}")
+        expect(DiscordIPC.decode(from: &dpOpMax) == .discard && dpOpMax.isEmpty,
+            "A6b: opcode 0xFFFFFFFF is discarded, not read as a negative int")
+
+        // A6c — partial reads never block and never consume.
+        var dpHeaderOnly = dpRaw(1, 2, Data())
+        expect(DiscordIPC.decode(from: &dpHeaderOnly) == .needMore && dpHeaderOnly.count == 8,
+            "A6c: a header with no body needs more and leaves the buffer intact "
+                + "(mutation: consuming on an incomplete frame loses the header)")
+        var dpHalfHeader = Data([1, 0, 0, 0])
+        expect(DiscordIPC.decode(from: &dpHalfHeader) == .needMore && dpHalfHeader.count == 4,
+            "A6c: fewer than 8 bytes needs more")
+
+        // A6d — malformed bodies are dropped silently. One validity check
+        // covers both cases: JSONSerialization rejects a body that is not valid
+        // UTF-8 as well as one that is not valid JSON.
+        var dpNonUTF8 = dpRaw(1, 3, Data([0xFF, 0xFE, 0xFD]))
+        expect(DiscordIPC.decode(from: &dpNonUTF8) == .discard && dpNonUTF8.isEmpty,
+            "A6d: a non-UTF-8 body is discarded "
+                + "(mutation: dropping the body validity check surfaces it as a frame)")
+        var dpBadJSON = dpFrameBytes(1, "{not json")
+        expect(DiscordIPC.decode(from: &dpBadJSON) == .discard && dpBadJSON.isEmpty,
+            "A6d: an unparseable JSON body is discarded")
+
+        // A6e — several frames in one read are taken one at a time, in order.
+        var dpStream = dpFrameBytes(1, "{\"a\":1}")
+            + dpFrameBytes(5, "{}")
+            + dpFrameBytes(0, "{\"b\":2}")
+        expect(DiscordIPC.decode(from: &dpStream) == .frame(.frame, Data("{\"a\":1}".utf8)),
+            "A6e: the first of three concatenated frames comes out intact")
+        expect(DiscordIPC.decode(from: &dpStream) == .discard,
+            "A6e: the bad middle frame is skipped without disturbing the rest")
+        expect(DiscordIPC.decode(from: &dpStream) == .frame(.handshake, Data("{\"b\":2}".utf8)),
+            "A6e: the third frame follows "
+                + "(mutation: advancing the buffer by the wrong amount fails here)")
+        expect(DiscordIPC.decode(from: &dpStream) == .needMore && dpStream.isEmpty,
+            "A6e: the buffer is fully drained afterwards")
+
+        // A-wire — the published surface and the serialized bytes are the same
+        // set. `leafStrings` walks the real JSON, nesting included, and renders
+        // numbers too, so a field smuggled in as a number is just as visible.
+        let dpWirePayload = DiscordPresence.Payload(
+            details: "12K tokens today", state: "Amp · $1-5", largeImageKey: "tokenbar")
+        let dpWire = DiscordIPC.activityJSON(dpWirePayload, pid: 4242, nonce: "NONCE-1")
+        // Sorted arrays, not Sets: a Set erases multiplicity, so a smuggled
+        // field whose value merely REPEATS an existing leaf — assets
+        // .small_image = the same "tokenbar", or a numeric field equal to the
+        // pid — left the set unchanged and escaped entirely. Counting leaves
+        // is what closes that.
+        expect(
+            DiscordIPC.leafStrings(dpWire).sorted()
+                == (Array(dpWirePayload.fields.values) + ["SET_ACTIVITY", "NONCE-1", "4242"]).sorted(),
+            "A-wire: the activity's leaves are exactly Payload.fields plus Discord's structural "
+                + "constants, counted (mutation: adding any field — hostname, startTimestamp, or "
+                + "one whose value duplicates an existing leaf — fails here)")
+        let dpWireObject = (try? JSONSerialization.jsonObject(with: dpWire)) as? [String: Any]
+        let dpWireArgs = dpWireObject?["args"] as? [String: Any]
+        let dpWireActivity = dpWireArgs?["activity"] as? [String: Any]
+        let dpWireAssets = dpWireActivity?["assets"] as? [String: Any]
+        expect(dpWireAssets?["large_image"] as? String == "tokenbar",
+            "A-wire: largeImageKey is published as assets.large_image, renamed but unaltered")
+        expect(dpWireActivity?["details"] as? String == "12K tokens today"
+            && dpWireActivity?["state"] as? String == "Amp · $1-5",
+            "A-wire: details and state go out verbatim")
+        expect(dpWireActivity?.count == 3,
+            "A-wire: the activity object holds exactly details, state and assets")
+        // The nested level needs its own count: `activity.count` only sees the
+        // top level, so a field added under `assets` kept it at 3.
+        // Keys are a channel of their own. A leaf scan cannot see them, and an
+        // empty container has no leaves at all, so `"x-<hostname>": [:]` was
+        // published with all 517 assertions green until this landed. Sorted
+        // array, not a Set, so a key repeated at another level shows too.
+        expect(
+            DiscordIPC.leafKeys(dpWire).sorted() == [
+                "activity", "args", "assets", "cmd", "details",
+                "large_image", "nonce", "pid", "state",
+            ],
+            "A-wire: the frame's keys are exactly the protocol's (mutation: adding a key whose "
+                + "VALUE is an empty object smuggles the key text out with no new leaf — this is "
+                + "the only assertion that sees it)")
+        expect(dpWireAssets?.count == 1,
+            "A-wire: assets holds exactly large_image (mutation: adding assets.small_image, "
+                + "even with a value that duplicates an existing leaf, fails here)")
+        expect(dpWireObject?["cmd"] as? String == "SET_ACTIVITY"
+            && dpWireArgs?["pid"] as? Int == 4242 && dpWireObject?["nonce"] as? String == "NONCE-1",
+            "A-wire: the envelope is SET_ACTIVITY with the given pid and nonce")
+        expect(String(decoding: DiscordIPC.activityJSON(nil, pid: 4242, nonce: "N"), as: UTF8.self)
+            .contains("\"activity\":null"),
+            "clearing the presence sends activity: null")
+
+        // A-wire, the OTHER outbound frames. The activity frame is not the
+        // only thing that leaves this machine: the handshake goes out on every
+        // connect, and the clear goes out on every stop. Both are serialized
+        // by the same helper and neither had a single assertion — the same key
+        // and leaf channels were wide open there while the activity frame was
+        // being tightened four times over. Pinning what leaves means pinning
+        // every frame, not the one that happened to be under review.
+        let dpShake = DiscordIPC.handshakeJSON()
+        expect(DiscordIPC.leafKeys(dpShake).sorted() == ["client_id", "v"],
+            "A-wire: the handshake's keys are exactly v and client_id")
+        expect(DiscordIPC.leafStrings(dpShake).sorted()
+            == [DiscordIPC.applicationID, "1"].sorted(),
+            "A-wire: the handshake carries the application id and the protocol version, and "
+                + "nothing else (mutation: adding any field, or a key with an empty value, fails "
+                + "one of these two)")
+        let dpClear = DiscordIPC.activityJSON(nil, pid: 4242, nonce: "NONCE-2")
+        expect(DiscordIPC.leafKeys(dpClear).sorted()
+            == ["activity", "args", "cmd", "nonce", "pid"],
+            "A-wire: the clear frame's keys are exactly the protocol's")
+        expect(DiscordIPC.leafStrings(dpClear).sorted()
+            == ["4242", "NONCE-2", "SET_ACTIVITY", "null"].sorted(),
+            "A-wire: the clear frame carries no payload data at all")
+
+        // A13 — nothing from an inbound frame may be read, kept or echoed. The
+        // READY frame Discord actually sends carries the account's username, id
+        // and avatar.
+        let dpReadyBody = "{\"cmd\":\"DISPATCH\",\"evt\":\"READY\",\"data\":{\"v\":1,"
+            + "\"user\":{\"username\":\"SECRET_USERNAME\",\"id\":\"SECRET_ID\","
+            + "\"avatar\":\"SECRET_AVATAR\",\"discriminator\":\"0001\"}}}"
+        let dpInboundToken = DiscordIPC.inbound(Data(dpReadyBody.utf8))
+        // Literal "ready", not DiscordIPC.readyEvent: an expectation read out of
+        // the constant it guards passes whatever that constant becomes.
+        expect(dpInboundToken == "ready" && !dpInboundToken.contains("SECRET_"),
+            "A13: a READY frame yields a fixed token and no frame content "
+                + "(mutation: returning the parsed user object, or the raw body, leaks SECRET_)")
+        expect(DiscordIPC.inbound(Data("{\"evt\":\"ERROR\",\"data\":{}}".utf8)) == "other",
+            "A13: a non-READY event is not mistaken for READY")
+
+        // A-path — sun_path is 104 bytes and truncation does not fail, it
+        // connects somewhere else.
+        func dpAddressFits(_ path: String) -> Bool {
+            DiscordIPC.unixSocketAddress(path: path).map { _ in true } ?? false
+        }
+        expect(!dpAddressFits(String(repeating: "a", count: 200)),
+            "A-path: an over-long socket path is refused "
+                + "(mutation: truncating to fit connects to a different path)")
+        expect(!dpAddressFits(String(repeating: "a", count: 104)),
+            "A-path: a path filling sun_path exactly leaves no room for the NUL")
+        expect(dpAddressFits(String(repeating: "a", count: 103)),
+            "A-path: 103 bytes still fits")
+        var dpAddress = DiscordIPC.unixSocketAddress(path: "/tmp/discord-ipc-0")!
+        let dpAddressPath = withUnsafeBytes(of: &dpAddress.sun_path) {
+            String(cString: $0.bindMemory(to: CChar.self).baseAddress!)
+        }
+        expect(dpAddressPath == "/tmp/discord-ipc-0",
+            "A-path: the address carries the path verbatim")
+
+        // A7a/A7c/A13 over a real socket pair.
+        let (dpLocal, dpPeer) = dpSocketPair()
+        let dpConnects = DPCounter()
+        let dpClient = DiscordIPCClient(connect: {
+            dpConnects.value += 1
+            return dpLocal
+        })
+        dpClient.start()
+        dpClient.start()
+        dpClient.drainForTesting()
+        expect(dpConnects.value == 1,
+            "A7a: start() twice opens one connection "
+                + "(mutation: dropping the `!running` guard in start() connects twice)")
+
+        var dpHandshakeBuffer = dpRecv(dpPeer)
+        var dpHandshakeOK = false
+        if case .frame(.handshake, let body) = DiscordIPC.decode(from: &dpHandshakeBuffer) {
+            let text = String(decoding: body, as: UTF8.self)
+            dpHandshakeOK = text.contains("\"client_id\":\"1534085299163107348\"")
+                && text.contains("\"v\":1")
+        }
+        expect(dpHandshakeOK, "the client opens with a v1 handshake carrying the application id")
+
+        dpFrameBytes(1, dpReadyBody).withUnsafeBytes { raw in
+            _ = send(dpPeer, raw.baseAddress!, raw.count, 0)
+        }
+        expect(dpWaitUntil { dpClient.inboundTokenForTesting == "ready" },
+            "the client recognises READY off the wire")
+        expect(!dpClient.inboundTokenForTesting.contains("SECRET_"),
+            "A13: nothing from the READY frame survives in the client's state")
+
+        dpClient.publish(dpWirePayload)
+        dpClient.publish(DiscordPresence.Payload(
+            details: "999K tokens today", state: "Zed · $50-100", largeImageKey: "tokenbar"))
+        dpClient.drainForTesting()
+        var dpActivityBuffer = dpRecv(dpPeer)
+        var dpActivityText = ""
+        var dpActivityBody = Data()
+        if case .frame(.frame, let body) = DiscordIPC.decode(from: &dpActivityBuffer) {
+            dpActivityText = String(decoding: body, as: UTF8.self)
+            dpActivityBody = body
+        }
+        expect(dpActivityText.contains("12K tokens today"),
+            "the first publish reaches the socket immediately")
+
+        // The bytes that actually left the socket, pinned the same way the
+        // pure-function frames are. Every A-wire assertion above calls
+        // `activityJSON` with `pid: 4242, nonce: "NONCE-1"`, so `pid()` and
+        // `nonce()` — which supply every real frame — were executed by no
+        // assertion at all. A `nonce()` returning
+        // `NSUserName() + "@" + hostName` shipped the username and this
+        // machine's reverse-DNS name on every publish with all 525 green.
+        // Guarding a serializer is not guarding what it is called with.
+        expect(
+            DiscordIPC.leafKeys(dpActivityBody).sorted() == [
+                "activity", "args", "assets", "cmd", "details",
+                "large_image", "nonce", "pid", "state",
+            ],
+            "the frame on the wire carries exactly the protocol's keys")
+        let dpLiveLeaves = DiscordIPC.leafStrings(dpActivityBody)
+        let dpLivePayloadLeaves = ["12K tokens today", "Amp · $1-5", "tokenbar", "SET_ACTIVITY"]
+        expect(
+            dpLiveLeaves.count == dpLivePayloadLeaves.count + 2
+                && dpLivePayloadLeaves.allSatisfy(dpLiveLeaves.contains),
+            "the frame on the wire carries the payload, the envelope constant, and exactly two "
+                + "more leaves — the pid and the nonce")
+        let dpLiveExtra = dpLiveLeaves.filter { !dpLivePayloadLeaves.contains($0) }
+        expect(dpLiveExtra.contains(String(ProcessInfo.processInfo.processIdentifier)),
+            "the pid on the wire is this process's own (mutation: deriving it from a hostname "
+                + "hash, or anything else, fails here)")
+        let dpLiveNonce = dpLiveExtra.first {
+            $0 != String(ProcessInfo.processInfo.processIdentifier)
+        }
+        expect(dpLiveNonce.map { UUID(uuidString: $0) != nil } == true,
+            "the nonce on the wire is a bare UUID and carries nothing else (mutation: building it "
+                + "from NSUserName() or the host name fails here)")
+        expect(!dpActivityText.contains("999K") && dpActivityBuffer.isEmpty,
+            "a second publish inside the 15s floor is coalesced rather than sent")
+
+        dpClient.stop()
+        dpClient.drainForTesting()
+        var dpTail = dpDrainToEOF(dpPeer)
+        var dpClearSeen = false
+        while case .frame(_, let body) = DiscordIPC.decode(from: &dpTail) {
+            if String(decoding: body, as: UTF8.self).contains("\"activity\":null") {
+                dpClearSeen = true
+            }
+        }
+        expect(dpClearSeen,
+            "A7c: stop() sends the activity clear before closing the socket "
+                + "(mutation: closing first loses the frame entirely)")
+        expect(!dpClient.isConnectedForTesting, "A7c: stop() closes the socket")
+        close(dpPeer)
+
+        // A9 — SIGPIPE. The connection is established first (SO_NOSIGPIPE only
+        // applies to a live socket — on a dead one setsockopt returns EINVAL),
+        // then the peer is closed and a frame written in the same queue item so
+        // the EOF handler cannot get there first. With SO_NOSIGPIPE removed
+        // this does not fail, it kills the selftest process: no FAIL line, no
+        // "selftest passed", exit status 141.
+        let (dpDeadLocal, dpDeadPeer) = dpSocketPair()
+        let dpSigClient = DiscordIPCClient(connect: { dpDeadLocal })
+        dpSigClient.start()
+        dpSigClient.drainForTesting()
+        _ = dpRecv(dpDeadPeer)
+        dpSigClient.probeWriteForTesting { close(dpDeadPeer) }
+        expect(dpSigClient.writeErrnoForTesting == EPIPE,
+            "A9: a write to a closed socket returns EPIPE and the process survives "
+                + "(mutation: dropping SO_NOSIGPIPE terminates the selftest on signal 13)")
+        expect(!dpSigClient.isConnectedForTesting,
+            "A9: the failed write tears the connection down")
+        dpSigClient.stop()
+
+        // A7b, part 1 — retries are bounded. Every connection here is born
+        // broken (peer closed immediately), so the retry path runs to its limit.
+        let dpRetries = DPCounter()
+        let dpRetryClient = DiscordIPCClient(connect: {
+            dpRetries.value += 1
+            var fds: [Int32] = [-1, -1]
+            _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+            close(fds[1])
+            return fds[0]
+        })
+        dpRetryClient.reconnectDelay = 0.02
+        dpRetryClient.start()
+        expect(dpWaitUntil { dpRetries.value >= 2 },
+            "a broken connection is retried at all (without this the bound below is vacuous)")
+        expect(dpWaitUntil { dpRetries.value == 6 },
+            "the retry budget is the initial attempt plus five")
+        usleep(300_000)
+        expect(dpRetries.value == 6,
+            "A7b: reconnection stops at the attempt limit "
+                + "(mutation: dropping the maxReconnectAttempts guard retries forever)")
+        dpRetryClient.stop()
+
+        // A7b, part 2 — stop() cancels the armed retry.
+        let dpCancelCount = DPCounter()
+        let dpCancelClient = DiscordIPCClient(connect: {
+            dpCancelCount.value += 1
+            var fds: [Int32] = [-1, -1]
+            _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+            close(fds[1])
+            return fds[0]
+        })
+        dpCancelClient.reconnectDelay = 0.5
+        dpCancelClient.start()
+        expect(dpWaitUntil { dpCancelClient.reconnectPendingForTesting },
+            "the disconnect arms a retry")
+        // A7a, second half: idempotence has to hold while a retry is armed too,
+        // where `fd < 0` no longer covers it.
+        dpCancelClient.start()
+        dpCancelClient.drainForTesting()
+        expect(dpCancelCount.value == 1,
+            "A7a: start() during an armed retry does not open a second connection "
+                + "(mutation: dropping the `!running` guard in start() connects immediately)")
+        dpCancelClient.stop()
+        dpCancelClient.drainForTesting()
+        expect(!dpCancelClient.reconnectPendingForTesting,
+            "A7b: stop() cancels the armed retry "
+                + "(mutation: dropping reconnectWork?.cancel() leaves it armed)")
+        usleep(700_000)
+        expect(dpCancelCount.value == 1, "A7b: the cancelled retry never fires")
+
+        // A7b, part 3 — after stop(), no path rebuilds the connection. Driven
+        // directly, because once stop() has closed the socket there is no
+        // disconnect left to provoke.
+        let (dpStopLocal, dpStopPeer) = dpSocketPair()
+        let dpStopConnects = DPCounter()
+        let dpStopClient = DiscordIPCClient(connect: {
+            dpStopConnects.value += 1
+            return dpStopLocal
+        })
+        dpStopClient.reconnectDelay = 0.02
+        dpStopClient.start()
+        dpStopClient.drainForTesting()
+        expect(dpStopConnects.value == 1, "the stopped-client fixture connected once")
+        dpStopClient.stop()
+        dpStopClient.drainForTesting()
+        dpStopClient.scheduleReconnectForTesting()
+        usleep(300_000)
+        expect(dpStopConnects.value == 1,
+            "A7b: no path reconnects after stop() "
+                + "(mutation: dropping the running guard in openConnection reconnects here)")
+        close(dpStopPeer)
+
+        // A2 — the two behaviours the previous review found unguarded.
+
+        // Superseding a live connection must close the old socket, not leak
+        // it. Checked from the OLD PEER, never from the fd number: descriptors
+        // get reused, so "is fd N still open" can be true simply because N is
+        // now the NEW socket. Only the peer reaching EOF proves every copy of
+        // the old local end is gone.
+        let dpSupA = dpSocketPair()
+        let dpSupB = dpSocketPair()
+        let dpSupIdx = DPCounter()
+        let dpSupFDs: [Int32] = [dpSupA.0, dpSupB.0]
+        let dpSupClient = DiscordIPCClient(connect: {
+            let i = min(dpSupIdx.value, dpSupFDs.count - 1)
+            dpSupIdx.value += 1
+            return dpSupFDs[i]
+        })
+        dpSupClient.reconnectDelay = 0.02
+        dpSupClient.start()
+        _ = dpWaitUntil { dpSupClient.isConnectedForTesting }
+        // Drain the handshake first, or the peer has bytes waiting and can
+        // never report EOF.
+        _ = dpRecv(dpSupA.1)
+        dpSupClient.scheduleReconnectForTesting()
+        _ = dpWaitUntil { dpSupIdx.value >= 2 }
+        let dpSupClosed = dpWaitUntil {
+            var byte: UInt8 = 0
+            return recv(dpSupA.1, &byte, 1, MSG_DONTWAIT) == 0
+        }
+        expect(dpSupClosed,
+            "reconnecting over a live connection closes the superseded socket (mutation: dropping "
+                + "openConnection's `if fd >= 0 { teardown() }` leaks the descriptor and the old "
+                + "peer never sees EOF)")
+        dpSupClient.stop()
+        close(dpSupA.1)
+        close(dpSupB.1)
+
+        // The retry budget resets once a connection reaches READY, so a long
+        // session survives more than `maxReconnectAttempts` Discord restarts.
+        // The peer answers READY and only then drops: a fixture that closes
+        // immediately never reaches READY and would pass even with the reset
+        // removed, which is exactly the trap that made this look untestable.
+        let dpReadyFrame = dpFrameBytes(1, "{\"evt\":\"READY\"}")
+        let dpReadyCount = DPCounter()
+        let dpReadyClient = DiscordIPCClient(connect: {
+            var fds: [Int32] = [-1, -1]
+            _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+            var on: Int32 = 1
+            setsockopt(fds[1], SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+            dpReadyCount.value += 1
+            _ = dpReadyFrame.withUnsafeBytes { send(fds[1], $0.baseAddress, $0.count, 0) }
+            let peer = fds[1]
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.03) { close(peer) }
+            return fds[0]
+        })
+        dpReadyClient.reconnectDelay = 0.01
+        dpReadyClient.start()
+        // Initial connect plus the cap is 6; anything beyond it can only come
+        // from a budget that was reset.
+        let dpReadyBeyondCap = dpWaitUntil {
+            dpReadyCount.value > DiscordIPCClient.maxReconnectAttempts + 1
+        }
+        dpReadyClient.stop()
+        expect(dpReadyBeyondCap,
+            "reaching READY resets the retry budget (mutation: dropping `attempts = 0` from the "
+                + "READY branch caps reconnects at maxReconnectAttempts for the whole start() "
+                + "lifetime, so the presence never returns after enough restarts)")
+
+        // The mirror image, and the one that pins the reset's TIMING rather
+        // than its existence: a peer that connects, says nothing, and drops.
+        // That is Discord running but refusing us, and it must still exhaust
+        // the budget. Resetting on the socket opening instead of on READY
+        // would reconnect against it forever — the assertion above cannot see
+        // that difference, because its connections do reach READY.
+        let dpMuteCount = DPCounter()
+        let dpMuteClient = DiscordIPCClient(connect: {
+            var fds: [Int32] = [-1, -1]
+            _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+            var on: Int32 = 1
+            setsockopt(fds[1], SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+            dpMuteCount.value += 1
+            let peer = fds[1]
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.01) { close(peer) }
+            return fds[0]
+        })
+        dpMuteClient.reconnectDelay = 0.01
+        dpMuteClient.start()
+        let dpMuteCap = DiscordIPCClient.maxReconnectAttempts + 1
+        _ = dpWaitUntil { dpMuteCount.value >= dpMuteCap }
+        // Long enough for ~30 more cycles at this delay, short enough not to
+        // pad the suite.
+        for _ in 0..<60 where dpMuteCount.value <= dpMuteCap { usleep(5_000) }
+        dpMuteClient.stop()
+        expect(dpMuteCount.value <= dpMuteCap,
+            "a peer that never reaches READY still exhausts the retry budget (mutation: resetting "
+                + "`attempts` when the socket opens instead of when READY arrives reconnects "
+                + "forever against a peer that accepts and immediately drops)")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -4273,6 +4273,103 @@ enum SelfTest {
                 + "`attempts` when the socket opens instead of when READY arrives reconnects "
                 + "forever against a peer that accepts and immediately drops)")
 
+        // Codex round 1 on the transport PR — four findings that were all the
+        // same root: the lifecycle treated "connected, published, dropped" as
+        // the end of the story instead of something that has to come back.
+
+        // Reconnecting republishes the last activity. Discord restarting is
+        // ordinary; before this the payload was marked sent, `hasPending` went
+        // false, and the READY on the replacement connection flushed nothing —
+        // the presence stayed missing until the producer happened to publish
+        // again, up to the tray's 5-minute poll away.
+        let dpRepubReady = dpFrameBytes(1, "{\"evt\":\"READY\"}")
+        let dpRepubPairs = [dpSocketPair(), dpSocketPair()]
+        let dpRepubIdx = DPCounter()
+        let dpRepubClient = DiscordIPCClient(connect: {
+            let i = min(dpRepubIdx.value, dpRepubPairs.count - 1)
+            dpRepubIdx.value += 1
+            return dpRepubPairs[i].0
+        })
+        dpRepubClient.reconnectDelay = 0.02
+        dpRepubClient.publishInterval = 0
+        dpRepubClient.start()
+        _ = dpWaitUntil { dpRepubClient.isConnectedForTesting }
+        _ = dpRepubReady.withUnsafeBytes { send(dpRepubPairs[0].1, $0.baseAddress, $0.count, 0) }
+        _ = dpWaitUntil { dpRepubClient.inboundTokenForTesting == DiscordIPC.readyEvent }
+        dpRepubClient.publish(dpWirePayload)
+        dpRepubClient.drainForTesting()
+        _ = dpDrainToEOF(dpRepubPairs[0].1)
+        // Break the first connection; the client retries onto the second pair.
+        close(dpRepubPairs[0].1)
+        _ = dpWaitUntil { dpRepubIdx.value >= 2 }
+        _ = dpRepubReady.withUnsafeBytes { send(dpRepubPairs[1].1, $0.baseAddress, $0.count, 0) }
+        dpRepubClient.drainForTesting()
+        // No second `publish()` anywhere: whatever arrives here was resent by
+        // the client itself.
+        var dpRepubSeen = false
+        _ = dpWaitUntil {
+            var buf = dpRecv(dpRepubPairs[1].1)
+            while case .frame(let op, let body) = DiscordIPC.decode(from: &buf) {
+                if op == .frame,
+                   String(decoding: body, as: UTF8.self).contains("12K tokens today") {
+                    dpRepubSeen = true
+                }
+            }
+            return dpRepubSeen
+        }
+        expect(dpRepubSeen,
+            "a replacement connection republishes the last activity without a new publish() "
+                + "(mutation: dropping the READY branch's `hasPending = true` leaves the presence "
+                + "missing until the next producer update)")
+        dpRepubClient.stop()
+        close(dpRepubPairs[1].1)
+
+        // Exhausting the retry budget returns the client to a state a later
+        // start() can act on. Leaving `running` true made start() hit the
+        // idempotence guard and do nothing, so a client started once at launch
+        // could never recover once Discord had been away long enough.
+        let dpDeadCount = DPCounter()
+        let dpDeadClient = DiscordIPCClient(connect: {
+            dpDeadCount.value += 1
+            throw DiscordIPC.Failure.unavailable
+        })
+        dpDeadClient.reconnectDelay = 0.01
+        dpDeadClient.start()
+        let dpDeadCap = DiscordIPCClient.maxReconnectAttempts + 1
+        _ = dpWaitUntil { dpDeadCount.value >= dpDeadCap }
+        for _ in 0..<40 where dpDeadCount.value <= dpDeadCap { usleep(5_000) }
+        let dpDeadBefore = dpDeadCount.value
+        dpDeadClient.start()
+        let dpDeadRestarted = dpWaitUntil { dpDeadCount.value > dpDeadBefore }
+        dpDeadClient.stop()
+        expect(dpDeadBefore == dpDeadCap && dpDeadRestarted,
+            "a client whose retry budget ran out can be started again (mutation: returning from "
+                + "scheduleReconnect without giveUp() leaves `running` true and the second start() "
+                + "silently does nothing)")
+
+        // A peer that accepts and then says nothing must not hold the client
+        // forever. SO_RCVTIMEO cannot see this — the read source never fires on
+        // an idle socket, so no recv() runs and its timeout is never observed.
+        let dpMuteReadyCount = DPCounter()
+        let dpMuteReadyClient = DiscordIPCClient(connect: {
+            var fds: [Int32] = [-1, -1]
+            _ = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+            var on: Int32 = 1
+            setsockopt(fds[1], SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+            dpMuteReadyCount.value += 1
+            // The peer end is deliberately never closed and never written to.
+            return fds[0]
+        })
+        dpMuteReadyClient.reconnectDelay = 0.01
+        dpMuteReadyClient.readyTimeout = 0.05
+        dpMuteReadyClient.start()
+        let dpMuteReadyRetried = dpWaitUntil { dpMuteReadyCount.value >= 2 }
+        dpMuteReadyClient.stop()
+        expect(dpMuteReadyRetried,
+            "a silent endpoint trips the READY deadline and is retried (mutation: removing "
+                + "armReadyDeadline leaves the client connected-but-never-ready forever, with "
+                + "every publish parked behind `ready`)")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -4589,6 +4589,20 @@ enum SelfTest {
             "an identical payload on the same connection is not sent twice (mutation: dropping "
                 + "the deliveredOnThisConnection check resends it immediately, past the floor)")
 
+        // Codex round 4 — the connect path itself, which every earlier round
+        // had treated as a detail that either works or throws.
+
+        // Close-on-exec from birth. The previous round set the flag after
+        // `connectFD()` returned, which left `socket()` and `connect()` inside
+        // the window an exec can inherit through — and `connect()` is exactly
+        // the call the next assertion shows can take a while.
+        let dpBornFD = DiscordIPC.makeSocket()
+        let dpBornFlags = fcntl(dpBornFD, F_GETFD)
+        close(dpBornFD)
+        expect(dpBornFD >= 0 && (dpBornFlags & FD_CLOEXEC) != 0,
+            "the socket is close-on-exec before connect() runs (mutation: moving the fcntl back "
+                + "out of makeSocket leaves the whole connect window inheritable)")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3795,6 +3795,16 @@ enum SelfTest {
             let count = recv(fd, &buf, buf.count, 0)
             return count > 0 ? Data(buf[0..<count]) : Data()
         }
+        /// Non-blocking, unlike `dpRecv`. The peer ends carry `SO_RCVTIMEO` of
+        /// one second, so a poll loop built on the blocking read spends up to a
+        /// second per turn and can outlast the very delay it is trying to
+        /// detect — which is exactly how a throttle assertion ends up unable to
+        /// fail.
+        func dpRecvNow(_ fd: Int32) -> Data {
+            var buf = [UInt8](repeating: 0, count: 4096)
+            let count = recv(fd, &buf, buf.count, MSG_DONTWAIT)
+            return count > 0 ? Data(buf[0..<count]) : Data()
+        }
         func dpDrainToEOF(_ fd: Int32) -> Data {
             var out = Data()
             while true {
@@ -4291,7 +4301,11 @@ enum SelfTest {
             return dpRepubPairs[i].0
         })
         dpRepubClient.reconnectDelay = 0.02
-        dpRepubClient.publishInterval = 0
+        // Deliberately high: a restore re-sends bytes Discord already has, so
+        // it must not queue behind the sampling floor. With the throttle
+        // applied to it, this frame would arrive 30s late and the wait below
+        // would time out.
+        dpRepubClient.publishInterval = 30
         dpRepubClient.start()
         _ = dpWaitUntil { dpRepubClient.isConnectedForTesting }
         _ = dpRepubReady.withUnsafeBytes { send(dpRepubPairs[0].1, $0.baseAddress, $0.count, 0) }
@@ -4369,6 +4383,106 @@ enum SelfTest {
             "a silent endpoint trips the READY deadline and is retried (mutation: removing "
                 + "armReadyDeadline leaves the client connected-but-never-ready forever, with "
                 + "every publish parked behind `ready`)")
+
+        // Codex round 2 — both findings are consequences of round 1's fixes.
+
+        // The kill switch clears the queued payload even when the retry budget
+        // already gave up. `giveUp()` keeps `pending` on purpose so a later
+        // start() can restore, and `stop()` used to bail on `!running`, which
+        // left that payload alive to be republished after the user turned the
+        // feature off.
+        let dpAbandonReady = dpFrameBytes(1, "{\"evt\":\"READY\"}")
+        let dpAbandonPairs = [dpSocketPair(), dpSocketPair()]
+        // The counter doubles as the fixture's mode: 0 hands out the first
+        // socket, anything below `dpAbandonRevive` fails so the budget is
+        // genuinely exhausted, and the test raises it later to let the second
+        // start() connect. An earlier version simply indexed the pair array,
+        // which handed out the second socket on the first retry and never
+        // reached the given-up state the assertion is about.
+        let dpAbandonIdx = DPCounter()
+        let dpAbandonRevive = DPCounter()
+        dpAbandonRevive.value = 1_000_000
+        let dpAbandonClient = DiscordIPCClient(connect: {
+            let i = dpAbandonIdx.value
+            dpAbandonIdx.value += 1
+            if i == 0 { return dpAbandonPairs[0].0 }
+            guard i >= dpAbandonRevive.value else { throw DiscordIPC.Failure.unavailable }
+            return dpAbandonPairs[1].0
+        })
+        dpAbandonClient.reconnectDelay = 0.01
+        dpAbandonClient.publishInterval = 0
+        dpAbandonClient.start()
+        _ = dpWaitUntil { dpAbandonClient.isConnectedForTesting }
+        _ = dpAbandonReady.withUnsafeBytes { send(dpAbandonPairs[0].1, $0.baseAddress, $0.count, 0) }
+        _ = dpWaitUntil { dpAbandonClient.inboundTokenForTesting == DiscordIPC.readyEvent }
+        dpAbandonClient.publish(dpWirePayload)
+        dpAbandonClient.drainForTesting()
+        _ = dpDrainToEOF(dpAbandonPairs[0].1)
+        // Drop the connection and let every remaining attempt fail, so the
+        // client reaches the given-up state with `pending` still set.
+        close(dpAbandonPairs[0].1)
+        _ = dpWaitUntil { dpAbandonIdx.value > DiscordIPCClient.maxReconnectAttempts + 1 }
+        // The user turns the feature off while it is in that state.
+        dpAbandonClient.stop()
+        dpAbandonClient.drainForTesting()
+        // Now start again on the second socket and see whether the abandoned
+        // payload comes back.
+        dpAbandonRevive.value = dpAbandonIdx.value
+        dpAbandonClient.start()
+        _ = dpWaitUntil { dpAbandonClient.isConnectedForTesting }
+        _ = dpAbandonReady.withUnsafeBytes { send(dpAbandonPairs[1].1, $0.baseAddress, $0.count, 0) }
+        dpAbandonClient.drainForTesting()
+        var dpAbandonRepublished = false
+        for _ in 0..<60 where !dpAbandonRepublished {
+            var buf = dpRecvNow(dpAbandonPairs[1].1)
+            while case .frame(let op, let body) = DiscordIPC.decode(from: &buf) {
+                if op == .frame,
+                   String(decoding: body, as: UTF8.self).contains("12K tokens today") {
+                    dpAbandonRepublished = true
+                }
+            }
+            usleep(5_000)
+        }
+        dpAbandonClient.stop()
+        close(dpAbandonPairs[1].1)
+        expect(!dpAbandonRepublished,
+            "stop() clears the payload the retry give-up kept, so a later start() does not "
+                + "resurrect it (mutation: restoring stop()'s `guard running else { return }` "
+                + "republishes an activity the user already switched off)")
+
+        // A clear is not a new sample, so it must not queue behind the
+        // sampling floor: delaying one keeps a stale presence public for up to
+        // the whole interval after the user hid the clients that produced it.
+        let dpClearReady = dpFrameBytes(1, "{\"evt\":\"READY\"}")
+        let dpClearPair = dpSocketPair()
+        let dpClearClient = DiscordIPCClient(connect: { dpClearPair.0 })
+        dpClearClient.publishInterval = 30
+        dpClearClient.start()
+        _ = dpWaitUntil { dpClearClient.isConnectedForTesting }
+        _ = dpClearReady.withUnsafeBytes { send(dpClearPair.1, $0.baseAddress, $0.count, 0) }
+        _ = dpWaitUntil { dpClearClient.inboundTokenForTesting == DiscordIPC.readyEvent }
+        dpClearClient.publish(dpWirePayload)
+        dpClearClient.drainForTesting()
+        _ = dpDrainToEOF(dpClearPair.1)
+        dpClearClient.publish(nil)
+        dpClearClient.drainForTesting()
+        var dpClearSent = false
+        for _ in 0..<60 where !dpClearSent {
+            var buf = dpRecvNow(dpClearPair.1)
+            while case .frame(let op, let body) = DiscordIPC.decode(from: &buf) {
+                if op == .frame,
+                   String(decoding: body, as: UTF8.self).contains("\"activity\":null") {
+                    dpClearSent = true
+                }
+            }
+            usleep(5_000)
+        }
+        dpClearClient.stop()
+        close(dpClearPair.1)
+        expect(dpClearSent,
+            "a clear goes out immediately rather than waiting for the publish floor (mutation: "
+                + "throttling it unconditionally leaves a stale presence public for the whole "
+                + "interval after the user hid everything)")
 
         if failures > 0 {
             print("\(failures) selftest check(s) failed")

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -4484,6 +4484,111 @@ enum SelfTest {
                 + "throttling it unconditionally leaves a stale presence public for the whole "
                 + "interval after the user hid everything)")
 
+        // Codex round 3 — user intent vs connection state, descriptor
+        // inheritance, and the duplicate that round 2's throttle bypass let in.
+
+        // A producer update while the retry budget is spent is still the
+        // latest intent, and the client is what a later start() must restore.
+        // `giveUp()` used to clear `running`, so `publish()` dropped it and the
+        // reconnect resurrected the pre-give-up payload instead.
+        let dpIntentReady = dpFrameBytes(1, "{\"evt\":\"READY\"}")
+        let dpIntentPairs = [dpSocketPair(), dpSocketPair()]
+        let dpIntentIdx = DPCounter()
+        let dpIntentRevive = DPCounter()
+        dpIntentRevive.value = 1_000_000
+        let dpIntentClient = DiscordIPCClient(connect: {
+            let i = dpIntentIdx.value
+            dpIntentIdx.value += 1
+            if i == 0 { return dpIntentPairs[0].0 }
+            guard i >= dpIntentRevive.value else { throw DiscordIPC.Failure.unavailable }
+            return dpIntentPairs[1].0
+        })
+        dpIntentClient.reconnectDelay = 0.01
+        dpIntentClient.publishInterval = 0
+        dpIntentClient.start()
+        _ = dpWaitUntil { dpIntentClient.isConnectedForTesting }
+        _ = dpIntentReady.withUnsafeBytes { send(dpIntentPairs[0].1, $0.baseAddress, $0.count, 0) }
+        _ = dpWaitUntil { dpIntentClient.inboundTokenForTesting == DiscordIPC.readyEvent }
+        dpIntentClient.publish(dpWirePayload)
+        dpIntentClient.drainForTesting()
+        _ = dpDrainToEOF(dpIntentPairs[0].1)
+        close(dpIntentPairs[0].1)
+        _ = dpWaitUntil { dpIntentIdx.value > DiscordIPCClient.maxReconnectAttempts + 1 }
+        // The producer moves on while the client is abandoned.
+        let dpIntentNewer = DiscordPresence.Payload(
+            details: "77K tokens today", state: "Zed · $1-5", largeImageKey: "tokenbar")
+        dpIntentClient.publish(dpIntentNewer)
+        dpIntentRevive.value = dpIntentIdx.value
+        dpIntentClient.start()
+        _ = dpWaitUntil { dpIntentClient.isConnectedForTesting }
+        _ = dpIntentReady.withUnsafeBytes { send(dpIntentPairs[1].1, $0.baseAddress, $0.count, 0) }
+        dpIntentClient.drainForTesting()
+        var dpIntentGotNewer = false
+        var dpIntentGotStale = false
+        for _ in 0..<60 where !dpIntentGotNewer {
+            var buf = dpRecvNow(dpIntentPairs[1].1)
+            while case .frame(let op, let body) = DiscordIPC.decode(from: &buf) {
+                let text = String(decoding: body, as: UTF8.self)
+                if op == .frame, text.contains("77K tokens today") { dpIntentGotNewer = true }
+                if op == .frame, text.contains("12K tokens today") { dpIntentGotStale = true }
+            }
+            usleep(5_000)
+        }
+        dpIntentClient.stop()
+        close(dpIntentPairs[1].1)
+        expect(dpIntentGotNewer && !dpIntentGotStale,
+            "a publish while the retries are spent is the intent a later start() restores "
+                + "(mutation: having giveUp() clear `running` makes publish() drop it and the "
+                + "reconnect republishes the pre-give-up payload)")
+
+        // The socket must not survive into a child process. The Rust core
+        // spawns helpers, and an inherited descriptor keeps Discord seeing a
+        // connection this app has already torn down.
+        let dpCloexecPair = dpSocketPair()
+        let dpCloexecClient = DiscordIPCClient(connect: { dpCloexecPair.0 })
+        dpCloexecClient.start()
+        _ = dpWaitUntil { dpCloexecClient.isConnectedForTesting }
+        let dpCloexecFlags = fcntl(dpCloexecPair.0, F_GETFD)
+        dpCloexecClient.stop()
+        close(dpCloexecPair.1)
+        expect(dpCloexecFlags >= 0 && (dpCloexecFlags & FD_CLOEXEC) != 0,
+            "the adopted socket is close-on-exec (mutation: dropping the fcntl leaks the "
+                + "connection into every helper the Rust core spawns)")
+
+        // Publishing the same payload twice on one connection sends it once.
+        // Round 2's throttle bypass is for restores; without a per-connection
+        // record it also let a duplicate through immediately, which resets the
+        // floor's clock and delays the next real payload behind a no-op.
+        let dpDupReady = dpFrameBytes(1, "{\"evt\":\"READY\"}")
+        let dpDupPair = dpSocketPair()
+        let dpDupClient = DiscordIPCClient(connect: { dpDupPair.0 })
+        dpDupClient.publishInterval = 0
+        dpDupClient.start()
+        _ = dpWaitUntil { dpDupClient.isConnectedForTesting }
+        _ = dpDupReady.withUnsafeBytes { send(dpDupPair.1, $0.baseAddress, $0.count, 0) }
+        _ = dpWaitUntil { dpDupClient.inboundTokenForTesting == DiscordIPC.readyEvent }
+        dpDupClient.publish(dpWirePayload)
+        dpDupClient.drainForTesting()
+        _ = dpDrainToEOF(dpDupPair.1)
+        dpDupClient.publish(dpWirePayload)
+        dpDupClient.drainForTesting()
+        var dpDupResent = false
+        for _ in 0..<40 where !dpDupResent {
+            var buf = dpRecvNow(dpDupPair.1)
+            while case .frame(let op, let body) = DiscordIPC.decode(from: &buf) {
+                if op == .frame,
+                   String(decoding: body, as: UTF8.self).contains("12K tokens today") {
+                    dpDupResent = true
+                }
+            }
+            usleep(5_000)
+        }
+        dpDupClient.stop()
+        close(dpDupPair.1)
+        expect(!dpDupResent,
+            "an identical payload on the same connection is not sent twice (mutation: dropping "
+                + "the deliveredOnThisConnection check resends it immediately, past the floor)")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -4603,6 +4603,73 @@ enum SelfTest {
             "the socket is close-on-exec before connect() runs (mutation: moving the fcntl back "
                 + "out of makeSocket leaves the whole connect window inheritable)")
 
+        // Codex round 5 — the bypass skipped the floor but still moved its
+        // clock, so a restore delayed the next real payload by a full
+        // interval measured from the restore instead of from the last sample.
+        let dpFloorReady = dpFrameBytes(1, "{\"evt\":\"READY\"}")
+        let dpFloorPairs = [dpSocketPair(), dpSocketPair()]
+        let dpFloorIdx = DPCounter()
+        let dpFloorClient = DiscordIPCClient(connect: {
+            let i = min(dpFloorIdx.value, dpFloorPairs.count - 1)
+            dpFloorIdx.value += 1
+            return dpFloorPairs[i].0
+        })
+        dpFloorClient.reconnectDelay = 0.02
+        dpFloorClient.publishInterval = 1.0
+        dpFloorClient.start()
+        _ = dpWaitUntil { dpFloorClient.isConnectedForTesting }
+        _ = dpFloorReady.withUnsafeBytes { send(dpFloorPairs[0].1, $0.baseAddress, $0.count, 0) }
+        _ = dpWaitUntil { dpFloorClient.inboundTokenForTesting == DiscordIPC.readyEvent }
+        dpFloorClient.publish(dpWirePayload)
+        dpFloorClient.drainForTesting()
+        _ = dpDrainToEOF(dpFloorPairs[0].1)
+        // Let the interval elapse against the real sample, so the payload that
+        // follows the restore is due immediately if the clock was left alone.
+        usleep(1_200_000)
+        close(dpFloorPairs[0].1)
+        _ = dpWaitUntil { dpFloorIdx.value >= 2 }
+        _ = dpFloorReady.withUnsafeBytes { send(dpFloorPairs[1].1, $0.baseAddress, $0.count, 0) }
+        // Wait for the restore to actually reach the socket before publishing
+        // the next payload. `drainForTesting` only syncs the queue, and the
+        // READY read event may not be on it yet — publishing early lets the
+        // new payload flush before the restore ever runs, at which point both
+        // the fixed and the broken build send it immediately and the
+        // assertion measures nothing.
+        var dpFloorRestored = false
+        for _ in 0..<200 where !dpFloorRestored {
+            var buf = dpRecvNow(dpFloorPairs[1].1)
+            while case .frame(let op, let body) = DiscordIPC.decode(from: &buf) {
+                if op == .frame,
+                   String(decoding: body, as: UTF8.self).contains("12K tokens today") {
+                    dpFloorRestored = true
+                }
+            }
+            usleep(5_000)
+        }
+        let dpFloorNewer = DiscordPresence.Payload(
+            details: "55K tokens today", state: "Amp · $5-10", largeImageKey: "tokenbar")
+        dpFloorClient.publish(dpFloorNewer)
+        dpFloorClient.drainForTesting()
+        // 400ms: comfortably under the 1s the buggy path would defer by, and
+        // comfortably over the time a due payload needs to reach the socket.
+        var dpFloorPrompt = false
+        for _ in 0..<80 where !dpFloorPrompt {
+            var buf = dpRecvNow(dpFloorPairs[1].1)
+            while case .frame(let op, let body) = DiscordIPC.decode(from: &buf) {
+                if op == .frame,
+                   String(decoding: body, as: UTF8.self).contains("55K tokens today") {
+                    dpFloorPrompt = true
+                }
+            }
+            usleep(5_000)
+        }
+        dpFloorClient.stop()
+        close(dpFloorPairs[1].1)
+        expect(dpFloorRestored && dpFloorPrompt,
+            "a restore does not consume the publish interval (mutation: advancing lastSent on a "
+                + "write that carries no new information throttles the next real payload from the "
+                + "restore instead of from the last sample)")
+
         if failures > 0 {
             print("\(failures) selftest check(s) failed")
             exit(1)


### PR DESCRIPTION
Second milestone of the Discord Rich Presence slice. The first shipped the pure payload builder — *what* may be published. This is *how it would travel*: a Unix-domain socket client for `$TMPDIR/discord-ipc-0`, the frame codec, the activity serializer and the connection lifecycle.

**Nothing calls it.** `grep` for `DiscordIPCClient` outside this file and SelfTest returns nothing, so the app's behaviour is byte-for-byte unchanged and no byte leaves the machine. The opt-in switch, the demo/test connection gate and the AppDelegate wiring are the next milestone — and that is where the P0 lives. Splitting it this way keeps parser hardening and crash safety, all of it hermetically testable, from being reviewed in the same breath as a UI toggle.

## Transport

Frames are a 4-byte LE opcode, a 4-byte LE length and a JSON body. `decode` bound-checks the length against a 64 KiB cap **before** any allocation is sized from it, accepts only opcodes 0–4, returns `needMore` without consuming when the buffer is short, and silently discards a body that is not valid JSON. `JSONSerialization` already rejects non-UTF-8, so a separate encoding check would have been an unreachable guard.

The lifecycle is one serial queue holding all mutable state, reads driven by a `DispatchSource` rather than a parked thread. `start()` is idempotent; `stop()` is a single kill switch that cancels every scheduled wake-up, sends `activity: null`, and only then closes the socket. Retries back off 30s and are bounded — Discord not running is the ordinary case, not an error worth an immortal background loop.

## `SO_NOSIGPIPE` fails, silently, and it is not hypothetical

Darwin refuses `setsockopt(SO_NOSIGPIPE)` on a socket whose peer has already gone away: it returns `-1/EINVAL` and leaves the option **off**. The next `send` then kills the whole process with SIGPIPE.

Confirmed with a standalone C probe:

| | `setsockopt` | readback | later `send` |
|---|---|---|---|
| peer alive | `rc=0` | `1` | `EPIPE`, process intact |
| peer already closed | `rc=-1 EINVAL` | **`0`** | **SIGPIPE, exit 141** |

Discord quitting between `connect()` and `setsockopt()` reaches exactly that window, so the return value is checked and a socket that could not be made SIGPIPE-safe is dropped and retried rather than written to.

That acceptance is also the one whose failure mode is not a FAIL line: with the option removed the selftest binary is killed mid-run — non-zero exit, truncated stdout, **zero FAILs**. `make`'s exit code is what carries it; a gate that only greps for `FAIL` would miss it.

## What five rounds of review taught

Independent review refuted the assertion suite **four times**, each time finding a channel the previous fix did not cover. Every one was a future regression rather than a live leak, and each is now closed with a mutation that reddens it.

| # | The channel | Why the previous fix missed it |
|---|---|---|
| 1 | field names | the scan read **values**; a `startTimestamp`'s value is a bare epoch number, never the word |
| 2 | computed properties | `Mirror` reflects stored properties only |
| 3 | duplicate values | comparing leaves as a `Set` **erases multiplicity** |
| 4 | key names | sorted leaves still ignore keys, and an empty container has no leaves — `"x-<hostname>": [:]` shipped the host name |
| 5 | **argument provenance** | frames were only ever built with literal arguments, so `pid()` and `nonce()` — which supply every real frame — were executed by **no assertion at all** |

Round 5 is the one worth remembering: a `nonce()` returning `NSUserName() + "@" + hostName` published the username and this machine's reverse-DNS name with everything green. The suite now pins the keys and leaves of bytes recovered from a **real socket**, not just of a pure-function call. Guarding a serializer is not guarding what it is called with.

`handshakeJSON` and the clear frame are pinned the same way. They leave the machine too, and had no assertions at all while the activity frame was being tightened four times over. Every outbound frame is now covered: handshake, activity, clear, and pong (which echoes the peer's own already-validated bytes back to the peer that sent them, adding nothing local).

## Also from review

**`openConnection` makes "no live connection here" true rather than guarding it.** Reaching it with an open descriptor would overwrite `fd` and `source` without cancelling the old source, leaking the descriptor while libdispatch kept firing on it. A precondition, not a second guard — two guards for one invariant leave neither provable on its own.

**The retry budget resets when a connection reaches READY, not when the socket opens.** Resetting on the open would reconnect forever against a peer that accepts and immediately drops. Both assertions are needed: one shows the reset exists, and only a peer that *never* answers READY shows it happens at the right moment.

**The superseded-socket check reads the peer's EOF, not the descriptor number** — numbers are reused, so a closed fd's number can belong to the new socket by the time it is examined.

## Verification

Assertions 516 → **529**, appended as one hunk per the coordination contract with the branch working the same file.

`make build`, `make selftest` (529 ok / 0 FAIL, stable over five consecutive runs), `swift build -c release`, `swift run TokenBar --smoke` with `trayDrift` matching.

## Known limits

- **Completeness of the privacy suite is not proven, only advanced.** Five channels were found and closed; a sixth is not ruled out. The structural answer — an outbound allowlist where anything not explicitly listed cannot be sent — belongs in the next milestone, where there is a transport actually being called for it to guard.
- A same-user process squatting on `$TMPDIR/discord-ipc-0` that answers READY and drops can keep the reconnect loop alive indefinitely. Inherent to any reset-on-success policy, and the threat model already assumes that squatter.
