### PR TITLE
feat(discord): a one-time card so the feature is findable

### DIFF
--- a/Sources/TokenBar/AppDelegate.swift
+++ b/Sources/TokenBar/AppDelegate.swift
@@ -112,6 +112,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // Deferred like the other launch-time windows: an alert racing the
+        // status item's first render fights it for the main runloop turn.
+        // Gated on the same demo/test arguments the connection is, so an
+        // `--icon-gallery` or `--demo` run never interrupts with it.
+        if DiscordPresence.mayConnect(arguments: CommandLine.arguments, enabled: true) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                DiscordIntro.presentIfNeeded()
+            }
+        }
         lastDiscordEnabled = DiscordPresence.enabled()
         lastCostStyle = DiscordPresence.costStyle()
         lastComponents = DiscordPresence.components()

--- a/Sources/TokenBar/DiscordIntro.swift
+++ b/Sources/TokenBar/DiscordIntro.swift
@@ -1,0 +1,86 @@
+import AppKit
+import TokenBarCore
+
+/// The one-time card that makes the Discord Rich Presence feature findable.
+///
+/// It exists because the feature is default-off and lives inside a Settings
+/// section nobody has a reason to open. It does **not** enable anything, and
+/// there is deliberately no path from here to on: the only route is the
+/// Settings toggle, because that is where the full disclosure is. A card with
+/// an enable button collects consent against the card's three sentences
+/// instead of against the disclosure — which is the dark pattern this exists
+/// to avoid, not a shortcut around it.
+///
+/// The motivation for building this feature and the user's privacy interest
+/// point in opposite directions, and this card is where that conflict lands.
+/// So it describes what the feature does and never what the project gets from
+/// it, and it is not shorter or friendlier than the disclosure in a way the
+/// disclosure would then have to argue against.
+enum DiscordIntro {
+    /// Set when the card is PRESENTED, not when it is acted on.
+    ///
+    /// Writing it only on the preferred action means the card returns until
+    /// the user complies. Dismiss, Esc, and quitting while it is on screen all
+    /// count as shown.
+    ///
+    /// Deliberately **not** versioned. A versioned flag turns every release
+    /// into a fresh consent-adjacent interruption — a reusable notification
+    /// channel pointed at the user, which is a different product than a
+    /// one-time introduction.
+    static let shownKey = "tokenbar.discord.introShown"
+
+    /// Once, ever, and never to someone already using the feature: there is
+    /// nothing to introduce, and interrupting them would be pure noise.
+    ///
+    /// `object(forKey:) as? Bool` rather than `bool(forKey:)` for the same
+    /// reason the switch itself uses it — the two should not read their own
+    /// preferences by different rules.
+    static func shouldPresent(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: shownKey) as? Bool != true else { return false }
+        return !DiscordPresence.enabled(defaults: defaults)
+    }
+
+    static func markShown(defaults: UserDefaults = .standard) {
+        defaults.set(true, forKey: shownKey)
+    }
+
+    /// What the two buttons do. Neither writes `DiscordPresence.enabledKey`,
+    /// and that is the contract the assertion pins: opening Settings is a
+    /// navigation, not a consent.
+    enum Choice {
+        case openSettings
+        case notNow
+    }
+
+    /// Separated from the AppKit presentation so the contract is reachable
+    /// without an app lifecycle — `SelfTest.run()` returns `Never` before
+    /// `NSApplication.shared` exists, and a rule that lives only inside a
+    /// modal callback cannot be asserted at all.
+    static func perform(_ choice: Choice, openSettings: () -> Void) {
+        switch choice {
+        case .openSettings: openSettings()
+        case .notNow: break
+        }
+    }
+
+    @MainActor
+    static func presentIfNeeded() {
+        guard shouldPresent() else { return }
+        // Before the modal runs, not after: quitting while it is up counts.
+        markShown()
+
+        let alert = NSAlert()
+        alert.messageText = "Show today's usage on Discord".localized
+        alert.informativeText = "TokenBar can publish today's tokens, a client name and a cost range to your Discord profile. It stays off until you turn it on in Settings, where the full disclosure is. Anyone who can see your profile can read and keep every update, and switching it off later cannot unshare what already went out.".localized
+        let settings = alert.addButton(withTitle: "Open Settings".localized)
+        let notNow = alert.addButton(withTitle: "Not now".localized)
+        // Neither button is the default. A filled, Return-bound button next to
+        // a plain one is a thumb on the scale, and the whole point of this card
+        // is that it does not have one. Esc closes, as it must.
+        settings.keyEquivalent = ""
+        notNow.keyEquivalent = "\u{1b}"
+
+        let choice: Choice = alert.runModal() == .alertFirstButtonReturn ? .openSettings : .notNow
+        perform(choice) { SettingsWindowController.shared.show() }
+    }
+}

