### PR TITLE
fix(attribution): disclose the routes the engine merged, and stop asking about zero

### DIFF
--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -210,7 +210,7 @@
 "Nothing is classified yet. Classify sources in Settings → Usage attribution." = "目前尚未分類任何內容。請前往「設定」→「用量歸屬」分類來源。";
 "No attributed usage in this range." = "這個區間沒有歸屬用量。";
 "Classify each observed client/provider source against the subscription it should count toward. Nothing here is inferred as a billing event." = "將每個觀察到的用戶端／供應商來源分類到它應計入的訂閱。這裡沒有任何內容是推測出的帳務事件。";
-"Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently. A few arrive already merged and cannot be separated here: Vertex AI is reported as Anthropic, and Codex as OpenAI." = "供應商 ID 會完全按照來源送出的內容進行比對，因此看起來相關的路由仍可能顯示為不同列，並分別分類。少數路由在送達前就已被合併，在這裡無法再拆開：Vertex AI 會回報為 Anthropic，Codex 會回報為 OpenAI。";
+"Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently. Some clients merge them before reporting — Vertex AI arriving as Anthropic, Codex as OpenAI — and a row that arrived merged cannot be split here." = "供應商 ID 會完全按照來源送出的內容進行比對，因此看起來相關的路由仍可能顯示為不同列，並分別分類。部分 client 會在回報前先行合併——Vertex AI 併入 Anthropic、Codex 併入 OpenAI——已合併送達的列在這裡無法再拆開。";
 "A declaration is your classification, not a billing fact." = "這項宣告是你的分類，不是帳務事實。";
 "No provider-split usage in this range." = "這個區間沒有按供應商分列的用量。";
 "Accept all suggestions (%lld)" = "接受所有建議（%lld）";

--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -210,7 +210,7 @@
 "Nothing is classified yet. Classify sources in Settings → Usage attribution." = "目前尚未分類任何內容。請前往「設定」→「用量歸屬」分類來源。";
 "No attributed usage in this range." = "這個區間沒有歸屬用量。";
 "Classify each observed client/provider source against the subscription it should count toward. Nothing here is inferred as a billing event." = "將每個觀察到的用戶端／供應商來源分類到它應計入的訂閱。這裡沒有任何內容是推測出的帳務事件。";
-"Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently." = "供應商 ID 會完全按照來源送出的內容進行比對，因此看起來相關的路由仍可能顯示為不同列，並分別分類。";
+"Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently. A few arrive already merged and cannot be separated here: Vertex AI is reported as Anthropic, and Codex as OpenAI." = "供應商 ID 會完全按照來源送出的內容進行比對，因此看起來相關的路由仍可能顯示為不同列，並分別分類。少數路由在送達前就已被合併，在這裡無法再拆開：Vertex AI 會回報為 Anthropic，Codex 會回報為 OpenAI。";
 "A declaration is your classification, not a billing fact." = "這項宣告是你的分類，不是帳務事實。";
 "No provider-split usage in this range." = "這個區間沒有按供應商分列的用量。";
 "Accept all suggestions (%lld)" = "接受所有建議（%lld）";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2051,6 +2051,24 @@ enum SelfTest {
                     isLoading: false) == .empty,
             "a source observed at zero is not offered for classification")
 
