### PR TITLE
fix(discord): offer only agents the presence can actually publish

### DIFF
--- a/Sources/TokenBar/DiscordPresence.swift
+++ b/Sources/TokenBar/DiscordPresence.swift
@@ -224,27 +224,41 @@ enum DiscordPresence {
     /// (`trayTotals` filters it out of the totals). Offering anything else is a
     /// row that reads as a choice and silently publishes nothing — the failure
     /// the whole feature is built to avoid, arriving through the picker.
+    /// `present` is nil until an accepted payload lands, and DISTINCT from an
+    /// empty one: Settings can be opened before the first scan, where an empty
+    /// picker would read as "your agents are gone". A loaded-but-empty scan is
+    /// a real answer — no usage at all, or every used client hidden — and the
+    /// honest picker there offers only "whichever client you used most".
+    /// Collapsing the two would repopulate the list with the whole registry for
+    /// a user who has no usage, which is the defect this exists to remove.
+    ///
+    /// nil also covers a graph fetch that keeps failing, since that never
+    /// assigns a payload. The registry list is the right answer there too: with
+    /// no data at all, nothing is knowable about which agents are in use, and
+    /// this is what the picker showed before the filter existed.
     static func selectableClients(
-        present: [String], hiddenRaw: String, orderRaw: String, selection: ClientSelection
+        present: [String]?, hiddenRaw: String, orderRaw: String, selection: ClientSelection
     ) -> [String] {
         let registered = Set(ClientRegistry.allIds)
-        let eligible = ClientRegistry
-            .displayClients(present: present, hiddenRaw: hiddenRaw, orderRaw: orderRaw)
-            .filter(registered.contains)
-        // `present` is empty until the first scan lands, and Settings can be
-        // opened before then. An empty picker would read as "your agents are
-        // gone"; the registry list is what shipped before this filter existed.
-        var out = eligible.isEmpty
-            ? ClientRegistry.orderedClients(
+        guard let present else {
+            return ClientRegistry.orderedClients(
                 ClientRegistry.allIds.filter {
                     !ClientRegistry.parseIdSet(hiddenRaw).contains($0)
                 }, orderRaw: orderRaw)
-            : eligible
+        }
+        var out = ClientRegistry
+            .displayClients(present: present, hiddenRaw: hiddenRaw, orderRaw: orderRaw)
+            .filter(registered.contains)
         // A stored selection that stopped qualifying — the user hid it, or that
-        // agent has no usage this year — stays listed. Dropping it would tick
-        // nothing while the preference still names it, showing the user a state
-        // the app is not in.
-        if case .only(let id) = selection, !out.contains(id) { out.append(id) }
+        // agent has no usage — stays listed. Dropping it would tick nothing
+        // while the preference still names it, showing a state the app is not
+        // in. Only while it stays REGISTERED: an id the registry no longer
+        // knows is one `payload` rejects outright, so listing it would tick a
+        // row that can never publish. Nothing ticked is the honest answer
+        // there, and the same one `.malformed` already gets.
+        if case .only(let id) = selection, registered.contains(id), !out.contains(id) {
+            out.append(id)
+        }
         return out
     }
 

--- a/Sources/TokenBar/DiscordPresence.swift
+++ b/Sources/TokenBar/DiscordPresence.swift
@@ -216,6 +216,38 @@ enum DiscordPresence {
 
     static let defaultComponentsRaw = rawComponents(Set(Component.allCases))
 
+    /// The agents the picker may offer, in the user's own tab order.
+    ///
+    /// Derived from the two conditions `payload` already enforces, rather than
+    /// from the registry: a row is only publishable when the id is registered
+    /// (an unregistered one returns nil at the `.only` guard) and not hidden
+    /// (`trayTotals` filters it out of the totals). Offering anything else is a
+    /// row that reads as a choice and silently publishes nothing — the failure
+    /// the whole feature is built to avoid, arriving through the picker.
+    static func selectableClients(
+        present: [String], hiddenRaw: String, orderRaw: String, selection: ClientSelection
+    ) -> [String] {
+        let registered = Set(ClientRegistry.allIds)
+        let eligible = ClientRegistry
+            .displayClients(present: present, hiddenRaw: hiddenRaw, orderRaw: orderRaw)
+            .filter(registered.contains)
+        // `present` is empty until the first scan lands, and Settings can be
+        // opened before then. An empty picker would read as "your agents are
+        // gone"; the registry list is what shipped before this filter existed.
+        var out = eligible.isEmpty
+            ? ClientRegistry.orderedClients(
+                ClientRegistry.allIds.filter {
+                    !ClientRegistry.parseIdSet(hiddenRaw).contains($0)
+                }, orderRaw: orderRaw)
+            : eligible
+        // A stored selection that stopped qualifying — the user hid it, or that
+        // agent has no usage this year — stays listed. Dropping it would tick
+        // nothing while the preference still names it, showing the user a state
+        // the app is not in.
+        if case .only(let id) = selection, !out.contains(id) { out.append(id) }
+        return out
+    }
+
     /// One reader for both switches, so their strictness cannot drift apart.
     ///
     /// `as? Bool` alone is not enough: `NSNumber` bridges, so an integer 1 or a

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -7433,7 +7433,18 @@ enum SelfTest {
             present: ["claude", "codex", "cc-mirror/foo"], hiddenRaw: "codex", orderRaw: "",
             selection: .mostUsed)
         let dpPickUnloaded = DiscordPresence.selectableClients(
-            present: [], hiddenRaw: "claude", orderRaw: "", selection: .mostUsed)
+            present: nil, hiddenRaw: "claude", orderRaw: "", selection: .mostUsed)
+        // A scan that finished and found nothing is a real answer, not a
+        // not-loaded one: the honest picker offers only "whichever you used
+        // most". Collapsing it into the unloaded branch hands a user with no
+        // usage the whole registry back.
+        let dpPickNoUsage = DiscordPresence.selectableClients(
+            present: [], hiddenRaw: "", orderRaw: "", selection: .mostUsed)
+        // An id the registry no longer knows is one `payload` rejects outright,
+        // so listing it would tick a row that can never publish.
+        let dpPickUnknown = DiscordPresence.selectableClients(
+            present: ["claude"], hiddenRaw: "", orderRaw: "",
+            selection: .only("not-a-registered-client"))
         let dpPickStale = DiscordPresence.selectableClients(
             present: ["claude"], hiddenRaw: "codex", orderRaw: "", selection: .only("codex"))
         // Every other fixture passes an empty order, which leaves "in the user's
@@ -7445,16 +7456,20 @@ enum SelfTest {
         expect(
             dpPickVisible == ["claude"]
                 && dpPickUnloaded.count > 1 && !dpPickUnloaded.contains("claude")
+                && dpPickNoUsage.isEmpty
                 && dpPickStale.contains("codex") && dpPickStale.contains("claude")
+                && dpPickUnknown == ["claude"]
                 && dpPickOrdered == ["codex", "claude"],
             "the agent picker offers only registered, unhidden clients with usage, falls back to "
                 + "the registry before the first scan lands, and keeps a stored selection listed "
                 + "after it stops qualifying (mutation: dropping the registry filter offers "
                 + "`cc-mirror/foo`, which `payload` rejects; dropping the hidden filter offers a "
                 + "client `trayTotals` subtracts; dropping the fallback empties the picker while "
-                + "the dashboard is still loading; dropping the stale append ticks nothing while "
-                + "the preference still names that agent; ignoring `orderRaw` lists the agents in "
-                + "registry order instead of the one the user dragged)")
+                + "the dashboard is still loading; treating a finished empty scan as unloaded "
+                + "hands the whole registry to a user with no usage; dropping the stale append "
+                + "ticks nothing while the preference still names that agent; appending an "
+                + "unregistered stale id ticks a row `payload` rejects; ignoring `orderRaw` lists "
+                + "the agents in registry order instead of the one the user dragged)")
         // Combining is the union of the retire. Losing one would let a payload
         // built against a state that no longer holds reach the socket.
         expect(

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -7424,6 +7424,29 @@ enum SelfTest {
         } else {
             expect(false, "the isolated selection suite could not be created")
         }
+        // The picker's universe is derived from what `payload` will publish, not
+        // from the registry. Every row it offers that the payload path rejects
+        // is a choice the user makes and nothing happens — the same silent
+        // nothing the zero-usage and empty-component guards exist to prevent,
+        // arriving through Settings instead of through the wire.
+        let dpPickVisible = DiscordPresence.selectableClients(
+            present: ["claude", "codex", "cc-mirror/foo"], hiddenRaw: "codex", orderRaw: "",
+            selection: .mostUsed)
+        let dpPickUnloaded = DiscordPresence.selectableClients(
+            present: [], hiddenRaw: "claude", orderRaw: "", selection: .mostUsed)
+        let dpPickStale = DiscordPresence.selectableClients(
+            present: ["claude"], hiddenRaw: "codex", orderRaw: "", selection: .only("codex"))
+        expect(
+            dpPickVisible == ["claude"]
+                && dpPickUnloaded.count > 1 && !dpPickUnloaded.contains("claude")
+                && dpPickStale.contains("codex") && dpPickStale.contains("claude"),
+            "the agent picker offers only registered, unhidden clients with usage, falls back to "
+                + "the registry before the first scan lands, and keeps a stored selection listed "
+                + "after it stops qualifying (mutation: dropping the registry filter offers "
+                + "`cc-mirror/foo`, which `payload` rejects; dropping the hidden filter offers a "
+                + "client `trayTotals` subtracts; dropping the fallback empties the picker while "
+                + "the dashboard is still loading; dropping the stale append ticks nothing while "
+                + "the preference still names that agent)")
         // Combining is the union of the retire. Losing one would let a payload
         // built against a state that no longer holds reach the socket.
         expect(

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -7436,17 +7436,25 @@ enum SelfTest {
             present: [], hiddenRaw: "claude", orderRaw: "", selection: .mostUsed)
         let dpPickStale = DiscordPresence.selectableClients(
             present: ["claude"], hiddenRaw: "codex", orderRaw: "", selection: .only("codex"))
+        // Every other fixture passes an empty order, which leaves "in the user's
+        // saved tab order" unfalsifiable — the picker could ignore `orderRaw`
+        // entirely and still pass them.
+        let dpPickOrdered = DiscordPresence.selectableClients(
+            present: ["claude", "codex"], hiddenRaw: "", orderRaw: "codex,claude",
+            selection: .mostUsed)
         expect(
             dpPickVisible == ["claude"]
                 && dpPickUnloaded.count > 1 && !dpPickUnloaded.contains("claude")
-                && dpPickStale.contains("codex") && dpPickStale.contains("claude"),
+                && dpPickStale.contains("codex") && dpPickStale.contains("claude")
+                && dpPickOrdered == ["codex", "claude"],
             "the agent picker offers only registered, unhidden clients with usage, falls back to "
                 + "the registry before the first scan lands, and keeps a stored selection listed "
                 + "after it stops qualifying (mutation: dropping the registry filter offers "
                 + "`cc-mirror/foo`, which `payload` rejects; dropping the hidden filter offers a "
                 + "client `trayTotals` subtracts; dropping the fallback empties the picker while "
                 + "the dashboard is still loading; dropping the stale append ticks nothing while "
-                + "the preference still names that agent)")
+                + "the preference still names that agent; ignoring `orderRaw` lists the agents in "
+                + "registry order instead of the one the user dragged)")
         // Combining is the union of the retire. Losing one would let a payload
         // built against a state that no longer holds reach the socket.
         expect(

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -872,6 +872,12 @@ struct SettingsPanel: View {
             // work — so it is treated as switching the feature off for as long
             // as it stays empty.
             hint("Untick everything and nothing is published at all.")
+            // Read here, not inside the options expression: `selection()` goes
+            // to UserDefaults and registers no SwiftUI dependency, so the list
+            // would keep a de-listed selection visible after the user picked
+            // another row. Touching the @AppStorage raw is what re-renders.
+            let selectionRaw = discordSelectionRaw
+            let discordSelection = DiscordPresence.selection()
             radioGroup(
                 selection: Binding(
                     get: {
@@ -880,8 +886,8 @@ struct SettingsPanel: View {
                         // substitutes its empty default for a key holding a
                         // non-string, which would tick "most used" while the
                         // runtime published nothing at all.
-                        _ = discordSelectionRaw
-                        switch DiscordPresence.selection() {
+                        _ = selectionRaw
+                        switch discordSelection {
                         case .mostUsed: return ""
                         case .only(let id): return id
                         case .malformed: return DiscordPresence.malformedSelectionLabel
@@ -889,7 +895,12 @@ struct SettingsPanel: View {
                     },
                     set: { discordSelectionRaw = $0 }),
                 options: [("", "Whichever client you used most")]
-                    + ClientRegistry.allIds.map { ($0, ClientRegistry.style($0).displayName) })
+                    + DiscordPresence.selectableClients(
+                        present: presentClients,
+                        hiddenRaw: tabsHiddenRaw,
+                        orderRaw: tabsOrderRaw,
+                        selection: discordSelection
+                    ).map { ($0, ClientRegistry.style($0).displayName) })
             // Nothing is ticked when the stored value is malformed, which is
             // honest: the runtime publishes nothing, and no option describes
             // that. Picking any row writes a well-formed value and recovers.

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -38,7 +38,10 @@ struct SettingsPanel: View {
     var modelReport: ModelReport?
 
     /// Present clients (used for the client tabs reorder/hide UI).
-    var presentClients: [String] = []
+    /// nil until an accepted payload lands, which is DIFFERENT from a scan
+    /// that found nothing. Only the Discord picker distinguishes them; the
+    /// other readers below want "whatever is present right now" and flatten it.
+    var presentClients: [String]?
 
     /// True while either initial request is still in flight. An empty client list
     /// is otherwise indistinguishable from "still loading", and the first seconds
@@ -161,16 +164,16 @@ struct SettingsPanel: View {
         // Client tabs), instead of re-deriving `knownClientIds` per section.
         // `orderRaw:` overloads keep both lists reactive to a drag/reorder.
         let knownIds = AgentLimitsCard.knownClientIds(
-            agentUsage: agentUsage, present: presentClients)
+            agentUsage: agentUsage, present: presentClients ?? [])
         // Agent-limits management universe: only clients that can actually
         // render a quota card (placeholder rows or a live snapshot).
         let limitOrdered = ClientRegistry.orderedClients(knownIds, orderRaw: tabsOrderRaw)
         // Client-tabs universe: every client that can be a top tab (present)
         // OR a quota card (knownIds — e.g. quota-only Antigravity), so both
         // orderings are managed from one list. Mirrors displayClients' source.
-        let presentSet = Set(presentClients)
+        let presentSet = Set(presentClients ?? [])
         let tabsUniverse = ClientRegistry.orderedClients(
-            Self.orderedUnion(presentClients, knownIds), orderRaw: tabsOrderRaw)
+            Self.orderedUnion(presentClients ?? [], knownIds), orderRaw: tabsOrderRaw)
 
         VStack(alignment: .leading, spacing: 14) {
             switch page {
@@ -272,7 +275,7 @@ struct SettingsPanel: View {
     @ViewBuilder
     private func individualItemsSection() -> some View {
         let rows = ClientTray.settingsRows(
-            presentClients: presentClients,
+            presentClients: presentClients ?? [],
             payload: agentUsage,
             enabled: ClientTray.parseEnabledRaw(individualEnabledRaw),
             selections: ClientTray.parseSelectionsRaw(individualSelectionsRaw),

--- a/Sources/TokenBar/Views/SettingsWindowView.swift
+++ b/Sources/TokenBar/Views/SettingsWindowView.swift
@@ -125,7 +125,7 @@ struct SettingsWindowView: View {
                         page: selectedPage,
                         agentUsage: model.agentUsage,
                         modelReport: model.modelReport,
-                        presentClients: model.stats?.presentClients ?? [],
+                        presentClients: model.stats?.presentClients,
                         isLoading: isInitialLoad,
                         reportLoading: model.modelLoading)
                         .padding(14)


### PR DESCRIPTION
The Discord agent picker in Settings listed every client TokenBar knows about, whether or not the user had ever run it. Reported immediately after v1.13.0 shipped.

## Why those rows do nothing

`DiscordPresence.payload` publishes for a named client only when two conditions both hold:

```swift
guard ClientRegistry.allIds.contains(id) else { return nil }   // registered
let totals = graph.trayTotals(hidden: hidden, today: today, only: only)   // hidden subtracted
...
guard totals.todayTokens > 0 || totals.todayCost > 0 else { return nil }
```

The picker's options came from `ClientRegistry.allIds`, so it offered a row for every agent the user has never used and every agent they had hidden. Picking one is a choice that publishes nothing and says nothing about it — the same silent no-op the zero-usage and empty-component guards exist to prevent, arriving through Settings instead of through the wire.

## The change

`DiscordPresence.selectableClients(present:hiddenRaw:orderRaw:selection:)` derives the picker's universe from those same two conditions rather than from the registry: present clients, minus hidden, intersected with the registry, in the user's own tab order via the existing `ClientRegistry.displayClients` reactive overload.

Two cases a plain filter gets wrong, both handled:

| Case | Behaviour | Why |
|---|---|---|
| `present` is empty | Falls back to the registry minus hidden | It is empty until the first scan lands, and Settings can be opened before then. An empty picker reads as "your agents are gone", not "not loaded yet" |
| Stored selection stopped qualifying | Stays listed | The user hid that client, or it has no usage. Dropping it would tick nothing while `tokenbar.discord.client` still names it — showing a state the app is not in |

The call site now resolves `discordSelectionRaw` and `selection()` into locals above `radioGroup`. `selection()` reads `UserDefaults` and registers no SwiftUI dependency; with the options list now depending on the selection, evaluating it inside the options expression would leave a de-listed selection visible after the user picked another row.

## Verification

`make build`, `make selftest`, `swift run TokenBar --smoke` all pass.

One behavioural assertion covers all five properties, and each was mutation-checked independently — every mutation turns it from `ok` to `FAIL`, with the rest of the suite still green:

| Guard removed | Observed failure |
|---|---|
| Registry filter | `cc-mirror/foo` is offered, which `payload` rejects |
| Hidden filter | A client `trayTotals` subtracts is offered |
| Unloaded fallback | The picker is empty while the dashboard is still loading |
| Stale-selection append | Nothing is ticked while the preference still names that agent |
| Saved tab order | Agents list in registry order instead of the dragged one |

The last row is the second commit. The first three fixtures all passed `orderRaw: ""`, and `orderedClients` returns its input unchanged for an empty order — so "in the user's own tab order" was unfalsifiable, and the whole ordering could have been deleted without the assertion noticing. A local verifier pass caught it.

That verifier also raised the opposite failure direction, which is the one worth worrying about here: an agent the runtime *would* publish for but the picker no longer offers. It read `presentClients` as the dashboard's year-filtered set, which would narrow the picker whenever a past year is selected. That does not hold — `SettingsWindowView` constructs its own `DashboardModel(initialYear: nil)` for exactly this reason, so a saved year filter cannot reach this picker.
