### PR TITLE
fix(pace): color the deficit marker by the gap, not by the estimator

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2726,11 +2726,22 @@ enum SelfTest {
             "linear mode ignores available historical")
         expect(UsagePace.compute(window: availableWindow, now: now)?.basis == .linear,
             "direct pace compute stays linear")
+        // The warning color is basis-independent: a Linear estimate in deficit
+        // is colored exactly like a Historical one, so the marker cannot blink
+        // out when the Historical fit stops re-qualifying. `linear` is the
+        // 50%/50% available window — on track, so not colored — and `hist` is a
+        // historical *reserve*, the negative control on the other side.
+        let linearDeficit = UsagePace.compute(
+            window: v3Window(used: 80, state: .available, historicalPace: historicalLasts),
+            mode: .linear, now: now)
         expect(
-            AgentLimitsCard.PacePresentation.isHistoricalDeficit(risky)
-                && !AgentLimitsCard.PacePresentation.isHistoricalDeficit(learningEstimate)
-                && !AgentLimitsCard.PacePresentation.isHistoricalDeficit(linear),
-            "UI warning color requires historical-basis deficit")
+            AgentLimitsCard.PacePresentation.isDeficit(risky)
+                && AgentLimitsCard.PacePresentation.isDeficit(learningEstimate)
+                && AgentLimitsCard.PacePresentation.isDeficit(linearDeficit)
+                && linearDeficit?.basis == .linear
+                && !AgentLimitsCard.PacePresentation.isDeficit(linear)
+                && !AgentLimitsCard.PacePresentation.isDeficit(hist),
+            "UI warning color follows the deficit stage, not the pace basis")
         let unavailableWindow = v3Window(used: 50, state: .unavailable)
         expect(UsagePace.compute(
             window: unavailableWindow, mode: .historical, now: now) == nil,
@@ -6197,7 +6208,7 @@ enum SelfTest {
         expect(
             demoLearningEstimate?.basis == .linear
                 && demoLearningEstimate?.isHistoricalDeficit == false,
-            "demo learning-history estimate cannot trigger historical warning color")
+            "demo learning-history estimate stays a Linear basis in the parity contract")
         expect(
             demoHistoricalAhead?.basis == .historical
                 && demoHistoricalAhead?.stage.isDeficit == true

--- a/Sources/TokenBar/Views/AgentLimitsCard.swift
+++ b/Sources/TokenBar/Views/AgentLimitsCard.swift
@@ -101,8 +101,16 @@ struct AgentLimitsCard: View {
             }
         }
 
-        static func isHistoricalDeficit(_ pace: UsagePace?) -> Bool {
-            pace?.isHistoricalDeficit == true
+        /// Warning color follows codexbar: the marker is tinted when actual
+        /// usage has passed the expected line, whichever estimator drew that
+        /// line. Keying it to the basis instead made the warning blink out
+        /// whenever the Historical fit failed to re-qualify — `available` is
+        /// re-decided on every refresh by an out-of-sample fit gate, so a card
+        /// oscillates between Historical and `learningHistory` while the deficit
+        /// underneath never moves. The status text still names the basis, so a
+        /// Linear estimate stays identifiable without the color flickering.
+        static func isDeficit(_ pace: UsagePace?) -> Bool {
+            pace?.stage.isDeficit == true
         }
     }
 
@@ -505,7 +513,7 @@ struct AgentLimitsCard: View {
                         let left = asUsed ? $0.expectedUsedPercent : 100 - $0.expectedUsedPercent
                         return min(100, max(0, left))
                     },
-                    paceIsDeficit: Self.PacePresentation.isHistoricalDeficit(pace))
+                    paceIsDeficit: Self.PacePresentation.isDeficit(pace))
                 paceFooter(window: window, leftLabel: leftLabel, pace: pace)
             }
         }
@@ -573,7 +581,7 @@ struct AgentLimitsCard: View {
         Text(text)
             .font(.caption2)
             .foregroundStyle(
-                Self.PacePresentation.isHistoricalDeficit(pace)
+                Self.PacePresentation.isDeficit(pace)
                     ? AnyShapeStyle(.orange) : AnyShapeStyle(.tertiary))
     }
 