--- a/Sources/TokenBar/DiscordIntro.swift
+++ b/Sources/TokenBar/DiscordIntro.swift
@@ -36,8 +36,17 @@ enum DiscordIntro {
     /// `object(forKey:) as? Bool` rather than `bool(forKey:)` for the same
     /// reason the switch itself uses it — the two should not read their own
     /// preferences by different rules.
-    static func shouldPresent(defaults: UserDefaults = .standard) -> Bool {
+    /// Whether to present — and it CONSUMES the one-time flag either way.
+    ///
+    /// Folding the decision and the marking together is what makes "once,
+    /// ever" true on the upgrade path. Someone who already had the feature on
+    /// when this card shipped has nothing to be introduced to, so they do not
+    /// see it; but if the flag were left unwritten, switching Discord off later
+    /// would introduce them to a feature they had used and deliberately turned
+    /// off. Skipping is a consumption, not a deferral.
+    static func consume(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: shownKey) as? Bool != true else { return false }
+        markShown(defaults: defaults)
         return !DiscordPresence.enabled(defaults: defaults)
     }
 
@@ -87,9 +96,9 @@ enum DiscordIntro {
 
     @MainActor
     static func presentIfNeeded() {
-        guard shouldPresent() else { return }
-        // Before the modal runs, not after: quitting while it is up counts.
-        markShown()
+        // Consumed here, before the modal runs: quitting while the card is up
+        // counts as shown, and so does skipping it for an existing user.
+        guard consume() else { return }
 
         let alert = NSAlert()
         alert.messageText = "Show today's usage on Discord".localized

--- a/Sources/TokenBar/DiscordIntro.swift
+++ b/Sources/TokenBar/DiscordIntro.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import TokenBarCore
 
 /// The one-time card that makes the Discord Rich Presence feature findable.
@@ -63,6 +64,27 @@ enum DiscordIntro {
         }
     }
 
+    /// A mock of the activity itself. Text alone made the card read as a
+    /// warning about a feature rather than an introduction to one, and a
+    /// picture of the actual thing is also the more honest surface: seeing the
+    /// four lines that would appear says more than a sentence describing them.
+    ///
+    /// Representative values, labelled as a preview. Not the user's real
+    /// figures — the graph has not necessarily loaded 1.5s after launch, and a
+    /// card that showed a number and then published a different one would be
+    /// worse than one that showed none.
+    @MainActor
+    private static func previewView() -> NSView {
+        let preview = DiscordPresencePreview(
+            title: "TokenBar".localized,
+            details: "1.2M tokens today".localized,
+            state: "Claude Code · $10-50".localized,
+            button: DiscordIPC.buttonLabel.localized)
+        let host = NSHostingView(rootView: preview)
+        host.frame = NSRect(x: 0, y: 0, width: 300, height: 104)
+        return host
+    }
+
     @MainActor
     static func presentIfNeeded() {
         guard shouldPresent() else { return }
@@ -71,7 +93,8 @@ enum DiscordIntro {
 
         let alert = NSAlert()
         alert.messageText = "Show today's usage on Discord".localized
-        alert.informativeText = "TokenBar can publish today's tokens, a client name and a cost range to your Discord profile. It stays off until you turn it on in Settings, where the full disclosure is. Anyone who can see your profile can read and keep every update, and switching it off later cannot unshare what already went out.".localized
+        alert.informativeText = "Your Discord profile can show what you have been building today. Pick exactly what appears — or nothing at all — in Settings.".localized
+        alert.accessoryView = previewView()
         let settings = alert.addButton(withTitle: "Open Settings".localized)
         let notNow = alert.addButton(withTitle: "Not now".localized)
         // Neither button is the default. A filled, Return-bound button next to
@@ -81,6 +104,48 @@ enum DiscordIntro {
         notNow.keyEquivalent = "\u{1b}"
 
         let choice: Choice = alert.runModal() == .alertFirstButtonReturn ? .openSettings : .notNow
-        perform(choice) { SettingsWindowController.shared.show() }
+        perform(choice) { SettingsWindowController.shared.show(scrollingTo: .discord) }
+    }
+}
+
+/// What the presence looks like on a profile, laid out the way Discord lays it
+/// out: art on the left, the app name, then `details` and `state`, with the
+/// button underneath.
+private struct DiscordPresencePreview: View {
+    let title: String
+    let details: String
+    let state: String
+    let button: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            // The app's own icon, because that is literally what Discord
+            // shows: `largeImageKey` resolves to the TokenBar art uploaded to
+            // the Developer Portal. A stand-in symbol would make the preview
+            // decorative rather than accurate.
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 56, height: 56)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.system(size: 12, weight: .bold))
+                Text(details).font(.system(size: 11))
+                Text(state).font(.system(size: 11)).foregroundStyle(.secondary)
+                Text(button)
+                    .font(.system(size: 10, weight: .medium))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4).fill(Color.secondary.opacity(0.18)))
+                    .padding(.top, 3)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.secondary.opacity(0.10)))
+        .frame(width: 300, alignment: .leading)
     }
 }

