### PR TITLE
build(sparkle): compile the updater with installed-name normalization on

### DIFF
--- a/docs/knowledge/release.md
+++ b/docs/knowledge/release.md
@@ -4,8 +4,8 @@ id: kb-release
 kind: canonical
 scope: repository
 read_when: changing release scripts, code signing, appcast, Sparkle, Homebrew, Pages, or post-release notes
-last_verified: 2026-07-17
-sources: [".github/workflows/release.yml", ".github/workflows/pages.yml", ".github/workflows/update-install-count.yml", "scripts/bundle.sh", "appcast.xml", "Makefile", "docs/knowledge/plans/provider-quota-pace.md", "public release history"]
+last_verified: 2026-08-09
+sources: [".github/workflows/release.yml", ".github/workflows/ci.yml", ".github/workflows/pages.yml", ".github/workflows/update-install-count.yml", "scripts/bundle.sh", "scripts/build-sparkle.sh", "appcast.xml", "Makefile", "docs/knowledge/plans/provider-quota-pace.md", "public release history"]
 ---
 
 # Release and delivery
@@ -20,6 +20,7 @@ sources: [".github/workflows/release.yml", ".github/workflows/pages.yml", ".gith
 - [Application release](#application-release)
 - [Code signing and local secret storage](#code-signing-and-local-secret-storage)
 - [Sparkle and appcast](#sparkle-and-appcast)
+- [Sparkle is compiled here, not taken from the prebuilt artifact](#sparkle-is-compiled-here-not-taken-from-the-prebuilt-artifact)
 - [Migration principle](#migration-principle)
 - [Legacy and beta migration](#legacy-and-beta-migration)
 - [Homebrew and install count](#homebrew-and-install-count)
@@ -71,6 +72,18 @@ The release workflow is tag-driven. It validates and bundles the native app, pro
 The feed is a single multi-item appcast. Stable items are channel-less; prerelease items carry the beta channel. The generator reads the existing feed, preserves prior items and signatures, and keeps a bounded history instead of overwriting the feed with one item.
 
 This matters because a single-item writer can hide a still-valid stable version when a bridge or prerelease item is added. The appcast fix uses Sparkle's `generate_appcast` and keeps the application-side channel toggle as a lazy delegate for a possible future beta lane.
+
+## Sparkle is compiled here, not taken from the prebuilt artifact
+
+`scripts/bundle.sh` embeds a `Sparkle.framework` built by `scripts/build-sparkle.sh` with `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME=1`. The official prebuilt xcframework ships that macro off, and it is a compile-time constant rather than an Info.plist key, so no app-side declaration can turn it on. With it off, Sparkle always installs over the host bundle's existing path — an app can never change its own filename through an update. Enabling it is what allows a future rename of the installed bundle to happen through the updater instead of the app moving itself.
+
+The macro has three consumers, all inside the framework, so one rebuild covers them: choosing the install path, switching away from the atomic swap when that path changes, and relaunching the app at the new path.
+
+Source comes from SwiftPM's own checkout under `.build/checkouts/Sparkle`, which `Package.resolved` already pins. A separate clone would introduce a second revision to keep in sync with the one the app links against. The macro appears in none of the framework's public headers, so the app still compiles and links against the stock SPM artifact and `Package.swift` is unchanged; only the binary copied into `Contents/Frameworks` differs. Building it takes roughly two to three minutes and is skipped when the output already matches the pinned revision.
+
+> **Updater rule：** this is the highest-consequence single point in the release chain. A defective framework breaks updating for the entire installed base at once, and the cask is `auto_updates true`, so `brew upgrade` is not a rescue channel. `scripts/bundle.sh` therefore asserts on the binary it just copied — the bundled `Autoupdate` must reference `SUNormalizedInstallationPath` — and fails the build otherwise. The assertion is on the shipping artifact rather than on source text, and it discriminates: the official prebuilt scores zero under the same check. Do not weaken it into a source scan, and do not make embedding the framework conditional; an app assembled without an updater looks fine and silently never updates again.
+
+CI runs `scripts/bundle.sh` on pushes to `main` through `make selftest-bundled`, so a broken Sparkle build fails there rather than after a tag is pushed. Upgrading Sparkle now means rebuilding it here; the prebuilt artifact cannot simply be consumed again.
 
 ## Migration principle
 

--- a/scripts/build-sparkle.sh
+++ b/scripts/build-sparkle.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Build Sparkle.framework with installed-application-name normalization enabled.
+#
+#   scripts/build-sparkle.sh        # builds if needed, prints the framework path
+#
+# Why this exists: SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME is a
+# compile-time macro (Sparkle's Configurations/ConfigCommon.xcconfig sets it to
+# 0), not an Info.plist key, so the official prebuilt xcframework can never
+# perform the v2.0 TokenBar.app -> Syrtis.app rename no matter what the app
+# declares. Enabling it requires compiling Sparkle ourselves. OpenAI did the
+# same for the Codex -> ChatGPT rename.
+#
+# The macro has three consumers, all inside the framework, so one rebuild
+# covers them: SUInstaller.m (chooses the install path), SUPlainInstaller.m
+# (switches away from the atomic swap when the path changes) and
+# InstallerProgressAppController.m (relaunches the app at the new path).
+#
+# Source comes from SwiftPM's own checkout, which Package.resolved already pins.
+# Cloning Sparkle separately would create a second revision to keep in sync with
+# the one the app links against.
+#
+# The macro is not exposed in any of the framework's 23 public headers, so the
+# app still compiles and links against the stock SPM artifact; only the binary
+# copied into Contents/Frameworks changes. Package.swift is untouched.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SRC=".build/checkouts/Sparkle"
+OUT=".build/sparkle-normalized"
+FRAMEWORK="$OUT/Sparkle.framework"
+STAMP="$OUT/.built-from"
+
+[ -d "$SRC" ] || { echo "build-sparkle: $SRC missing — run 'swift build' first" >&2; exit 1; }
+REV="$(git -C "$SRC" rev-parse HEAD)"
+# Universal, matching the official xcframework slice the app used to ship.
+WANT="$REV arm64 x86_64 normalize=1"
+
+if [ -d "$FRAMEWORK" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$WANT" ]; then
+  echo "$FRAMEWORK"
+  exit 0
+fi
+
+command -v xcodebuild >/dev/null || {
+  echo "build-sparkle: xcodebuild not found. Full Xcode is required to bundle a" >&2
+  echo "  release; the Command Line Tools alone cannot build Sparkle." >&2
+  exit 1
+}
+
+echo "==> building normalization-enabled Sparkle (${REV:0:12}, ~2-3 min)" >&2
+rm -rf "$OUT"; mkdir -p "$OUT"
+xcodebuild -project "$SRC/Sparkle.xcodeproj" -scheme Sparkle -configuration Release \
+  -derivedDataPath "$OUT/dd" \
+  -clonedSourcePackagesDirPath "$OUT/spm" \
+  SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME=1 \
+  ONLY_ACTIVE_ARCH=NO ARCHS="arm64 x86_64" \
+  CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM="" \
+  build >"$OUT/build.log" 2>&1 || { tail -40 "$OUT/build.log" >&2; exit 1; }
+
+cp -R "$OUT/dd/Build/Products/Release/Sparkle.framework" "$FRAMEWORK"
+echo "$WANT" > "$STAMP"
+echo "$FRAMEWORK"

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -44,10 +44,31 @@ cp -R Sources/TokenBar/Resources/Localizations/*.lproj "$APP/Contents/Resources/
 if [ -f assets/icon.icns ]; then
   cp assets/icon.icns "$APP/Contents/Resources/icon.icns"
 fi
-# Sparkle framework (SPM binary artifact).
-SPARKLE_FRAMEWORK=".build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
-if [ -d "$SPARKLE_FRAMEWORK" ]; then
-  cp -R "$SPARKLE_FRAMEWORK" "$APP/Contents/Frameworks/"
+# Sparkle framework, compiled here rather than taken from the SPM binary
+# artifact — see scripts/build-sparkle.sh for why the official prebuilt one
+# cannot rename the installed app. Not conditional: an app assembled without an
+# updater looks fine and silently never updates again.
+SPARKLE_FRAMEWORK="$(scripts/build-sparkle.sh)"
+cp -R "$SPARKLE_FRAMEWORK" "$APP/Contents/Frameworks/"
+
+# Assert on the binary that actually ships, not on the source that produced it.
+# With the macro off the call is compiled out, so the stock artifact scores zero
+# here — this check has been run against both and does discriminate. Without it,
+# a build that quietly fell back to the official framework would reach users as
+# an app whose next major version can never rename itself, and there is no
+# second channel to correct that (the cask is auto_updates true).
+#
+# `grep -c`, not `grep -q`: under `set -o pipefail` a quiet grep closes the pipe
+# on its first match, `strings` dies of SIGPIPE, and the pipeline reports
+# failure exactly when the check passes. Counting reads all the input, and the
+# count is the thing being asserted anyway.
+NORMALIZE_REFS="$(strings -a "$APP/Contents/Frameworks/Sparkle.framework/Versions/Current/Autoupdate" \
+                  | grep -c SUNormalizedInstallationPath || true)"
+if [ "$NORMALIZE_REFS" -eq 0 ]; then
+  echo "error: bundled Sparkle lacks installed-name normalization." >&2
+  echo "  Built from: $SPARKLE_FRAMEWORK" >&2
+  echo "  Remove .build/sparkle-normalized and re-run to rebuild it." >&2
+  exit 1
 fi
 
 cat > "$APP/Contents/Info.plist" <<PLIST


### PR DESCRIPTION
The app now embeds a `Sparkle.framework` compiled here with `SPARKLE_NORMALIZE_INSTALLED_APPLICATION_NAME=1`, instead of copying the official prebuilt xcframework out of the SwiftPM artifact directory.

**This PR renames nothing.** Normalization resolves to the bundle's current path unless the host also declares `SUBundleName`, which nothing does. That was observed, not assumed — see the inertness rows below.

## Why the prebuilt artifact cannot be used

The flag is a compile-time macro, set to `0` in Sparkle's `Configurations/ConfigCommon.xcconfig`. It is not an Info.plist key, so no declaration on the app side can turn it on. With it off, `SUInstaller` always installs over the host bundle's own path, and an app can never change its installed filename through an update.

OpenAI shipped the Codex to ChatGPT rename this way. On the copy of that app installed here, `Autoupdate` references `SUNormalizedInstallationPath` twice; the official prebuilt binary references it zero times.

The macro has three consumers, all inside the framework, so one rebuild covers them:

| Site | Role |
|---|---|
| `SUInstaller.m` | chooses the install path |
| `SUPlainInstaller.m` | switches away from the atomic swap when that path changes |
| `InstallerProgressAppController.m` | relaunches the app at the new path |

Patching only the first would not be equivalent.

## How it is built

`scripts/build-sparkle.sh` builds from `.build/checkouts/Sparkle` — SwiftPM's own checkout, already pinned by `Package.resolved`. A separate clone would introduce a second revision to keep in sync with the one the app links against. Output lands in `.build/sparkle-normalized` behind a stamp recording revision and settings, so repeat bundles skip the roughly two-and-a-half minute build. Universal (arm64 + x86_64), matching the xcframework slice that shipped before.

A missing `xcodebuild` is a hard error rather than a fallback. The Command Line Tools alone cannot build Sparkle, and silently reverting to the official framework is the exact failure this change exists to prevent.

`Package.swift` is untouched. The macro appears in none of the framework's 23 public headers, so the app still compiles and links against the stock SPM artifact; only the binary copied into `Contents/Frameworks` differs.

## The guard

`scripts/bundle.sh` asserts on the framework it just copied: the bundled `Autoupdate` must reference `SUNormalizedInstallationPath`, or the build fails.

> This is the highest-consequence single point in the release chain. A defective framework breaks updating for the entire installed base at once, and the cask is `auto_updates true`, so `brew upgrade` is not a rescue channel.

The assertion is on the shipping artifact rather than on source text, so relocating code cannot escape it, and it discriminates in both directions — see the mutation rows below.

It uses `grep -c`, not `grep -q`. Under `set -o pipefail` a quiet grep closes the pipe on its first match, `strings` dies of SIGPIPE, and the pipeline reports failure precisely when the check passes. The first run of this change failed exactly that way, on a framework that was correct.

Embedding the framework is also no longer conditional. The previous `if [ -d ]` silently produced an app with no updater, which looks fine and never updates again.

## Verification

Eight update-chain lanes ran against a stand-in app driven by a headless `SPUUserDriver`, so the whole chain is exercised without clicking. Every lane where the host carries the self-built framework is also evidence that the framework performs real installs.

| Lane | Scenario | Result |
|---|---|---|
| 1 | self-built framework, whole chain | pass, by lanes 3/5/6 actually performing installs |
| 2 | in-place update, host without normalization | pass, no move |
| 3 | host declares `SUBundleName`, target differs | pass, moved, old leaf gone, one copy on disk |
| 4 | version skip from a pre-normalization host | pass, no move, contents updated |
| 5 | that machine, one release later | pass, moves then, self-heal confirmed |
| 6 | destination already occupied | pass, falls back in place, occupant untouched |
| 7 | a release between arming and the rename | renames early, filename ahead of branding — recorded, not a defect of this PR |
| 8 | **normalization with no `SUBundleName`** | **pass, inert, no move** |

Then the real app, since the lanes above bypass the framework's UI half:

| Check | Result |
|---|---|
| real app updates through its own `UpdaterService` and the framework's `SPUStandardUserDriver` | 9.0.0 to 9.0.1, completed |
| bundle filename after that update | unchanged — inertness holds for the real app too |
| `codesign --verify --deep --strict` after Sparkle's install | pass |
| `make bundle`, `make selftest-bundled` | green; the latter runs the bundled binary, which also proves the app loads the framework at its rpath |
| exported symbol set, self-built vs official | zero differences; identical resource tree; `SPUStandardUserDriver` and `SPUStandardUpdaterController` exported by both |
| guard fed the official framework | build fails, exit 1 |
| guard fed the self-built framework | build passes |
| cold rebuild after deleting the output | reproduces the property, third independent build |

The real-app run used a throwaway bundle identifier, the spike's throwaway EdDSA key, an install directory outside `/Applications`, and obviously fake versions. The shipping preference domain, the release signing key and the installed app were not touched.

## Known gaps

CI does not run `scripts/bundle.sh` on pull requests — that step is push-only by existing policy, for the build-time reasons documented in `ci.yml`. So the first time CI compiles Sparkle is the `main` push after merge, on a runner whose Xcode may differ from the one used here. A failure there lands before any tag and is recoverable, but that run is worth watching.

Upgrading Sparkle from now on means rebuilding it here; the prebuilt artifact cannot simply be consumed again.

## Documentation

`docs/knowledge/release.md` gains a section covering all of the above, including an updater rule stating that the guard must not be weakened into a source scan and that embedding the framework must not become conditional again.