--- a/Sources/TokenBarCore/UsagePace.swift
+++ b/Sources/TokenBarCore/UsagePace.swift
@@ -45,7 +45,11 @@ public struct UsagePace: Sendable {
     /// True if the current rate lasts past the reset (won't run out).
     public let willLastToReset: Bool
 
-    /// Yellow historical deficit is valid only for a backend historical result.
+    /// Which estimator produced a deficit — the cross-language parity contract's
+    /// basis discriminator. **Not** the warning-color rule: the card tints by
+    /// `stage.isDeficit` alone, because `available` is re-decided on every
+    /// refresh by an out-of-sample fit gate and keying the color here made it
+    /// blink out while the deficit underneath never moved.
     public var isHistoricalDeficit: Bool {
         basis == .historical && stage.isDeficit
     }

--- a/docs/knowledge/plans/provider-quota-pace.md
+++ b/docs/knowledge/plans/provider-quota-pace.md
@@ -309,7 +309,9 @@ windowKey == nil <=> unavailable(windowIdentity)
 
 Linear setting 也使用同一個 exact `durationSeconds`。Historical setting 只有在 `learningHistory` 可以暫時使用 Linear，而且 UI 必須明示；`learningDuration`、`unavailable`、`legacyMissing` 都不能 silent fallback。Settings 文案要從「weekly curve」改成「learns each quota window's usage pattern」。
 
-黃色 ahead／deficit 狀態只有在 `available` 時能宣稱是 historical comparison；`learningHistory` 的 Linear estimate 必須以不同文案標示，避免把測試用 reverse 或硬編文字誤認為真實 historical result。
+「這是 historical comparison」的宣稱只有在 `available` 時成立，而且**只由文案承擔**：`learningHistory` 的 Linear estimate 必須以不同文案標示，避免把測試用 reverse 或硬編文字誤認為真實 historical result。
+
+橘色 ahead／deficit 標記本身不承擔這個宣稱——只要 actual 越過 expected 線就上色，Historical 與 Linear 同色。理由是 `available` 由每次 refresh 重跑的 out-of-sample fit gate 決定（`evaluate_partial_projection` 有六個 `return None` 分支：bucket 數、phase span、fit quality、slope、crossing 範圍），同一張 card 會在 `available` 與 `learningHistory` 之間來回；把顏色綁在 basis 上，使用者看到的是預測「一下子就不見了」，而底層 deficit 一直存在。
 
 ## Generic historical evaluator
 
@@ -559,7 +561,7 @@ Mac-owned [`provider-quota-pace-v3.json`](../../../Fixtures/CrossCheck/provider-
 
 | Case | Required result |
 |---|---|
-| Historical available | Card 使用 Rust historical expected、ETA、will-last與risk；ahead狀態可呈現真正黃色 |
+| Historical available | Card 使用 Rust historical expected、ETA、will-last與risk；ahead狀態上橘色（與 Linear 的 deficit 同色） |
 | Learning duration | 顯示 `Learning reset duration`，不顯示 deficit、projected empty或 lasts |
 | Learning history | 明示 Linear estimate；不得看起來像已啟用 Historical |
 | Unavailable／legacy payload | 顯示 typed unavailable／update state，不 silent Linear |

--- a/docs/knowledge/verification.md
+++ b/docs/knowledge/verification.md
@@ -123,7 +123,7 @@ Live account-scope smoke必須在hermetic security suite通過後才執行，且
 
 不需要 `.app` bundle 語意的人工 UI 檢查，優先從 repository root 執行 `swift run TokenBar --open-popover`。只有 icon、`Info.plist`、`LSUIElement`、Sparkle、autostart 或安裝路徑等 bundle-only 行為，才以 `make bundle` 產生的 `dist/TokenBar.app` 驗收。
 
-Provider quota pace 以 `swift run TokenBar --demo --open-popover` 提供 deterministic 人工驗收面；snapshot badge 明示 `FIXTURE`，且 `DemoUsageDataSource` 不呼叫 live FFI、不讀寫 quota cache。Historical／Linear／Off 都要實際呈現；驗收時必須區分低 remaining 觸發的 quota 長條黃／紅健康色，與只有 `available` historical deficit 才可使用的 pace marker／footer 橘色。
+Provider quota pace 以 `swift run TokenBar --demo --open-popover` 提供 deterministic 人工驗收面；snapshot badge 明示 `FIXTURE`，且 `DemoUsageDataSource` 不呼叫 live FFI、不讀寫 quota cache。Historical／Linear／Off 都要實際呈現；驗收時必須區分低 remaining 觸發的 quota 長條黃／紅健康色，與 deficit stage 觸發的 pace marker／footer 橘色。橘色只看 actual 有沒有越過 expected 線，不看是哪個 estimator 畫出那條線——Historical 與 Linear 的 deficit 同色，狀態文案仍必須分辨兩者。舊規則（只有 `available` 可上色）已廢止：`available` 由每次 refresh 重跑的 out-of-sample fit gate 決定，同一張卡會在 Historical 與 `learningHistory` 之間來回，把顏色綁在 basis 上會讓使用者看到預測「一下子就不見了」，而底層 deficit 其實一直存在。
 
 Individual client items的deterministic Settings檢查以Argument Domain注入初始偏好；這只驗visual state與initial routing，不在同一process宣稱toggle persistence：
 


### PR DESCRIPTION
The pace marker and its footer were tinted only when `basis == .historical`, so a Linear estimate sitting in deficit rendered exactly like one on track.

## Why this reads as "the prediction keeps disappearing"

`available` is not a stable property of a card. It is re-decided on **every refresh** by an out-of-sample fit gate — `evaluate_partial_projection` has six `return None` branches (bucket count, phase span, fit quality, slope, crossing bounds) — so a window oscillates between `available` and `learningHistory` while the deficit underneath never moves. Keying the color to the basis published that oscillation as though it were the signal: the warning appeared when the fit happened to qualify and vanished when it did not, with nothing about the user's actual usage having changed.

## What it does now

The marker is tinted when actual usage has passed the expected line, whichever estimator drew that line. This is codexbar's rule — its stripe is colored by `paceOnTop` alone (`UsageProgressBar.swift`), and the estimator is invisible to that decision.

Historical and Linear deficits now look the same. The status text still names the basis, so `Learning history · Linear estimate` stays distinguishable without the color carrying that claim — which is the right split, because the text is a statement about provenance and the color is a statement about the gap.

## What is deliberately unchanged

`UsagePace.isHistoricalDeficit` keeps its name and its meaning. It is the cross-language parity contract's basis discriminator, emitted by `CrossCheckHarness` and asserted by the Windows fixture, so redefining it would break that seam for a presentation change. Only the card stopped consulting it to pick a color. Its doc comment previously described itself as the color rule and now says the opposite, since that sentence is exactly what would send the next reader down the wrong path.

## Verification

`make build` and `make selftest` pass.

The replaced assertion is proven falsifiable: reverting `isDeficit` to the old basis rule produces `FAIL UI warning color follows the deficit stage, not the pace basis`, and restoring it returns to green. It carries two negative controls on opposite sides — `linear` is an available window at 50%/50%, on track and therefore uncolored, and `hist` is a historical *reserve*. Without both, a rule that colored everything would pass.

Visual acceptance through `swift run TokenBar --demo --open-popover`. In the fixture all three rows are `Learning history · Linear estimate`, so basis is held constant and only the gap differs: Claude Code's `17% in reserve` and `31% in reserve` render grey, Codex CLI's `4% in deficit` renders orange along with its marker on the bar. Before this change that third row was grey too.

Docs updated: `verification.md`'s acceptance line no longer says only `available` may be colored, and `provider-quota-pace.md` records that the historical-comparison claim is carried by the copy rather than by the color, with the fit-gate branches as the evidence for why.

Follows #204, which fixed the other half of the same report — history restarting on every external token rotation.
