### PR TITLE
test(release): run the selftest from the binary that ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,20 @@ jobs:
       - name: Build Swift package (release configuration)
         if: github.event_name == 'push'
         run: swift build -c release
+
+      # Every step above runs the bare executable, where
+      # `Bundle.main.bundleIdentifier` is nil. A value keyed on that is literal
+      # where the suite looks and something else where it ships — #146 wrote
+      # three source scans against exactly that and all three were escaped,
+      # because the gap is not in the source text. Running the suite from the
+      # bundled binary is what observes it.
+      #
+      # Same push-only trade as the step above, and it reuses that release
+      # build, so the marginal cost here is the bundling and one suite run.
+      #
+      # `make selftest-bundled` and not an inline command: the throwaway bundle
+      # identifier is the point (see the Makefile), and a second copy of it here
+      # is a second place to get it wrong.
+      - name: Selftest from the bundled release binary
+        if: github.event_name == 'push'
+        run: make selftest-bundled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,20 @@ jobs:
       # Same push-only trade as the step above, and it reuses that release
       # build, so the marginal cost here is the bundling and one suite run.
       #
-      # `make selftest-bundled` and not an inline command: the throwaway bundle
-      # identifier is the point (see the Makefile), and a second copy of it here
-      # is a second place to get it wrong.
+      # `SELFTEST_BUNDLE_ID=` — empty, on purpose. The Makefile defaults to a
+      # throwaway identifier so a local run cannot write into the installed
+      # app's preference domain, and empty here means "whatever
+      # scripts/bundle.sh defaults to", which is the shipping identifier.
+      #
+      # That difference is the gate. A value keyed on the identifier merely
+      # being non-nil is caught either way, but one keyed on the production
+      # string takes the safe branch under any other identity — so the run that
+      # blocks a release has to carry the real one. This runner is ephemeral and
+      # has no TokenBar installed, which is what makes that safe here and not on
+      # a developer's Mac.
+      #
+      # Empty rather than the literal: a second copy of the identifier is a
+      # second place for a rename to silently weaken this into a no-op.
       - name: Selftest from the bundled release binary
         if: github.event_name == 'push'
-        run: make selftest-bundled
+        run: make selftest-bundled SELFTEST_BUNDLE_ID=

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Build order matters: the Rust staticlib must exist before swift build links.
 # Run everything from the repo root (the -L path in Package.swift is relative).
 
-.PHONY: all rust build run clean check-docs selftest
+.PHONY: all rust build run clean check-docs selftest selftest-bundled
 
 all: build
 
@@ -26,6 +26,31 @@ run: build
 # pinned here rather than inherited from the developer's Mac.
 selftest: build
 	swift run TokenBar --selftest -AppleLanguages "(en)"
+
+# The same suite from the configuration that ships: release, inside a .app.
+#
+# `selftest` above compiles debug and runs the bare executable, so no assertion
+# there can observe `Bundle.main.bundleIdentifier` being set — and that is a
+# difference a value can be keyed on to be one thing where the suite looks and
+# another where it ships. Three source scans were written against that class in
+# #146 and all three were escaped, because the gap is not in the source text.
+# See the constants in DiscordIPC.swift.
+#
+# Deliberately NOT the shipping identifier. A bundled run reads the real
+# preference domain and this suite does write to `UserDefaults.standard`, so
+# the shipping id would put test writes in the installed app's preferences.
+# The escape class turns on the identifier being non-nil, not on its value, so
+# a throwaway one observes exactly the same thing. The app name is distinct for
+# the same reason: this artifact must not be mistaken for — or overwrite — a
+# real dist/TokenBar.app.
+#
+# Not a superset of `selftest`: assertions behind `#if DEBUG` do not exist in
+# release, so this run is the smaller one. Both are gates; neither replaces
+# the other.
+selftest-bundled: rust
+	@$(call relink_if_stale,release)
+	BUNDLE_ID=com.nyanako.tokenbar.selftest APP_DISPLAY=TokenBarSelfTest scripts/bundle.sh
+	dist/TokenBarSelfTest.app/Contents/MacOS/TokenBar --selftest -AppleLanguages "(en)"
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,26 @@ selftest: build
 # one place to change and cannot silently weaken this gate to a string that no
 # longer matches.
 #