+        // The Stats breakdown keeps any entry with `total != 0 || cost != 0`.
+        // Settings must not be stricter, or the card can report unassigned
+        // usage the settings page offers no row to classify. A negative
+        // aggregate is the case where a positive test and a nonzero test part.
+        let negativeSourceEntries = [
+            attributionEntry(
+                client: "cursor", provider: "anthropic", model: "corrupt-model",
+                total: -5, cost: 0.0),
+        ]
+        expect(
+            UsageAttributionSettings.rows(
+                entries: negativeSourceEntries, confirmed: [], suggestions: []
+            ).map(\.tokens) == [-5]
+                && UsageAttributionBreakdown.rows(
+                    entries: negativeSourceEntries, clientIds: ["cursor"], confirmed: []
+                ).contains { $0.tokens == -5 },
+            "settings keeps every source the breakdown card still reports")
+
         let allTimeSource = AttributedSeriesTestSource(
             graphPayload: payloadFixture([
                 contributionJSON(

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2016,6 +2016,41 @@ enum SelfTest {
                 && !UsageAttributionSettings.Copy.canonicalizationHint.contains("canonicalized"),
             "attribution copy describes exact provider comparison")
 
+        // The engine folds `vertex`/`vertex_ai` into `anthropic` and
+        // `openai_codex` into `openai` before the report is built, so two
+        // billing relationships share one row and no later stage can split
+        // them. Saying only that this page compares exactly reads as a promise
+        // that nothing was merged anywhere.
+        expect(
+            UsageAttributionSettings.Copy.canonicalizationHint.contains(
+                "Vertex AI is reported as Anthropic")
+                && UsageAttributionSettings.Copy.canonicalizationHint.contains(
+                    "Codex as OpenAI"),
+            "attribution copy discloses the routes the engine already merged")
+
+        let zeroSourceRows = UsageAttributionSettings.rows(
+            entries: [
+                attributionEntry(
+                    client: "cursor", provider: "anthropic", model: "idle-model",
+                    total: 0, cost: 0.0),
+                attributionEntry(
+                    client: "claude", provider: "anthropic", model: "used-model",
+                    total: 41, cost: 0.5),
+            ],
+            confirmed: [],
+            suggestions: [])
+        expect(
+            zeroSourceRows.map(\.client) == ["claude"]
+                && UsageAttributionSettings.pageState(
+                    hasReport: true,
+                    rowCount: UsageAttributionSettings.rows(
+                        entries: [attributionEntry(
+                            client: "cursor", provider: "anthropic", model: "idle-model",
+                            total: 0, cost: 0.0)],
+                        confirmed: [], suggestions: []).count,
+                    isLoading: false) == .empty,
+            "a source observed at zero is not offered for classification")
+
         let allTimeSource = AttributedSeriesTestSource(
             graphPayload: payloadFixture([
                 contributionJSON(

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2073,6 +2073,32 @@ enum SelfTest {
                 ).contains { $0.tokens == -5 },
             "settings keeps every source the breakdown card still reports")
 
+        // The same test has to run at the same stage as the card's, not merely
+        // read the same. Two rows that cancel are individually nonzero, so the
+        // card keeps both and — resolving each before folding — can place them
+        // in different buckets and report them. A settings filter applied to
+        // the sum would see one empty source and offer nothing to classify.
+        let cancellingEntries = [
+            attributionEntry(
+                client: "cursor", provider: "anthropic", model: "credited-model",
+                total: 5, cost: 0.0),
+            attributionEntry(
+                client: "cursor", provider: "anthropic", model: "reversed-model",
+                total: -5, cost: 0.0),
+        ]
+        expect(
+            UsageAttributionSettings.rows(
+                entries: cancellingEntries, confirmed: [], suggestions: []
+            ).map { ($0.provider, $0.tokens) }.map { "\($0.0)=\($0.1)" } == ["anthropic=0"]
+                && UsageAttributionBreakdown.rows(
+                    entries: cancellingEntries,
+                    clientIds: ["cursor"],
+                    confirmed: [UsageAttribution.Record(
+                        client: "cursor", provider: "anthropic", model: "credited-model",
+                        state: .assigned("claude"))]
+                ).count == 2,
+            "a source whose rows cancel is still offered for classification")
+
         let allTimeSource = AttributedSeriesTestSource(
             graphPayload: payloadFixture([
                 contributionJSON(

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -2016,17 +2016,21 @@ enum SelfTest {
                 && !UsageAttributionSettings.Copy.canonicalizationHint.contains("canonicalized"),
             "attribution copy describes exact provider comparison")
 
-        // The engine folds `vertex`/`vertex_ai` into `anthropic` and
-        // `openai_codex` into `openai` before the report is built, so two
-        // billing relationships share one row and no later stage can split
-        // them. Saying only that this page compares exactly reads as a promise
-        // that nothing was merged anywhere.
+        // Parsers that call `provider_identity::n` fold `vertex` into
+        // `anthropic` and `openai_codex` into `openai` before the report is
+        // built, so two billing relationships share one row no later stage can
+        // split. Fourteen parsers never call it, so the same aliases stay
+        // separable there. Both halves must be present and the claim must be
+        // hedged: "nothing is merged" is false for Claude Code, "Codex is
+        // reported as OpenAI" is false for OpenClaw.
         expect(
             UsageAttributionSettings.Copy.canonicalizationHint.contains(
-                "Vertex AI is reported as Anthropic")
+                "Vertex AI arriving as Anthropic")
                 && UsageAttributionSettings.Copy.canonicalizationHint.contains(
-                    "Codex as OpenAI"),
-            "attribution copy discloses the routes the engine already merged")
+                    "Codex as OpenAI")
+                && UsageAttributionSettings.Copy.canonicalizationHint.contains(
+                    "Some clients merge them"),
+            "attribution copy discloses merged routes as something only some clients do")
 
         let zeroSourceRows = UsageAttributionSettings.rows(
             entries: [

--- a/Sources/TokenBarCore/UsageAttributionSettings.swift
+++ b/Sources/TokenBarCore/UsageAttributionSettings.swift
@@ -5,14 +5,19 @@ public enum UsageAttributionSettings {
     public enum Copy {
         public static let section = "Usage attribution"
         public static let classifyHint = "Classify each observed client/provider source against the subscription it should count toward. Nothing here is inferred as a billing event."
-        /// Two facts about provider identity, deliberately in one hint. The
-        /// first is about this page: it compares whatever string the report
-        /// emitted, and never canonicalizes. The second is about what reaches
-        /// it: the engine already folds a few routes together upstream
-        /// (`canonical_provider`), and those cannot be separated here at any
-        /// later stage. Stating only the first reads as a promise that nothing
-        /// was merged, which is the opposite of what happens to Vertex.
-        public static let canonicalizationHint = "Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently. A few arrive already merged and cannot be separated here: Vertex AI is reported as Anthropic, and Codex as OpenAI."
+        /// Two facts about provider identity, deliberately in one hint, and
+        /// both hedged for a reason.
+        ///
+        /// The first is about this page: it compares whatever string arrived
+        /// and never canonicalizes. The second is about what arrives.
+        /// `canonical_provider` folds `vertex` into `anthropic` and
+        /// `openai_codex` into `openai`, but it is applied per parser, not
+        /// globally — of the engine's session parsers, fourteen never call it,
+        /// so an OpenClaw row really does keep `openai-codex` as its own
+        /// classifiable source. Neither half can be stated flatly: "nothing is
+        /// merged" is false for Claude Code, and "Codex is reported as OpenAI"
+        /// is false for OpenClaw. Hence "some clients".
+        public static let canonicalizationHint = "Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently. Some clients merge them before reporting — Vertex AI arriving as Anthropic, Codex as OpenAI — and a row that arrived merged cannot be split here."
         public static let declarationHint = "A declaration is your classification, not a billing fact."
         public static let noRows = "No provider-split usage in this range."
         /// The report request finished without one. Distinct from `noRows`,

--- a/Sources/TokenBarCore/UsageAttributionSettings.swift
+++ b/Sources/TokenBarCore/UsageAttributionSettings.swift
@@ -5,7 +5,14 @@ public enum UsageAttributionSettings {
     public enum Copy {
         public static let section = "Usage attribution"
         public static let classifyHint = "Classify each observed client/provider source against the subscription it should count toward. Nothing here is inferred as a billing event."
-        public static let canonicalizationHint = "Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently."
+        /// Two facts about provider identity, deliberately in one hint. The
+        /// first is about this page: it compares whatever string the report
+        /// emitted, and never canonicalizes. The second is about what reaches
+        /// it: the engine already folds a few routes together upstream
+        /// (`canonical_provider`), and those cannot be separated here at any
+        /// later stage. Stating only the first reads as a promise that nothing
+        /// was merged, which is the opposite of what happens to Vertex.
+        public static let canonicalizationHint = "Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently. A few arrive already merged and cannot be separated here: Vertex AI is reported as Anthropic, and Codex as OpenAI."
         public static let declarationHint = "A declaration is your classification, not a billing fact."
         public static let noRows = "No provider-split usage in this range."
         /// The report request finished without one. Distinct from `noRows`,
@@ -304,6 +311,12 @@ public enum UsageAttributionSettings {
 
         return order.compactMap { key in
             guard let value = aggregate[key] else { return nil }
+            // A source observed at zero has nothing to classify: no tokens were
+            // spent, so no subscription could have covered them. Dropping it
+            // here rather than in the view keeps `pageState` honest — a range
+            // whose only sources are empty reads as "no usage", not as a page
+            // of decisions waiting to be made.
+            guard value.tokens > 0 || value.cost != 0 else { return nil }
             let state = UsageAttribution.resolve(
                 client: value.client, provider: value.provider, model: nil, records: confirmed)
             // A stored suggestion carries its own state now: `excluded` is a

--- a/Sources/TokenBarCore/UsageAttributionSettings.swift
+++ b/Sources/TokenBarCore/UsageAttributionSettings.swift
@@ -301,6 +301,15 @@ public enum UsageAttributionSettings {
         var aggregate: [String: (client: String, provider: String, tokens: Int64, cost: Double)] = [:]
         var order: [String] = []
         for entry in entries {
+            // Per entry and before folding, which is where
+            // `UsageAttributionBreakdown.rows` applies the same test. Applying
+            // it to the aggregate instead would agree on every ordinary input
+            // and part on one that cancels: two rows of +5 and -5 sum to an
+            // empty source here while the card, having resolved each row first,
+            // can still place them in different buckets and report both. Same
+            // test at the same stage is one invariant; same test at two stages
+            // is an invariant plus a standing obligation to remember it.
+            guard entry.total != 0 || entry.cost != 0 else { continue }
             let key = sourceKey(client: entry.client, provider: entry.provider)
             if let current = aggregate[key] {
                 aggregate[key] = (
@@ -316,18 +325,6 @@ public enum UsageAttributionSettings {
 
         return order.compactMap { key in
             guard let value = aggregate[key] else { return nil }
-            // A source observed at zero has nothing to classify: no tokens were
-            // spent, so no subscription could have covered them. Dropping it
-            // here rather than in the view keeps `pageState` honest — a range
-            // whose only sources are empty reads as "no usage", not as a page
-            // of decisions waiting to be made.
-            //
-            // Nonzero, not positive, and deliberately the same test
-            // `UsageAttributionBreakdown.rows` applies. The two surfaces
-            // describe one set of sources: anything the Stats card is willing
-            // to report as unassigned must have a row here to classify it,
-            // including a pathological negative aggregate.
-            guard value.tokens != 0 || value.cost != 0 else { return nil }
             let state = UsageAttribution.resolve(
                 client: value.client, provider: value.provider, model: nil, records: confirmed)
             // A stored suggestion carries its own state now: `excluded` is a

--- a/Sources/TokenBarCore/UsageAttributionSettings.swift
+++ b/Sources/TokenBarCore/UsageAttributionSettings.swift
@@ -316,7 +316,13 @@ public enum UsageAttributionSettings {
             // here rather than in the view keeps `pageState` honest — a range
             // whose only sources are empty reads as "no usage", not as a page
             // of decisions waiting to be made.
-            guard value.tokens > 0 || value.cost != 0 else { return nil }
+            //
+            // Nonzero, not positive, and deliberately the same test
+            // `UsageAttributionBreakdown.rows` applies. The two surfaces
+            // describe one set of sources: anything the Stats card is willing
+            // to report as unassigned must have a row here to classify it,
+            // including a pathological negative aggregate.
+            guard value.tokens != 0 || value.cost != 0 else { return nil }
             let state = UsageAttribution.resolve(
                 client: value.client, provider: value.provider, model: nil, records: confirmed)
             // A stored suggestion carries its own state now: `excluded` is a

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -177,7 +177,7 @@ Pricing metadata is refreshable rather than frozen for the process lifetime; the
 | 跨 client 建議的政策 | `crossAgentSubscriptionProviders` 允許從其他 agent 使用，涵蓋三類：第一方賣跨 agent 存取的（`openai`、`xai`）、coding plan 本身就是賣給別的 agent 用的中國廠商（`deepseek`、`moonshot`、`minimax`、`zhipu`、`alibaba`）、以及根本不涉及廠商關係的（`open-weights` 產品自行代管、`own` 產品自訓、`microsoft`／`amazon` 只在別人的 bundle 裡賣）。`subscriptionBoundProviders`（`anthropic`、`google`）不允許。兩者必須互斥，且每個訂閱服務的 provider 都要落在其一——self-test 對此 fail closed |
 | Bound 的對象是訂閱而非 provider | `providerOwnClient` 指出每個 provider 自己的訂閱屬於哪個 client。bound 規則只排除該 client 作為跨 agent 目標；轉售同一 provider 的訂閱（Copilot 服務 `anthropic`）不受限 |
 | opencode 的第二個所有權來源 | `opencodeSubscriptions` 以顯示標籤報告已 oauth 的 provider。解析三段：四個改名（`Codex`／`Claude`／`Copilot`／`Gemini`）走 `subscriptionLabelAliases` 顯式反查；其餘標籤是大寫的 provider key，先去掉方案後綴（`Minimax-coding-plan` → `minimax`），再查 `providerOwnClient`——**不是** `subscriptionProviderMap`，因為多數 provider 有多個轉售商，「唯一涵蓋者」對 `Xai` 之類已無法判定，而 oauth 條目代表使用者直接簽入該廠商，答案必然是它的第一方 client。查不到時退而接受該段本身為 client，但僅限它確實賣方案（`Kimi-for-coding` → `kimi`，因為 key 命名產品而非廠商）；否則不成為目標 |
-| 已知不可分 | `canonical_provider` 使 `openai_codex`／`openai`、`vertex`／`anthropic` 在資料裡同鍵。UI 必須明載，不得假裝可分 |
+| 已知不可分 | 呼叫 `provider_identity::n` 的 parser 會使 `openai_codex`／`openai`、`vertex`／`anthropic` 在資料裡同鍵。**但正規化是 per-parser**（見上一列）：14 個 session parser 從不呼叫它，同一組別名在那些來源仍是可獨立分類的兩列。UI 必須明載這件事會發生，且必須寫成條件句——「一律合併」與「一律不合併」都是錯的 |
 | 帳號變更 | `agent_usage` wire 不帶 account scope，Swift 端偵測不到帳號更換，因此不宣稱對應會隨帳號失效 |
 
 > **政策來源：** 上述 provider 分組是可稽核的產品知識，不是從本機用量或 quota payload 推論而得。新增 provider 時必須選邊，self-test 對此 fail closed。


### PR DESCRIPTION
Two gaps left by the Usage attribution page that shipped in v1.13.0.

## Provider identity was described from one side only

`canonicalizationHint` told the user:

> Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently.

That is true of this page, and misleading about what reaches it. The engine's `canonical_provider` folds routes together before a report is ever built:

```rust
"anthropic" | "vertex" | "vertex_ai" => "anthropic",
"openai"    | "openai_codex"         => "openai",
```

Vertex-hosted Claude and Anthropic direct are two billing relationships arriving under one key, and no stage after the fold can separate them. Read against that, the sentence promised the opposite of what happens. [`docs/knowledge/architecture.md`](../blob/main/docs/knowledge/architecture.md) already recorded the requirement — 「UI 必須明載，不得假裝可分」 — without it existing anywhere in the UI.

The hint now carries both facts. The zh-Hant translation moves with it, because the English text is the lookup key and an unchanged entry would have silently fallen back to English.

## Sources observed at zero were offered for classification

`rows` built a row for every observed source key, including keys with no usage — a Cursor row reading `0 tokens · $0.00` asked which subscription had paid for nothing.

The guard lives in `rows` rather than in the view on purpose. Keeping it here is what makes `pageState` honest: a range whose only sources are empty now reads as `.empty` — "No provider-split usage in this range." — instead of presenting a page of decisions that cannot matter. A row with zero tokens but non-zero cost is kept; that is spend, however it arrived.

## Verification

`make selftest` green, `python3 scripts/check_knowledge.py` passes.

Both new assertions were mutated to prove they can fail:

| Mutation | Result |
|---|---|
| Strip the disclosure sentence from the hint | `FAIL attribution copy discloses the routes the engine already merged` |
| Remove the zero-usage guard from `rows` | `FAIL a source observed at zero is not offered for classification` |

The second asserts through `pageState`, not only the row array, so a filter that dropped the row without reaching the page would not satisfy it.