--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -217,7 +217,9 @@
 "Show today's usage on Discord" = "在 Discord 顯示今日用量";
 "Open Settings" = "開啟設定";
 "Not now" = "暫時不要";
-"TokenBar can publish today's tokens, a client name and a cost range to your Discord profile. It stays off until you turn it on in Settings, where the full disclosure is. Anyone who can see your profile can read and keep every update, and switching it off later cannot unshare what already went out." = "TokenBar 可以把今日 token 數、用戶端名稱與花費級距發布到你的 Discord 個人檔案。在你到設定裡開啟之前都是關閉的，完整說明也在那裡。任何看得到你檔案的人都能讀取並保存每一次更新，之後關閉也無法收回已經送出的內容。";
+"1.2M tokens today" = "今日 1.2M token";
+"Claude Code · $10-50" = "Claude Code · $10-50";
+"Your Discord profile can show what you have been building today. Pick exactly what appears — or nothing at all — in Settings." = "你的 Discord 個人檔案可以顯示你今天在做什麼。要顯示哪些內容——或什麼都不顯示——都在設定裡挑。";
 "Off by default. Publishes what you pick below — today's tokens, a client name, a cost range or rounded figure — for whichever client you choose, and a link to TokenBar's source to your Discord profile. It updates while you work, so your active hours show too. Anyone who can see your profile can read and keep every update; switching this off stops new ones but cannot unshare what already went out. Hidden clients are never included, and a change here reaches your profile within about 15 seconds." = "預設關閉。會把你在下方勾選的內容——今日 token 數、用戶端名稱、花費級距或取整金額——依你指定的用戶端，連同一個 TokenBar 原始碼連結，發布到你的 Discord 個人檔案。工作時會持續更新，因此活動時段也會曝光。任何看得到你檔案的人都能讀取並保存每一次更新；關閉只會停止後續更新，無法收回已經送出的內容。已隱藏的用戶端不會送出；在這裡做的變更約 15 秒內反映到你的個人檔案。";
 "Include today's tokens" = "包含今日 token 數";
 "Include the client name" = "包含用戶端名稱";

