### PR TITLE
fix(clients): drop the form-factor suffix from three non-surface-scoped display names

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -890,6 +890,21 @@ enum SelfTest {
         expect(ClientRegistry.style("kimi").displayName == "Kimi", "Kimi registry covers CLI and Code")
         expect(ClientRegistry.style("junie").displayName == "Junie", "Junie registry metadata")
         expect(ClientRegistry.style("opencodereview").displayName == "OpenCodeReview", "OpenCodeReview registry metadata")
+        // Sources that are not surface-scoped carry no form-factor suffix:
+        // ~/.codex/sessions is majority Codex Desktop, ~/.copilot merges CLI
+        // OTel with the desktop app's data.db, and the cursor source is an
+        // account-level billing export. Naming any of them "... CLI"/"... IDE"
+        // claims a scope the data does not have.
+        for (id, name) in [("codex", "Codex"), ("copilot", "Copilot"), ("cursor", "Cursor")] {
+            expect(ClientRegistry.style(id).displayName == name,
+                "\(id) carries no form-factor suffix — its source spans CLI, IDE and desktop")
+            expect(ClientRegistry.shortName(id) == name,
+                "\(id) legend label is unchanged by dropping the suffix")
+        }
+        // The " IDE" arm of shortName was dropped with "Cursor IDE"; it stays
+        // dropped only while no registered name ends in it.
+        expect(ClientRegistry.allIds.allSatisfy { !ClientRegistry.style($0).displayName.hasSuffix(" IDE") },
+            "no registered display name ends in \" IDE\" (shortName no longer strips it)")
         // AgentLimitsCard keeps its own generic "-cli" fold for quota-card
         // attribution: explicit aliases via the registry, then a local strip so
         // antigravity-cli shares the antigravity quota snapshot — this fold must
@@ -3607,7 +3622,7 @@ enum SelfTest {
                 && dpHidden.map { !$0.fields.values.joined().contains("1.2M") } == true,
             "published tokens are the visible-only sum, and the mixed day-level total reaches "
                 + "no field (mutation: reading the day-level totals publishes 1.2M)")
-        expect(dpHidden?.state.contains("Codex CLI") == true
+        expect(dpHidden?.state.contains("Codex") == true
             && dpHidden?.state.contains("Claude Code") == false,
             "the top client skips the hidden client (mutation: dropping the hidden filter from "
                 + "the fold publishes Claude Code)")
@@ -3806,7 +3821,7 @@ enum SelfTest {
             graph: dpFoldGraph, hidden: [], today: dpToday, costStyle: .banded, components: dpAllComponents)
         expect(dpFold?.state.hasPrefix("Claude Code") == true,
             "the top client folds stripes per client first (mutation: max over raw stripes picks "
-                + "Codex CLI's single 50 over Claude Code's 30+30)")
+                + "Codex's single 50 over Claude Code's 30+30)")
 
         // Deterministic tie-break: tokens, then higher cost, then the smallest
         // id. The six-way tie is fed in both orders because an unsorted key walk

--- a/Sources/TokenBarCore/ClientRegistry.swift
+++ b/Sources/TokenBarCore/ClientRegistry.swift
@@ -17,9 +17,17 @@ public enum ClientRegistry {
         "openclaw": ("OpenClaw", "#dc2626"),
         "gemini": ("Gemini CLI", "#60a5fa"),
         "opencode": ("OpenCode", "#1f2937"),
-        "codex": ("Codex CLI", "#9ca3af"),
-        "copilot": ("Copilot CLI", "#1f2937"),
-        "cursor": ("Cursor IDE", "#0ea5e9"),
+        // No form-factor suffix on these three: their sources are not
+        // surface-scoped. `codex` reads ~/.codex/sessions, written by Codex
+        // Desktop / the IDE extension / the CLI alike (a 1733-file sample was
+        // 70% "Codex Desktop", 4% CLI). `copilot` merges the CLI/VS Code OTel
+        // export with the desktop app's ~/.copilot/data.db. `cursor` is not a
+        // session parser at all — it reads Cursor's account usage export CSV,
+        // which bills IDE, cursor-agent and cloud agents into one undifferentiated
+        // ledger.
+        "codex": ("Codex", "#9ca3af"),
+        "copilot": ("Copilot", "#1f2937"),
+        "cursor": ("Cursor", "#0ea5e9"),
         "amp": ("Amp", "#10b981"),
         "droid": ("Droid", "#22c55e"),
         "hermes": ("Hermes", "#a78bfa"),
@@ -67,7 +75,7 @@ public enum ClientRegistry {
     public static func shortName(_ id: String) -> String {
         let name = style(id).displayName
         let registeredNames = Set(entries.values.map { $0.displayName })
-        for suffix in [" CLI", " Code", " IDE"] where name.hasSuffix(suffix) {
+        for suffix in [" CLI", " Code"] where name.hasSuffix(suffix) {
             let base = String(name.dropLast(suffix.count))
             // Don't collapse onto a base that is itself another client's full
             // name — e.g. "Antigravity CLI" must stay distinct from the IDE

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -8,7 +8,7 @@
 ## What it is
 - Native macOS menu-bar app for Apple Silicon, macOS 14+ (Liquid Glass needs macOS 26; earlier systems get a vibrancy fallback). MIT licensed, free, open source.
 - v1.0.0 (June 2026) replaced the original Tauri implementation; the Tauri repo is archived and `tokenbar@legacy` pins its final build (v0.4.5, macOS 11+).
-- Tracks 25+ AI coding agents from local logs: Claude Code, Codex CLI, Cursor, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Goose, Kilo/KiloCode, Roo Code, Qwen, Kimi, Crush, Zed, Kiro, Trae, Warp, and more.
+- Tracks 25+ AI coding agents from local logs: Claude Code, Codex, Cursor, OpenCode, Gemini CLI, Copilot, Amp, Droid, Hermes, Goose, Kilo/KiloCode, Roo Code, Qwen, Kimi, Crush, Zed, Kiro, Trae, Warp, and more.
 - Session parsing, dedup, and pricing are delegated to the vendored tokscale-core crate.
 
 ## Dashboard views

--- a/landing/src/i18n/copy.ts
+++ b/landing/src/i18n/copy.ts
@@ -143,7 +143,7 @@ const en = {
       },
       {
         q: 'Which AI coding tools does it track?',
-        a: '25+ agents from their local logs — Claude Code, Codex CLI, Cursor, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Goose, Kilo/KiloCode, Roo Code, Qwen, Kimi, Crush, Zed, Kiro, Trae, Warp and more. Parsing is handled by the vendored tokscale-core, so coverage tracks tokscale.',
+        a: '25+ agents from their local logs — Claude Code, Codex, Cursor, OpenCode, Gemini CLI, Copilot, Amp, Droid, Hermes, Goose, Kilo/KiloCode, Roo Code, Qwen, Kimi, Crush, Zed, Kiro, Trae, Warp and more. Parsing is handled by the vendored tokscale-core, so coverage tracks tokscale.',
       },
       {
         q: 'Does it cost anything?',
@@ -353,7 +353,7 @@ const zhTw: typeof en = {
       },
       {
         q: '追蹤哪些 AI 編碼工具？',
-        a: '25+ 個 agent，直接讀本機紀錄——Claude Code、Codex CLI、Cursor、OpenCode、Gemini CLI、Copilot CLI、Amp、Droid、Hermes、Goose、Kilo/KiloCode、Roo Code、Qwen、Kimi、Crush、Zed、Kiro、Trae、Warp 等。解析交給 vendored tokscale-core，涵蓋範圍跟著 tokscale 走。',
+        a: '25+ 個 agent，直接讀本機紀錄——Claude Code、Codex、Cursor、OpenCode、Gemini CLI、Copilot、Amp、Droid、Hermes、Goose、Kilo/KiloCode、Roo Code、Qwen、Kimi、Crush、Zed、Kiro、Trae、Warp 等。解析交給 vendored tokscale-core，涵蓋範圍跟著 tokscale 走。',
       },
       {
         q: '要錢嗎？',


### PR DESCRIPTION
## What

Three entries in `ClientRegistry.entries` carried a form-factor suffix their data source does not support. This drops the suffix.

| id | Was | Now |
|---|---|---|
| `codex` | Codex CLI | **Codex** |
| `copilot` | Copilot CLI | **Copilot** |
| `cursor` | Cursor IDE | **Cursor** |

## Why

Each name claimed a scope the underlying source does not have.

**`codex`** reads `~/.codex/sessions`, which every Codex surface writes to. Breaking down 1,733 local rollout files by `session_meta.originator`:

| originator | files |
|---|---|
| Codex Desktop | 1,218 |
| Claude Code (shared runtime via the codex plugin) | 441 |
| codex-tui | 50 |
| codex_exec | 18 |
| codex_cli_rs | 4 |
| codex_work_desktop / codex_vscode | 1 each |

The actual CLI is roughly 4% of what the card was labelling "Codex CLI".

**`copilot`** merges two parsers into one client id in `lib.rs` via `prefer_copilot_otel_messages`. `sessions/copilot.rs` reads OTel JSONL exported by both Copilot CLI and VS Code Copilot Chat; `sessions/copilot_desktop.rs` reads the macOS desktop app's `~/.copilot/data.db` and `~/.copilot/session-state/`.

**`cursor`** is not a session parser at all. `sessions/cursor.rs` parses Cursor's account usage export CSV cached at `~/.config/tokscale/cursor-cache/*.csv`. The only surface-bearing columns are `Cloud Agent ID` and `Automation ID` — `Kind` is a billing class, not an interface — so IDE, `cursor-agent` and cloud-agent spend all land in one undifferentiated ledger. TokenBar never fetches this export; it only reads whatever the upstream tokscale CLI left behind.

## Names deliberately left alone

> This started as a one-name fix and was widened to a full audit of every suffixed display name. These were checked and kept.

| id | Name | Source, and why the name holds |
|---|---|---|
| `gemini` | Gemini CLI | `~/.gemini/tmp`, CLI only |
| `qwen` | Qwen CLI | `~/.qwen/projects` |
| `kilo` | Kilo CLI | `~/.local/share/kilo/kilo.db` |
| `grok` | Grok Build | product name, not a suffix |
| `claude` | Claude Code | product name covering all its surfaces |
| `antigravity` / `antigravity-cli` | Antigravity / Antigravity CLI | genuinely two independent sources |

The Antigravity pair is worth spelling out, because the naming looks like the same bug and is not. The IDE client reads a JSONL cache under the config dir; the CLI client reads `~/.gemini/antigravity-cli/*.db`. Their shared Agent-limits card is also correct: `agent_antigravity.rs` fetches an account-level Google Code Assist quota — local language-server `GetUserStatus` over loopback, or the `cloudcode-pa.googleapis.com` OAuth path — which covers the desktop IDE and the CLI alike, and `AgentLimitsCard` already aliases the `antigravity` snapshot onto `antigravity-cli` for exactly that reason.

## Blast radius

Everywhere `shortName` is used — chart legend, top tabs, DayBars labels, the Settings client list — output is **unchanged**, because those already stripped the suffix and showed `Codex` / `Copilot` / `Cursor` before this PR. What changes is the full `displayName`: the Agent-limits card header and the Discord presence string.

With "Cursor IDE" gone, the `" IDE"` arm of `shortName`'s suffix list matches nothing, so it is removed.

```diff
-        for suffix in [" CLI", " Code", " IDE"] where name.hasSuffix(suffix) {
+        for suffix in [" CLI", " Code"] where name.hasSuffix(suffix) {
```

## Verification

| Check | Result |
|---|---|
| `make selftest` | 603 assertions, passed |
| `cargo test -p tb_core_ffi --release` | 335 passed, 0 failed |

SelfTest gains three paired assertions (displayName and shortName per renamed id) plus an invariant that no registered display name ends in `" IDE"` — that invariant is the precondition for having deleted the arm, so it fails loudly if someone reintroduces one.

Both were mutation-checked rather than trusted for being green:

| Mutation | Outcome |
|---|---|
| restore `"codex": ("Codex CLI", ...)` | displayName assertion fails; the shortName assertion still passes, confirming the pair tests two different things |
| add a `"Zed IDE"` entry | `" IDE"` invariant fails |

> **Not observed in the running app.** The Agent-limits card header is the surface this PR exists to fix and it has no assertion on its rendered text — the Discord presence string does, and the card renders the same `style.displayName` one hop away, but that is inference, not observation. Flagging it rather than leaving it implied.

## Also updated

The landing FAQ and `llms.txt` listed the same two stale names; both locales are corrected.
