### PR TITLE
chore(release): prepare v1.13.2 notes

### DIFF
--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -1,3 +1,25 @@
+## Before you update
+
+**Pace history restarts once.** Quota cards for Claude, Grok, Copilot and Antigravity will show "Learning history · Linear estimate" again and rebuild their curve over the next few days — a short window in hours, a little longer for a weekly one. Nothing is broken; this is the one-time cost of the identity fix below, and it does not repeat. Codex is unaffected.
+
 ## Fixes
 
-- **The Discord agent picker no longer lists every agent TokenBar recognises.** It used to offer a row for each one, including agents you had never run and agents you had hidden, and naming one of those left the presence empty without saying why. [#202](https://github.com/Nanako0129/TokenBar/pull/202)
+- **Pace history no longer restarts every time another app refreshes a shared login.** [#204](https://github.com/Nanako0129/TokenBar/pull/204)
+
+  Providers without a stable account identifier keyed their history on a fingerprint of the OAuth refresh token. When a sibling application rotated that token — the Claude CLI refreshing its own Keychain item, for instance — TokenBar saw a credential it did not recognise and began learning from zero. On one machine this had produced 17 separate series holding 1,007 unreachable samples for a single Claude account, and Historical pace could never accumulate.
+
+  Durable history now has its own identity, separate from the one used for caching. Where a provider exposes a stable account ID it is still used, so Codex and the Antigravity IDE keep their per-account separation. Where none exists, history is now keyed per installation, which means two accounts on one machine share one curve on those providers. That is deliberate: the curve describes how a person consumes a window, which belongs to the operator rather than to the billing account.
+
+- **A pace marker in deficit is highlighted whichever estimator produced it.** [#205](https://github.com/Nanako0129/TokenBar/pull/205)
+
+  Only a historical result was coloured before, so a linear estimate sitting in deficit looked identical to one on track. Because the historical fit is re-evaluated on every refresh, the warning appeared and vanished while the deficit underneath never moved. The colour now follows the gap; the status text still says which estimator drew the line.
+
+- **A clock disagreement no longer discards the whole quota history.** [#206](https://github.com/Nanako0129/TokenBar/pull/206)
+
+  A single forward jump of the system clock — a time sync, or a sleep and wake — was latched permanently into a window's timestamps. Once the clock settled back, every later read saw a value from the future and quarantined the entire store, taking every provider's history with it. One report lost 585 samples and three weeks of evidence this way, with every other invariant intact.
+
+  Such a store is now repaired in place instead of being discarded, and only a window whose own recorded observations cannot be verified is dropped. Structurally damaged files are still quarantined exactly as before. Reported by [@starburst3190](https://github.com/starburst3190) with the quarantined file's timestamps isolated to the single failing invariant, which is what made the cause findable. [#144](https://github.com/Nanako0129/TokenBar/issues/144)
+
+## Changes
+
+- Updater: the bundled Sparkle framework is now compiled from source as part of the build. [#208](https://github.com/Nanako0129/TokenBar/pull/208)

--- a/release-notes.override.md
+++ b/release-notes.override.md
@@ -1,6 +1,14 @@
 ## Before you update
 
-**Pace history restarts once.** Quota cards for Claude, Grok, Copilot and Antigravity will show "Learning history · Linear estimate" again and rebuild their curve over the next few days — a short window in hours, a little longer for a weekly one. Nothing is broken; this is the one-time cost of the identity fix below, and it does not repeat. Codex is unaffected.
+**Pace history restarts once.** Affected quota cards show "Learning history · Linear estimate" again and rebuild their curve — a short window within hours, a weekly one over a few days. Nothing is broken; this is the one-time cost of the identity fix below, and it does not repeat.
+
+Which cards depends on whether the provider gives TokenBar a stable account identifier, not on the provider's name:
+
+| Keeps its history | Starts over |
+|---|---|
+| Codex, when its stored credential carries an account ID | Claude, on every login route |
+| The Antigravity IDE | Grok, Copilot, and Antigravity's remote login |
+| | Codex, if its credential has no account ID |
 
 ## Fixes
 

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -1,8 +1,8 @@
 Note:
-- Pace history restarts once with this update. Quota cards return to "Learning history" and rebuild over the next few days. This is the cost of the identity fix below and it happens only once.
+- Pace history restarts once with this update. A card returns to "Learning history" and rebuilds unless its provider gives TokenBar a stable account identifier, which today means Codex with an account ID on its credential, and the Antigravity IDE. This is the cost of the identity fix below and it happens only once.
 
 Fixes:
-- Pace history no longer restarts every time another app refreshes a shared login. Claude, Grok, Copilot and Antigravity kept losing their learned usage curve whenever the Claude CLI or a sibling tool rotated the credential they share, so Historical pace could never accumulate.
+- Pace history no longer restarts every time another app refreshes a shared login. Providers without a stable account identifier kept losing their learned usage curve whenever the Claude CLI or a sibling tool rotated the credential they share, so Historical pace could never accumulate.
 - A pace marker in deficit is now highlighted whether it came from the historical curve or the linear estimate. Previously only a historical result was coloured, so the warning appeared and disappeared as the fit requalified while the deficit itself never moved.
 - A clock disagreement no longer discards the whole quota history. A single forward jump of the system clock, from a time sync or a sleep and wake, could leave one window with a timestamp ahead of the next read, which quarantined every provider's history at once. It is now repaired in place, and only genuinely unverifiable data is dropped.
 

--- a/release-notes.override.txt
+++ b/release-notes.override.txt
@@ -1,2 +1,10 @@
+Note:
+- Pace history restarts once with this update. Quota cards return to "Learning history" and rebuild over the next few days. This is the cost of the identity fix below and it happens only once.
+
 Fixes:
-- The Discord agent picker no longer lists every agent TokenBar recognises. It used to offer a row for each one, including agents you had never run and agents you had hidden, and naming one of those left the presence empty without saying why.
+- Pace history no longer restarts every time another app refreshes a shared login. Claude, Grok, Copilot and Antigravity kept losing their learned usage curve whenever the Claude CLI or a sibling tool rotated the credential they share, so Historical pace could never accumulate.
+- A pace marker in deficit is now highlighted whether it came from the historical curve or the linear estimate. Previously only a historical result was coloured, so the warning appeared and disappeared as the fit requalified while the deficit itself never moved.
+- A clock disagreement no longer discards the whole quota history. A single forward jump of the system clock, from a time sync or a sleep and wake, could leave one window with a timestamp ahead of the next read, which quarantined every provider's history at once. It is now repaired in place, and only genuinely unverifiable data is dropped.
+
+Improved:
+- Updater: the bundled Sparkle framework is now compiled from source as part of the build.


### PR DESCRIPTION
Release-note overrides for **v1.13.2**. No code change — these two files replace the generated text on the GitHub Release body and on the Sparkle appcast and legacy metadata respectively.

## What is in the release

`v1.13.1..main` is 13 commits across four PRs.

| PR | Change | User-visible |
|---|---|---|
| [#204](https://github.com/Nanako0129/TokenBar/pull/204) | Durable pace history gets an identity that survives token rotation | **Yes — history restarts once** |
| [#205](https://github.com/Nanako0129/TokenBar/pull/205) | The deficit marker is coloured by the gap, not by the estimator | Yes |
| [#206](https://github.com/Nanako0129/TokenBar/pull/206) | A clock disagreement is repaired instead of discarding the store | Yes |
| [#208](https://github.com/Nanako0129/TokenBar/pull/208) | The bundled Sparkle framework is compiled from source | No |

Patch rather than minor: no feature ships here. The one-time history reset is a consequence of a fix, not a new capability, and it is handled by the notes rather than implied by the version.

## Why the lead item is a warning

Changing the key durable pace history is stored under means every affected provider's card returns to "Learning history · Linear estimate" on first launch and rebuilds. That is exactly the symptom [#183](https://github.com/Nanako0129/TokenBar/issues/183) described, so a user who is not told will report the fix as the bug. The note names the providers, gives a rough duration, and says Codex is unaffected — "nothing is broken" only lands with something checkable attached.

## Credit

[@starburst3190](https://github.com/starburst3190) is credited on the clock-disagreement entry for isolating the quarantined file's timestamps to the single failing invariant. That is what made the mechanism findable; the root cause was the part [#144](https://github.com/Nanako0129/TokenBar/issues/144) had explicitly left open.

## Sparkle

One sentence, exactly as its handoff specified. That commit's body discusses a future rename — none of it belongs in a release note and none of it is in this release. The override is what ships if the generator pulls more.

## Not done here

Tagging. Publishing is an irreversible public state change and needs its own instruction; `docs/knowledge/release.md` puts that outside what preparing the notes authorises.

After publishing, in addition to the usual drift check across the Release body, appcast and legacy metadata, the Sparkle handoff asks for one artifact check on the downloaded app:

```bash
strings -a "<downloaded>/TokenBar.app/Contents/Frameworks/Sparkle.framework/Versions/Current/Autoupdate" \
  | grep -c SUNormalizedInstallationPath      # expect 2
```