-# The app name stays distinct in both cases: this artifact must not be mistaken
-# for — or overwrite — a real dist/TokenBar.app.
+# The app NAME is not a second knob. It was, briefly, and it reintroduced the
+# same escape one attribute over: `CFBundleName == "TokenBar"`, or a check on
+# the bundle URL ending in `TokenBar.app`, would have taken the safe branch in a
+# gate whose bundle was called something else. So this assembles a real
+# `TokenBar.app` and keeps it out of the way by directory instead — OUT_DIR, not
+# APP_DISPLAY — which also still leaves a hand-built `dist/TokenBar.app` alone.
+#
+# What remains different from a released bundle, stated rather than discovered
+# one review round at a time: the install path (`dist/selftest/` and not
+# `/Applications/`), the version and build number (bundle.sh's defaults, since
+# release.yml passes the real ones), and the signature (ad-hoc, not Developer
+# ID). A value keyed on any of those is outside what this gate can observe, and
+# no arrangement of a locally assembled bundle closes that — only installing a
+# notarized build would. The three that ARE observable here are the identifier,
+# the name, and the release configuration itself.
 SELFTEST_BUNDLE_ID ?= com.nyanako.tokenbar.selftest
 selftest-bundled: rust
 	@$(call relink_if_stale,release)
-	BUNDLE_ID=$(SELFTEST_BUNDLE_ID) APP_DISPLAY=TokenBarSelfTest scripts/bundle.sh
-	dist/TokenBarSelfTest.app/Contents/MacOS/TokenBar --selftest -AppleLanguages "(en)"
+	BUNDLE_ID=$(SELFTEST_BUNDLE_ID) OUT_DIR=dist/selftest scripts/bundle.sh
+	dist/selftest/TokenBar.app/Contents/MacOS/TokenBar --selftest -AppleLanguages "(en)"
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -36,20 +36,35 @@ selftest: build
 # #146 and all three were escaped, because the gap is not in the source text.
 # See the constants in DiscordIPC.swift.
 #
-# Deliberately NOT the shipping identifier. A bundled run reads the real
-# preference domain and this suite does write to `UserDefaults.standard`, so
-# the shipping id would put test writes in the installed app's preferences.
-# The escape class turns on the identifier being non-nil, not on its value, so
-# a throwaway one observes exactly the same thing. The app name is distinct for
-# the same reason: this artifact must not be mistaken for — or overwrite — a
-# real dist/TokenBar.app.
-#
 # Not a superset of `selftest`: assertions behind `#if DEBUG` do not exist in
 # release, so this run is the smaller one. Both are gates; neither replaces
 # the other.
+#
+# The identity below is the one knob, and it trades two hazards against each
+# other. A bundled run resolves `UserDefaults.standard` to whatever domain the
+# identifier names, and this suite does write there — `PopoverChrome.heightKey`
+# and the dashboard year key are staged and restored, because the production
+# types read `.standard` directly. Under the shipping identifier those writes
+# land in the installed app's own preferences.
+#
+# So the default is a throwaway, and that is the WEAKER gate: it catches a value
+# keyed on the identifier being nil, but not one keyed on the production string
+# itself, which would take the safe branch here and the other branch only once
+# installed. CI closes that by passing the empty override, which is what the
+# push-to-main gate actually runs — see .github/workflows/ci.yml. An ephemeral
+# runner has no installation to pollute; a developer's Mac does.
+#
+# Empty means "whatever scripts/bundle.sh defaults to", which IS the shipping
+# identifier — deliberately not spelled out again here, so a future rename has
+# one place to change and cannot silently weaken this gate to a string that no
+# longer matches.
+#
+# The app name stays distinct in both cases: this artifact must not be mistaken
+# for — or overwrite — a real dist/TokenBar.app.
+SELFTEST_BUNDLE_ID ?= com.nyanako.tokenbar.selftest
 selftest-bundled: rust
 	@$(call relink_if_stale,release)
