### PR TITLE
test(selftest): gate model re-entry arrivals deterministically

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -282,6 +282,36 @@ private func waitUntil(
     return await predicate()
 }
 
+/// Proves every re-entry task has started on the MainActor before a fixture
+/// observes the state those tasks should have reached. Resuming the waiter does
+/// not preempt the current actor job, so the last entrant continues until its
+/// next suspension before the waiter can inspect the shared model request.
+@MainActor
+private final class MainActorArrivalGate {
+    private let target: Int
+    private var arrivals = 0
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    init(target: Int) {
+        precondition(target > 0)
+        self.target = target
+    }
+
+    func arrive() {
+        precondition(arrivals < target, "arrival gate received too many entrants")
+        arrivals += 1
+        guard arrivals == target, let waiter else { return }
+        self.waiter = nil
+        waiter.resume()
+    }
+
+    func waitForTarget() async {
+        if arrivals == target { return }
+        precondition(waiter == nil, "arrival gate supports one waiter")
+        await withCheckedContinuation { waiter = $0 }
+    }
+}
+
 private enum DashboardModelTestError: Error {
     case graphUnavailable
 }
@@ -5295,10 +5325,21 @@ enum SelfTest {
             await reentryModel.load()
             await reentrySource.blockModel()
             let firstEntry = Task { await reentryModel.ensureModelColors() }
-            _ = await waitUntil { await reentrySource.pendingModelCount() > 0 }
-            let secondEntry = Task { await reentryModel.ensureModelColors() }
-            let thirdEntry = Task { await reentryModel.ensureModelData(for: .models) }
-            let coalescedWhileInFlight = await reentrySource.pendingModelCount() == 1
+            let firstEntryParked = await waitUntil {
+                await reentrySource.pendingModelCount() > 0
+            }
+            let reentryArrivals = MainActorArrivalGate(target: 2)
+            let secondEntry = Task { @MainActor in
+                reentryArrivals.arrive()
+                await reentryModel.ensureModelColors()
+            }
+            let thirdEntry = Task { @MainActor in
+                reentryArrivals.arrive()
+                await reentryModel.ensureModelData(for: .models)
+            }
+            await reentryArrivals.waitForTarget()
+            let pendingAfterReentry = await reentrySource.pendingModelCount()
+            let coalescedWhileInFlight = firstEntryParked && pendingAfterReentry == 1
             await reentrySource.releaseModel()
             await firstEntry.value
             await secondEntry.value


### PR DESCRIPTION
## Summary

- add a MainActor-scoped two-arrival gate so the re-entry fixture waits for both callers to start before inspecting the blocked model source
- retain the positive check that the first request actually parked, then cover both `ensureModelColors()` and `ensureModelData(for: .models)` before asserting that only one scan exists
- keep `DashboardModel` production behavior, APIs, persistence, serialization, and ABI unchanged

## Why

The previous fixture launched the second and third tasks and immediately read `pendingModelCount()`. That read could pass before either re-entry task ran, so the assertion was capable of reporting a successful join without exercising the join path.

The new gate uses MainActor scheduling as the synchronization boundary: once the last entrant records its arrival, its current actor job continues into the existing same-identity join until the shared model task suspends it. Only then can the waiting fixture inspect the pending request count.

## Verification

- mutation proof: temporarily made the same-identity join branch unreachable; `make selftest` exited 2 and failed the targeted re-entry assertion plus the related ABA slot-ownership assertion
- restored the mutation and ran `make selftest` 10 consecutive times; every run passed with 849 assertions and zero failures
- `make selftest-bundled` passed with 845 assertions and zero failures
- `git diff --check` passed

Live provider smoke was not run because this is a test-only change and that smoke enters the real `agentUsage()` provider and credential flow.

Closes #200