--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -215,6 +215,9 @@
 "Check Now" = "立即檢查";
 "Receive beta updates" = "接收 beta 版更新";
 "Show today's usage on Discord" = "在 Discord 顯示今日用量";
+"Open Settings" = "開啟設定";
+"Not now" = "暫時不要";
+"TokenBar can publish today's tokens, a client name and a cost range to your Discord profile. It stays off until you turn it on in Settings, where the full disclosure is. Anyone who can see your profile can read and keep every update, and switching it off later cannot unshare what already went out." = "TokenBar 可以把今日 token 數、用戶端名稱與花費級距發布到你的 Discord 個人檔案。在你到設定裡開啟之前都是關閉的，完整說明也在那裡。任何看得到你檔案的人都能讀取並保存每一次更新，之後關閉也無法收回已經送出的內容。";
 "Off by default. Publishes what you pick below — today's tokens, a client name, a cost range or rounded figure — for whichever client you choose, and a link to TokenBar's source to your Discord profile. It updates while you work, so your active hours show too. Anyone who can see your profile can read and keep every update; switching this off stops new ones but cannot unshare what already went out. Hidden clients are never included, and a change here reaches your profile within about 15 seconds." = "預設關閉。會把你在下方勾選的內容——今日 token 數、用戶端名稱、花費級距或取整金額——依你指定的用戶端，連同一個 TokenBar 原始碼連結，發布到你的 Discord 個人檔案。工作時會持續更新，因此活動時段也會曝光。任何看得到你檔案的人都能讀取並保存每一次更新；關閉只會停止後續更新，無法收回已經送出的內容。已隱藏的用戶端不會送出；在這裡做的變更約 15 秒內反映到你的個人檔案。";
 "Include today's tokens" = "包含今日 token 數";
 "Include the client name" = "包含用戶端名稱";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -4075,11 +4075,11 @@ enum SelfTest {
         let dpIntroSuite = "TokenBar.SelfTest.DiscordIntro"
         if let dpIntroDefaults = UserDefaults(suiteName: dpIntroSuite) {
             defer { UserDefaults.standard.removePersistentDomain(forName: dpIntroSuite) }
-            let dpIntroFirst = DiscordIntro.shouldPresent(defaults: dpIntroDefaults)
-            // Presentation is what marks it, not the choice: a card that
-            // returns until the user picks the preferred action is a nag.
-            DiscordIntro.markShown(defaults: dpIntroDefaults)
-            let dpIntroAgain = DiscordIntro.shouldPresent(defaults: dpIntroDefaults)
+            // Deciding CONSUMES the flag: presentation is what marks it, not
+            // the choice, so a card that returns until the user picks the
+            // preferred action is impossible.
+            let dpIntroFirst = DiscordIntro.consume(defaults: dpIntroDefaults)
+            let dpIntroAgain = DiscordIntro.consume(defaults: dpIntroDefaults)
             var dpIntroOpened = 0
             // Read, never written: the process's own domain is where a card
             // that enabled the feature would actually write, and an assertion
@@ -4115,8 +4115,16 @@ enum SelfTest {
             if let dpIntroOn = UserDefaults(suiteName: dpIntroOnSuite) {
                 defer { UserDefaults.standard.removePersistentDomain(forName: dpIntroOnSuite) }
                 dpIntroOn.set(true, forKey: DiscordPresence.enabledKey)
-                expect(!DiscordIntro.shouldPresent(defaults: dpIntroOn),
-                    "the card is not shown to someone already using the feature")
+                let dpIntroSkipped = DiscordIntro.consume(defaults: dpIntroOn)
+                // The upgrade path: they had it on before this card existed, so
+                // they never see it — and must not see it later if they switch
+                // off. Skipping has to consume the flag, not defer it.
+                dpIntroOn.set(false, forKey: DiscordPresence.enabledKey)
+                expect(!dpIntroSkipped && !DiscordIntro.consume(defaults: dpIntroOn),
+                    "someone already using the feature is not introduced to it, and switching it "
+                        + "off later does not introduce them either (mutation: skipping without "
+                        + "consuming the flag shows the card to a user who deliberately turned "
+                        + "the feature off)")
             }
         } else {
             expect(false, "the isolated intro suite could not be created")

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -4069,6 +4069,59 @@ enum SelfTest {
             "a turn that both replaces content and adds some still retires the old payload, "
                 + "while a turn that only adds does not (mutation: an AND instead of an OR lets "
                 + "a payload built for the previous selection reach the socket)")
+        // The intro card. One contract, behavioural: nothing it does turns the
+        // feature on. A source scan counting writes to the key name is exactly
+        // the shape #148 removed and #147 showed gets relocated around.
+        let dpIntroSuite = "TokenBar.SelfTest.DiscordIntro"
+        if let dpIntroDefaults = UserDefaults(suiteName: dpIntroSuite) {
+            defer { UserDefaults.standard.removePersistentDomain(forName: dpIntroSuite) }
+            let dpIntroFirst = DiscordIntro.shouldPresent(defaults: dpIntroDefaults)
+            // Presentation is what marks it, not the choice: a card that
+            // returns until the user picks the preferred action is a nag.
+            DiscordIntro.markShown(defaults: dpIntroDefaults)
+            let dpIntroAgain = DiscordIntro.shouldPresent(defaults: dpIntroDefaults)
+            var dpIntroOpened = 0
+            // Read, never written: the process's own domain is where a card
+            // that enabled the feature would actually write, and an assertion
+            // confined to the isolated suite cannot see that. Measured — a
+            // mutation adding `UserDefaults.standard.set(true, forKey:)` to the
+            // openSettings branch passed the suite-only form of this check.
+            //
+            // Known limit, stated rather than papered over: this detects a
+            // CHANGE, so it cannot see a write of `true` over an existing
+            // `true`. Under `swift run` that domain starts empty, so the case
+            // only arises from a previous mutation run leaving the key behind —
+            // which happened while writing this, and silently disabled the
+            // check. Asserting the key is absent beforehand would be the
+            // stronger form, but it would fail on a bundled run for
+            // any user who has the feature switched on.
+            let dpIntroStandardBefore =
+                UserDefaults.standard.object(forKey: DiscordPresence.enabledKey) as? Bool
+            DiscordIntro.perform(.openSettings) { dpIntroOpened += 1 }
+            DiscordIntro.perform(.notNow) { dpIntroOpened += 1 }
+            let dpIntroStandardAfter =
+                UserDefaults.standard.object(forKey: DiscordPresence.enabledKey) as? Bool
+            expect(
+                dpIntroFirst && !dpIntroAgain && dpIntroOpened == 1
+                    && !DiscordPresence.enabled(defaults: dpIntroDefaults)
+                    && dpIntroStandardBefore == dpIntroStandardAfter,
+                "the intro card is shown once, marked by being presented rather than acted on, "
+                    + "and NEITHER action turns the feature on (mutation: an enable button, or "
+                    + "marking it shown only on the preferred choice, fails here)")
+            // Already using it: nothing to introduce, and interrupting would be
+            // noise. Asserted on a second suite so the flag above cannot be
+            // what makes this pass.
+            let dpIntroOnSuite = "TokenBar.SelfTest.DiscordIntroOn"
+            if let dpIntroOn = UserDefaults(suiteName: dpIntroOnSuite) {
+                defer { UserDefaults.standard.removePersistentDomain(forName: dpIntroOnSuite) }
+                dpIntroOn.set(true, forKey: DiscordPresence.enabledKey)
+                expect(!DiscordIntro.shouldPresent(defaults: dpIntroOn),
+                    "the card is not shown to someone already using the feature")
+            }
+        } else {
+            expect(false, "the isolated intro suite could not be created")
+        }
+
         // MARK: - Discord Rich Presence transport (DISCORD-PRESENCE M2a)
         //
         // Nothing in the app calls this transport yet. These run against real

--- a/Sources/TokenBar/SettingsWindowController.swift
+++ b/Sources/TokenBar/SettingsWindowController.swift
@@ -15,9 +15,20 @@ final class SettingsWindowController {
     private var host: NSHostingController<AnyView>?
     private var closeObserver: NSObjectProtocol?
 
-    func show() {
+    /// A place in Settings a caller wants brought into view. The intro card
+    /// uses it so "Open Settings" lands on the section it just described
+    /// instead of the top of the first page.
+    enum Destination {
+        case discord
+
+        var page: SettingsPanel.Page { .general }
+        /// Matched by a `.id(...)` on the section itself.
+        var anchor: String { "settings.section.discord" }
+    }
+
+    func show(scrollingTo destination: Destination? = nil) {
         let existing = self.window
-        let window = existing ?? makeWindow()
+        let window = existing ?? makeWindow(destination: destination)
         self.window = window
         // Reopening a kept-alive window: reinstall the live settings UI that
         // the previous close swapped out for a static placeholder. (Closing
@@ -25,7 +36,13 @@ final class SettingsWindowController {
         // preview TimelineView(.periodic) keep re-rendering off-screen at up
         // to 40fps and pin a core in the background — the chronic CPU spin.)
         if existing != nil {
-            host?.rootView = AnyView(SettingsWindowView())
+            // `.id` only when a destination is requested: a fresh identity
+            // re-runs the view's `@State`, which is what selects the page and
+            // fires the scroll — and is exactly what an ordinary reopen must
+            // NOT do, since it would discard the page the user was last on.
+            host?.rootView = destination.map {
+                AnyView(SettingsWindowView(destination: $0).id($0.anchor + UUID().uuidString))
+            } ?? AnyView(SettingsWindowView())
         }
         let firstShow = !window.isVisible
         // Accessory apps are never frontmost; activate or the window opens
@@ -52,8 +69,8 @@ final class SettingsWindowController {
             y: visible.midY - window.frame.height / 2))
     }
 
-    private func makeWindow() -> NSWindow {
-        let host = NSHostingController(rootView: AnyView(SettingsWindowView()))
+    private func makeWindow(destination: Destination? = nil) -> NSWindow {
+        let host = NSHostingController(rootView: AnyView(SettingsWindowView(destination: destination)))
         self.host = host
         let window = NSWindow(contentViewController: host)
         // NSWindow(contentViewController:) sizes lazily (the frame is still

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -632,6 +632,7 @@ struct SettingsPanel: View {
             // sequence of them across weeks is closer still.
             hint("A range keeps you among everyone else in that band. A figure is rounded to the dollar, never cents, but still says more about you — every day. With one client named above, it becomes that tool's daily spend.")
         }
+        .id(SettingsWindowController.Destination.discord.anchor)
 
         section("Language") {
             radioGroup(

--- a/Sources/TokenBar/Views/SettingsWindowView.swift
+++ b/Sources/TokenBar/Views/SettingsWindowView.swift
@@ -43,6 +43,10 @@ struct SettingsWindowView: View {
     // popover's restore snapshot with its independently polled data.
     @State private var model = DashboardModel(initialYear: nil)
     @State private var tokensPerMin: Double?
+    /// Set only when a caller asked for a specific place; the intro card is
+    /// the one caller today. Nil means an ordinary open, which must land
+    /// wherever the user last was.
+    var destination: SettingsWindowController.Destination?
     @State private var selectedPage = SettingsPanel.Page.menuBar
     /// Master switch: off hides the preview's Agent-limits card too.
     @AppStorage("tokenbar.limits.enabled") private var limitsEnabled = true
@@ -115,18 +119,32 @@ struct SettingsWindowView: View {
             // The columns sit inside the title-bar safe area, so a plain Divider
             // stops ~32pt short of the top edge and reads as a broken seam.
             Divider().ignoresSafeArea(edges: .top)
-            ScrollView {
-                SettingsPanel(
-                    page: selectedPage,
-                    agentUsage: model.agentUsage,
-                    presentClients: model.stats?.presentClients ?? [],
-                    isLoading: isInitialLoad)
-                    .padding(14)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(OverlayScrollerEnforcer())
+            ScrollViewReader { proxy in
+                ScrollView {
+                    SettingsPanel(
+                        page: selectedPage,
+                        agentUsage: model.agentUsage,
+                        presentClients: model.stats?.presentClients ?? [],
+                        isLoading: isInitialLoad)
+                        .padding(14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(OverlayScrollerEnforcer())
+                }
+                .scrollIndicators(.never)
+                .frame(width: 354)
+                .onAppear {
+                    guard let destination else { return }
+                    selectedPage = destination.page
+                    // Next runloop turn: the page's own sections have to exist
+                    // before the anchor can be resolved, and selecting the page
+                    // above is what creates them.
+                    DispatchQueue.main.async {
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            proxy.scrollTo(destination.anchor, anchor: .top)
+                        }
+                    }
+                }
             }
-            .scrollIndicators(.never)
-            .frame(width: 354)
             Divider().ignoresSafeArea(edges: .top)
             ScrollView {
                 previewColumn


### PR DESCRIPTION
M5, the last milestone of the Discord composition plan.

`make selftest`: **598 ok, 0 FAIL, exit 0.** Knowledge contracts and the FFI smoke pass.

## What it is

The feature is default-off and lives in a Settings section nobody has a reason to open, so without this it is discoverable only by accident. The card fixes that and does nothing else.

**It cannot turn the feature on, and there is no path from it to on.** The only route is the Settings toggle, because that is where the full disclosure is. A card with an enable button would collect consent against its own three sentences instead of against the disclosure — that is the dark pattern this milestone exists to avoid, not a shortcut around it.

The motivation for building this feature and the user's privacy interest point in opposite directions, and this card is where that conflict lands. So it describes what the feature does and never what the project gets from it, and it carries the cannot-take-it-back sentence rather than being friendlier than the disclosure it leads to.

## Details that are the whole point

| decision | why |
|---|---|
| `NSAlert`, not a custom card | the platform gives Esc-closes and equally weighted buttons for free, and resists being styled into a funnel |
| neither button is the default | `keyEquivalent` cleared on the first, so no filled Return-bound choice pulls toward one answer |
| flag written on **presentation**, not on the action | marking it on the preferred action means the card returns until the user complies; dismiss, Esc and quitting while it is up all count as shown |
| flag is **not versioned** | a versioned flag turns every release into a fresh consent-adjacent interruption — a notification channel, not an introduction |
| never shown to someone already using it | nothing to introduce; interrupting would be pure noise |
| gated on the demo/test arguments | `--demo` and `--icon-gallery` runs are never interrupted |

## The assertion needed two corrections, both found by mutation

The contract is behavioural. A source scan counting writes to a key name is the shape #148 removed and #147 showed gets relocated around.

**First**, a card that enabled the feature was invisible. The check inspected only the isolated suite, while a real one would write the process's own domain. It now reads that domain before and after, never writing it.

**Second, and worth recording:** after widening it, the same mutation passed *again*. The first mutation run had left `tokenbar.discord.enabled` set in the bare-executable domain, so before and after were both `true` — **the mutation had polluted the state the detector depends on.** Cleaning the key and re-running caught it.

The remaining blind spot — a write of `true` over an existing `true` — is stated in the fixture rather than papered over, together with why the stronger form (asserting the key absent beforehand) is not used: it would fail on a bundled run for any user who has the feature switched on.

## Mutations

| mutation | result |
|---|---|
| the card enables the feature on "Open Settings" | 1 FAIL (from a clean domain) |
| the shown-flag is marked only on the preferred action | 1 FAIL |

Refs #148