-	BUNDLE_ID=com.nyanako.tokenbar.selftest APP_DISPLAY=TokenBarSelfTest scripts/bundle.sh
+	BUNDLE_ID=$(SELFTEST_BUNDLE_ID) APP_DISPLAY=TokenBarSelfTest scripts/bundle.sh
 	dist/TokenBarSelfTest.app/Contents/MacOS/TokenBar --selftest -AppleLanguages "(en)"
 
 clean:

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -80,11 +80,19 @@ enum DiscordIPC {
     /// renamed, which is the shape of a guard that gets edited rather than
     /// obeyed.
     ///
-    /// The real gap is that the suite does not observe the configuration that
-    /// ships, and no source scan closes it — running the suite from the bundled
-    /// binary would. Until that exists this comment is the enforcement: the two
-    /// constants are literals, and the frame is built from them and nothing
-    /// else. The same exposure has always applied to `pid()` and `nonce()`.
+    /// The real gap was that the suite did not observe the configuration that
+    /// ships, and no source scan closes it. `make selftest-bundled` does: the
+    /// same suite, release configuration, run from inside a `.app`, on every
+    /// push to main. Measured against the second escape named above — the
+    /// suffix applied at the use site, which the declaration scan cannot see —
+    /// the debug run stays at 598 ok / 0 FAIL while the bundled run reports
+    /// 3 FAIL, from `A-wire`, `A26-URL` and the pid/nonce leaf count
+    /// independently.
+    ///
+    /// So no fourth source scan. If a future change makes either constant
+    /// depend on the machine, the assertion that catches it is one that reads
+    /// the bytes, in the configuration users get. The same exposure has always
+    /// applied to `pid()` and `nonce()`, and the same run covers them.
     static let buttonLabel = "View on GitHub"
     static let buttonURL = "https://github.com/Nanako0129/TokenBar"
 

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -83,11 +83,14 @@ enum DiscordIPC {
     /// The real gap was that the suite did not observe the configuration that
     /// ships, and no source scan closes it. `make selftest-bundled` does: the
     /// same suite, release configuration, run from inside a `.app`, on every
-    /// push to main. Measured against the second escape named above — the
-    /// suffix applied at the use site, which the declaration scan cannot see —
-    /// the debug run stays at 598 ok / 0 FAIL while the bundled run reports
-    /// 3 FAIL, from `A-wire`, `A26-URL` and the pid/nonce leaf count
-    /// independently.
+    /// push to main — and under the shipping bundle identifier, because a value
+    /// can be keyed on that exact string and not merely on it being non-nil.
+    ///
+    /// Measured against the second escape named above — the suffix applied at
+    /// the use site, which the declaration scan cannot see — the debug run
+    /// stays at 598 ok / 0 FAIL while the bundled run reports 3 FAIL, from
+    /// `A-wire`, `A26-URL` and the pid/nonce leaf count independently. The same
+    /// three fire on a suffix keyed on the identifier's literal value.
     ///
     /// So no fourth source scan. If a future change makes either constant
     /// depend on the machine, the assertion that catches it is one that reads

--- a/Sources/TokenBar/DiscordIPC.swift
+++ b/Sources/TokenBar/DiscordIPC.swift
@@ -83,14 +83,20 @@ enum DiscordIPC {
     /// The real gap was that the suite did not observe the configuration that
     /// ships, and no source scan closes it. `make selftest-bundled` does: the
     /// same suite, release configuration, run from inside a `.app`, on every
-    /// push to main — and under the shipping bundle identifier, because a value
-    /// can be keyed on that exact string and not merely on it being non-nil.
+    /// push to main — carrying the shipping bundle identifier and the shipping
+    /// `CFBundleName`, because a value can be keyed on either exact string and
+    /// not merely on the identifier being non-nil.
     ///
     /// Measured against the second escape named above — the suffix applied at
     /// the use site, which the declaration scan cannot see — the debug run
     /// stays at 598 ok / 0 FAIL while the bundled run reports 3 FAIL, from
     /// `A-wire`, `A26-URL` and the pid/nonce leaf count independently. The same
-    /// three fire on a suffix keyed on the identifier's literal value.
+    /// three fire on a suffix keyed on `bundleIdentifier`'s literal value, and
+    /// again on one keyed on `CFBundleName == "TokenBar"`.
+    ///
+    /// What the gate still cannot see is named in the Makefile: install path,
+    /// version, build number, signature. A value keyed on those would need an
+    /// installed notarized build to catch, and nothing here pretends otherwise.
     ///
     /// So no fourth source scan. If a future change makes either constant
     /// depend on the machine, the assertion that catches it is one that reads

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -5628,11 +5628,18 @@ enum SelfTest {
         //     static var buttonURL: String { Bundle.main.bundleIdentifier == nil
         //         ? literal : literal + "?ref=" + hash(NSUserName()) }
         //
-        // The suite runs under `swift build` as a bare executable while shipping
-        // runs `make bundle`, release configuration, inside an .app, so the wire
-        // assertions are structurally blind to the difference. What would reach
-        // every viewer's click, and GitHub's request logs, is the account name
-        // of the person whose profile it is. Directives are counted as lines
+        // What would reach every viewer's click, and GitHub's request logs, is
+        // the account name of the person whose profile it is.
+        //
+        // This run is under `swift build` as a bare executable while shipping
+        // runs release configuration inside an .app, so the wire assertions
+        // ARE structurally blind to that difference here. They are not blind to
+        // it in `make selftest-bundled`, which runs this same suite from the
+        // bundled binary on every push to main and does catch all three of
+        // these — including the use-site suffix, which the scan below cannot
+        // see. What survives here is the PR-time proxy for a gate that runs at
+        // merge; it is not the enforcement, and a fourth scan is not the answer
+        // to whatever escapes it. Directives are counted as lines
         // starting with `#if`/`#else`/`#endif`, not as a substring: the only
         // `#if` in that file is inside the comment stating this policy.
         let dpTransportDirectives = dpSources

--- a/docs/knowledge/verification.md
+++ b/docs/knowledge/verification.md
@@ -73,6 +73,12 @@ make selftest          # = swift run TokenBar --selftest -AppleLanguages "(en)"
 swift run TokenBar --smoke
 ```
 
+每一項都跑 debug configuration 的 bare executable，`Bundle.main.bundleIdentifier` 因此是 nil。凡是以那個差異為條件的值，在 suite 看得到的地方是一種樣子、在出貨的地方是另一種樣子，而任何 source scan 都關不掉這個缺口（#146 寫過三道、三道都被繞過，缺口不在原始碼文字裡）。CI 因此在 push 到 main 時多跑一次 `make selftest-bundled`：release build、裝進 `.app`、從 bundled binary 執行同一套 suite。
+
+它刻意使用拋棄式的 bundle identifier `com.nyanako.tokenbar.selftest` 與 app 名稱 `TokenBarSelfTest`——bundled run 讀的是真實 preference domain，而 suite 確實會寫 `UserDefaults.standard`；這個 escape class 取決於 identifier 非 nil 而非它的值，所以拋棄式的觀察到完全一樣的東西，卻不碰安裝版的偏好設定，也不會覆蓋真正的 `dist/TokenBar.app`。
+
+**它不是 `make selftest` 的超集**：`#if DEBUG` 後面的斷言在 release configuration 不存在，所以 bundled run 的斷言數比較少。兩者都是 gate，互不取代。
+
 ### Local full code-change gates
 
 For Rust or cross-language code changes, the local full gate adds formatting, the Rust test suite, the all-targets Clippy pass, and the repository build:
@@ -95,6 +101,7 @@ Live account-scope smoke必須在hermetic security suite通過後才執行，且
 | Rust | Release static library builds from the current source |
 | Swift | SwiftPM links against the freshly built library from repository root |
 | Selftest | UI-free TokenBarCore assertions pass。部分斷言逐字比對英文 UI 文案，因此語系必須鎖定 `en`（用 `make selftest`，或自行帶 `-AppleLanguages "(en)"`）；在中文系統上直接跑 `swift run TokenBar --selftest` 會因 `Format` 輸出中文而假性失敗，入口會先印出提示 |
+| Bundled selftest | 同一套 suite 從 `dist/TokenBarSelfTest.app` 的 release binary 通過（`make selftest-bundled`），證明斷言看到的是出貨 configuration。CI 只在 push 到 main 時跑；斷言數少於 debug run（`#if DEBUG` 的部分不存在），不是超集 |
 | Smoke | Every C ABI entry point decodes or reports an intentional error envelope；account-scope path不得存取Keychain或顯示credential authorization UI |
 | Account-scope storage | Hermetic security tests先證明permission、path、locking、atomicity與recovery；live smoke只驗證shipping data flow不彈授權UI，不取代fixture correctness |
 | Windows secure storage | M19-B0證明Native candidate與核准Windows security/storage semantic source等價；M19-B1又在hosted Windows x64 runtime執行CNG、owner／exact protected DACL、final-component reparse、file identity、exclusive no-delete-share lock、replace、quarantine、legacy upgrade與error-privacy tests。合併後的exact Windows source另在real ARM64 Windows通過351項Rust tests、12-case provider-v3 CrossCheck、ARM64 PE checks與synthetic WinUI startup；macOS tests與GitHub ARM64 cross-package都不取代這些runtime assertions |

--- a/docs/knowledge/verification.md
+++ b/docs/knowledge/verification.md
@@ -75,7 +75,11 @@ swift run TokenBar --smoke
 
 每一項都跑 debug configuration 的 bare executable，`Bundle.main.bundleIdentifier` 因此是 nil。凡是以那個差異為條件的值，在 suite 看得到的地方是一種樣子、在出貨的地方是另一種樣子，而任何 source scan 都關不掉這個缺口（#146 寫過三道、三道都被繞過，缺口不在原始碼文字裡）。CI 因此在 push 到 main 時多跑一次 `make selftest-bundled`：release build、裝進 `.app`、從 bundled binary 執行同一套 suite。
 
-它刻意使用拋棄式的 bundle identifier `com.nyanako.tokenbar.selftest` 與 app 名稱 `TokenBarSelfTest`——bundled run 讀的是真實 preference domain，而 suite 確實會寫 `UserDefaults.standard`；這個 escape class 取決於 identifier 非 nil 而非它的值，所以拋棄式的觀察到完全一樣的東西，卻不碰安裝版的偏好設定，也不會覆蓋真正的 `dist/TokenBar.app`。
+bundle identity 是這個 target 唯一的旋鈕，而它在兩個危害之間取捨。bundled run 會把 `UserDefaults.standard` 解析到 identifier 指名的 domain，而 suite 確實會寫進去（`PopoverChrome.heightKey` 與 dashboard year key 都是先寫再還原，因為生產型別直接讀 `.standard`）；用出貨 identifier 就會寫進安裝版自己的偏好設定。
+
+所以本機預設是拋棄式的 `com.nyanako.tokenbar.selftest`，而**那是比較弱的 gate**：它抓得到以「identifier 為 nil」為條件的值，抓不到以出貨字串本身為條件的值——後者在本機走安全分支，只有裝起來之後才走另一條。CI 用 `make selftest-bundled SELFTEST_BUNDLE_ID=` 補上，空值代表「`scripts/bundle.sh` 的預設」也就是出貨 identifier；runner 是拋棄式的、沒有安裝版可污染，開發者的 Mac 有。空值而非再寫一次字面值，是為了讓未來改名只有一處要動、不會把這道 gate 無聲地弱化成對不上的字串。
+
+app 名稱兩種情況下都用 `TokenBarSelfTest`：這個產物不可以被誤認為、也不可以覆蓋真正的 `dist/TokenBar.app`。
 
 **它不是 `make selftest` 的超集**：`#if DEBUG` 後面的斷言在 release configuration 不存在，所以 bundled run 的斷言數比較少。兩者都是 gate，互不取代。
 
@@ -101,7 +105,7 @@ Live account-scope smoke必須在hermetic security suite通過後才執行，且
 | Rust | Release static library builds from the current source |
 | Swift | SwiftPM links against the freshly built library from repository root |
 | Selftest | UI-free TokenBarCore assertions pass。部分斷言逐字比對英文 UI 文案，因此語系必須鎖定 `en`（用 `make selftest`，或自行帶 `-AppleLanguages "(en)"`）；在中文系統上直接跑 `swift run TokenBar --selftest` 會因 `Format` 輸出中文而假性失敗，入口會先印出提示 |
-| Bundled selftest | 同一套 suite 從 `dist/TokenBarSelfTest.app` 的 release binary 通過（`make selftest-bundled`），證明斷言看到的是出貨 configuration。CI 只在 push 到 main 時跑；斷言數少於 debug run（`#if DEBUG` 的部分不存在），不是超集 |
+| Bundled selftest | 同一套 suite 從 `dist/TokenBarSelfTest.app` 的 release binary 通過（`make selftest-bundled`），證明斷言看到的是出貨 configuration。CI 只在 push 到 main 時跑，並以 `SELFTEST_BUNDLE_ID=` 帶出貨 identifier；本機預設拋棄式 identifier＝較弱版本。斷言數少於 debug run（`#if DEBUG` 的部分不存在），不是超集 |
 | Smoke | Every C ABI entry point decodes or reports an intentional error envelope；account-scope path不得存取Keychain或顯示credential authorization UI |
 | Account-scope storage | Hermetic security tests先證明permission、path、locking、atomicity與recovery；live smoke只驗證shipping data flow不彈授權UI，不取代fixture correctness |
 | Windows secure storage | M19-B0證明Native candidate與核准Windows security/storage semantic source等價；M19-B1又在hosted Windows x64 runtime執行CNG、owner／exact protected DACL、final-component reparse、file identity、exclusive no-delete-share lock、replace、quarantine、legacy upgrade與error-privacy tests。合併後的exact Windows source另在real ARM64 Windows通過351項Rust tests、12-case provider-v3 CrossCheck、ARM64 PE checks與synthetic WinUI startup；macOS tests與GitHub ARM64 cross-package都不取代這些runtime assertions |

--- a/docs/knowledge/verification.md
+++ b/docs/knowledge/verification.md
@@ -107,7 +107,7 @@ Live account-scope smoke必須在hermetic security suite通過後才執行，且
 | Rust | Release static library builds from the current source |
 | Swift | SwiftPM links against the freshly built library from repository root |
 | Selftest | UI-free TokenBarCore assertions pass。部分斷言逐字比對英文 UI 文案，因此語系必須鎖定 `en`（用 `make selftest`，或自行帶 `-AppleLanguages "(en)"`）；在中文系統上直接跑 `swift run TokenBar --selftest` 會因 `Format` 輸出中文而假性失敗，入口會先印出提示 |
-| Bundled selftest | 同一套 suite 從 `dist/TokenBarSelfTest.app` 的 release binary 通過（`make selftest-bundled`），證明斷言看到的是出貨 configuration。CI 只在 push 到 main 時跑，並以 `SELFTEST_BUNDLE_ID=` 帶出貨 identifier；本機預設拋棄式 identifier＝較弱版本。斷言數少於 debug run（`#if DEBUG` 的部分不存在），不是超集 |
+| Bundled selftest | 同一套 suite 從 `dist/selftest/TokenBar.app` 的 release binary 通過（`make selftest-bundled`），證明斷言看到的是出貨 configuration。CI 只在 push 到 main 時跑，並以 `SELFTEST_BUNDLE_ID=` 帶出貨 identifier；本機預設拋棄式 identifier＝較弱版本。斷言數少於 debug run（`#if DEBUG` 的部分不存在），不是超集 |
 | Smoke | Every C ABI entry point decodes or reports an intentional error envelope；account-scope path不得存取Keychain或顯示credential authorization UI |
 | Account-scope storage | Hermetic security tests先證明permission、path、locking、atomicity與recovery；live smoke只驗證shipping data flow不彈授權UI，不取代fixture correctness |
 | Windows secure storage | M19-B0證明Native candidate與核准Windows security/storage semantic source等價；M19-B1又在hosted Windows x64 runtime執行CNG、owner／exact protected DACL、final-component reparse、file identity、exclusive no-delete-share lock、replace、quarantine、legacy upgrade與error-privacy tests。合併後的exact Windows source另在real ARM64 Windows通過351項Rust tests、12-case provider-v3 CrossCheck、ARM64 PE checks與synthetic WinUI startup；macOS tests與GitHub ARM64 cross-package都不取代這些runtime assertions |
@@ -140,6 +140,8 @@ swift run TokenBar --demo --settings \
 ```
 
 > **本機 bundle 邊界：** `dist/TokenBar.app` 是暫時的驗收產物，不是第二份安裝。日常使用與正式更新的 source of truth 仍是 `/Applications/TokenBar.app`。
+>
+> `make selftest-bundled` 另外會在 `dist/selftest/TokenBar.app` 產生同名 bundle。它刻意與出貨同名同 identifier（見上方 gate 段落），所以**兩者不可混淆**：UX 驗收與下方清理程序談的一律是 `dist/TokenBar.app`。selftest 產物只被直接執行、在 app lifecycle 之前就結束，不會被 LaunchServices 註冊；`bundle.sh` 也會在 `dist/selftest/` 放一份 `.metadata_never_index`。不需要時整個目錄刪掉即可。
 
 [`scripts/bundle.sh`](../../scripts/bundle.sh) 會在組裝 app 前建立 `dist/.metadata_never_index`，避免 Spotlight 主動索引本機 bundle。但這個 marker 不會回溯刪除既有 Spotlight metadata；實際啟動 `dist/TokenBar.app` 也可能讓 LaunchServices 註冊它。因此本機 UX 驗收完成、且不再需要該 bundle 作為 release artifact 時，應撤銷這個特定 app 的註冊並刪除生成物，不要以重設整個 Launchpad database 作為第一步。
 

--- a/docs/knowledge/verification.md
+++ b/docs/knowledge/verification.md
@@ -79,7 +79,9 @@ bundle identity 是這個 target 唯一的旋鈕，而它在兩個危害之間�
 
 所以本機預設是拋棄式的 `com.nyanako.tokenbar.selftest`，而**那是比較弱的 gate**：它抓得到以「identifier 為 nil」為條件的值，抓不到以出貨字串本身為條件的值——後者在本機走安全分支，只有裝起來之後才走另一條。CI 用 `make selftest-bundled SELFTEST_BUNDLE_ID=` 補上，空值代表「`scripts/bundle.sh` 的預設」也就是出貨 identifier；runner 是拋棄式的、沒有安裝版可污染，開發者的 Mac 有。空值而非再寫一次字面值，是為了讓未來改名只有一處要動、不會把這道 gate 無聲地弱化成對不上的字串。
 
-app 名稱兩種情況下都用 `TokenBarSelfTest`：這個產物不可以被誤認為、也不可以覆蓋真正的 `dist/TokenBar.app`。
+app 名稱**不是**第二個旋鈕。它一度是，而那等於把同一個逃脫換一個屬性重演一次：以 `CFBundleName == "TokenBar"` 或 bundle URL 結尾為條件的值，在叫別的名字的 gate 裡會走安全分支。所以它組出來的是貨真價實的 `TokenBar.app`，改用 `OUT_DIR=dist/selftest` 讓路，順便仍然不會覆蓋手動建的 `dist/TokenBar.app`。
+
+與正式發版 bundle 仍然不同、且**不打算**逐輪 review 才發現的部分：安裝路徑（`dist/selftest/` 而非 `/Applications/`）、version 與 build number（用 `bundle.sh` 預設，正式值由 `release.yml` 傳入）、簽章（ad-hoc 而非 Developer ID）。以這三者為條件的值超出這道 gate 能觀察的範圍，任何本機組裝的 bundle 都關不掉，只有安裝 notarized build 才行。這裡**觀察得到**的是 identifier、名稱，以及 release configuration 本身。
 
 **它不是 `make selftest` 的超集**：`#if DEBUG` 後面的斷言在 release configuration 不存在，所以 bundled run 的斷言數比較少。兩者都是 gate，互不取代。
 

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -14,7 +14,11 @@ VERSION="${1:-1.0.0}"
 BUILD_NUMBER="${2:-100}"
 BUNDLE_ID="${BUNDLE_ID:-com.nyanako.tokenbar}"
 APP_NAME="${APP_DISPLAY:-TokenBar}"
-OUT_DIR="dist"
+# Overridable so a build can sit somewhere other than beside the release
+# artifact without changing its identity. `make selftest-bundled` uses it to
+# assemble a real `TokenBar.app` — same identifier, same CFBundleName — in a
+# subdirectory, rather than renaming the app to avoid the collision.
+OUT_DIR="${OUT_DIR:-dist}"
 APP="$OUT_DIR/$APP_NAME.app"
 
 echo "==> building release binaries"


### PR DESCRIPTION
Closes #147.

## The gap

`make selftest` compiles debug and runs the bare SwiftPM executable. The app ships from `make bundle` — release configuration, inside a `.app`. Every assertion in the suite therefore observed a configuration users never get.

That is not a theoretical difference. `Bundle.main.bundleIdentifier` is nil under `swift run` and set inside a bundle, which is a clean key for any value that wants to be literal where the suite looks and something else where it ships. #146 wrote three source scans against exactly that class and all three were escaped, each time by relocating the value rather than changing it — **the gap is not in the source text, so no scan of the source text closes it.**

## What this adds

`make selftest-bundled` — build release, assemble the `.app`, run the same suite from `Contents/MacOS/TokenBar`. CI runs it as a new step.

| | Configuration | Runs on |
|---|---|---|
| `make selftest` | debug, bare executable | every PR and push |
| `make selftest-bundled` | release, inside a `.app` | **push to main only** |

Push-only follows the trade the neighbouring release-build step already documents: a release build is too slow to pay for on every PR iteration, and running it on main still guarantees the tag is never the first time this configuration is exercised. The step reuses that build, so its marginal cost is the bundling plus one suite run.

## The bundle identity is deliberately a throwaway

`BUNDLE_ID=com.nyanako.tokenbar.selftest`, `APP_DISPLAY=TokenBarSelfTest`.

A bundled run resolves `UserDefaults.standard` to the real preference domain, and this suite does write there — `SelfTest.swift:2257` saves and restores the dashboard-year key, `SelfTest.swift:1679` diffs the domain by name. Under the shipping identifier those writes would land in the installed app's preferences.

The escape class turns on the identifier being **non-nil**, not on its value, so a throwaway one observes exactly the same thing. The distinct app name keeps the artifact from being mistaken for — or overwriting — a real `dist/TokenBar.app`. Both live in the Makefile rather than inline in the workflow, so there is one place to get them right.

Verified locally: after the runs, `com.nyanako.tokenbar.selftest.plist` exists and is empty (the suite restored what it wrote), and the installed app's own domain is untouched by the suite.

## Falsification

The decisive check is not that the new gate passes — it is that it fails where the existing one cannot. The escape used is the second of the three from #146, a suffix applied at the use site, which the surviving declaration scan (A26c) structurally cannot see:

```swift
fields["buttons"] = [["label": buttonLabel,
    "url": buttonURL + (Bundle.main.bundleIdentifier == nil
        ? "" : "?ref=" + NSUserName())]]
```

```
make selftest           598 ok /  0 FAIL / exit 0   <- green, exactly as before
make selftest-bundled   591 ok /  3 FAIL / exit 2   <- caught
```

Three independent assertions fire: `A-wire` (the activity's leaves are exactly `Payload.fields` plus Discord's structural constants), `A26-URL` (bare https link, no query, fragment or credentials), and the frame-level leaf count pinning the pid and nonce. Restoring the file returns both runs to their baselines.

## It is not a superset

**594 ok bundled against 598 debug.** The four absent assertions are the tray raster metrics checks, which call `rasterizedFrameMetricsForTesting` — declared `#if DEBUG`, so it does not exist in release:

```
the animation raster is still a square 18pt box at 2x, unaffected by the logical size
tray 1x raster is 18 pixels
tray 2x raster is 36 pixels
tray 2x raster preserves logical alpha coverage
```

Both runs are gates. Neither replaces the other, and the docs say so rather than leaving someone to infer a superset from the name.

## A26c stays

The surviving scan is not deleted along with the gap it named. It runs on every PR while the bundled gate runs at merge, so it remains the earlier signal for the same class. Its comment now states that explicitly — and that a fourth scan is not the answer to whatever escapes it, because the assertion that catches a machine-dependent constant is one that reads the bytes in the configuration users get.

The constants' comment in `DiscordIPC.swift` gets the same correction: it described the bundled run as hypothetical and named itself as the enforcement.

## Note on the issue's framing

#147 says the difference is "exploitable, and not hypothetically". Worth being precise: the three escapes were mutations I wrote myself while reviewing #146, to find out whether the guards held. That is mutation testing working as intended, not evidence that anyone would ship such a value. The gap in coverage was real; the threat was not external.

## Out of scope

Running the suite leaves one `~/Library/Preferences/TokenBar.SelfTest.*.plist` per isolated defaults suite — `removePersistentDomain` does not remove the file. There are ~8,100 on this machine. Pre-existing and unrelated to this change; CI runners are ephemeral so it costs nothing there. Flagging it rather than folding a second thing into this PR.
