### PR TITLE
fix(dashboard): prevent retired snapshot writes after reopen

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -171,24 +171,19 @@ private struct DashboardSnapshot {
     /// Survives the model's deallocation so the next PopoverView starts with
     /// cached data instead of `.loading`. A deliberate process-lifetime cache
     /// (one COW-shared value snapshot, never invalidated). Every model may
-    /// *read* it on init, but only the popover's model *writes* it (gated by
-    /// `cachesSnapshot`): SettingsWindowView's independent DashboardModel runs
-    /// the same poll loops on a year frozen at its own init, so letting it
-    /// write here would clobber the snapshot with the settings model's stale
-    /// year and re-introduce the reopen flash. TODO: the cleaner end-state is
-    /// StatusItemController owning one long-lived DashboardModel injected via
-    /// `.environment`, with the poll loops started/stopped explicitly on
-    /// popover open/close — that deletes this static, DashboardSnapshot, and
-    /// the year guard while preserving the Phase B CPU win.
+    /// *read* it on init, but only the most recently initialized popover model
+    /// may write it: an older instance can outlive its view while an FFI scan
+    /// finishes, and must not roll back the next popover's fresher snapshot.
     private static var lastSnapshot: DashboardSnapshot?
+    private static var lastSnapshotOwner: ObjectIdentifier?
     /// Reopen cache for the expensive hourly fold. Multiple slices coexist so
     /// Daily/Monthly's Codex+Claude report cannot evict Hourly's all-client one.
     // ponytail: FIFO at eight slices bounds memory; use LRU only if churn shows misses.
     private static let hourlyCacheLimit = 8
     private static var hourlyCache: [HourlyCacheKey: HourlyReport] = [:]
     private static var hourlyCacheOrder: [HourlyCacheKey] = []
-    /// Whether this model owns the shared `lastSnapshot` (true only for the
-    /// popover's model, whose teardown/rebuild is what the cache speeds up).
+    /// Whether this model participates in the shared `lastSnapshot` cache.
+    /// The newest participating instance becomes its sole writer.
     private let cachesSnapshot: Bool
     private let source: any UsageDataSource
     /// The exact build this process ships as, or nil for anything that is not
@@ -311,6 +306,9 @@ private struct DashboardSnapshot {
             restoreGatePending = true
         } else {
             phase = .loading
+        }
+        if cachesSnapshot {
+            Self.lastSnapshotOwner = ObjectIdentifier(self)
         }
     }
 
@@ -858,19 +856,27 @@ private struct DashboardSnapshot {
     /// the cache for reasons unrelated to the graph moving.
     @ObservationIgnored private var payloadCapturedAt = Date()
 
-    /// Capture the full restore cache from the current state. Called ONLY from
-    /// apply(), where the year-scoped payload/stats and `year` are set together
-    /// and `year` has been validated against the payload — so the snapshot's
-    /// `year` always matches the slice its `payload` holds. No-op unless this
-    /// model owns the cache and a base payload has loaded.
+    private var ownsLastSnapshot: Bool {
+        cachesSnapshot && Self.lastSnapshotOwner == ObjectIdentifier(self)
+    }
+
+    private func replaceLastSnapshot(_ snapshot: DashboardSnapshot) {
+        guard ownsLastSnapshot else { return }
+        Self.lastSnapshot = snapshot
+    }
+
+    /// Capture the full restore cache from the current state. `apply()` first
+    /// commits the validated payload/year pair; `publishModel()` may then add a
+    /// report for that same slice. No-op unless this is the newest popover model
+    /// and a base payload has loaded.
     private func cacheSnapshot() {
         guard cachesSnapshot, let payload, let stats else { return }
-        Self.lastSnapshot = DashboardSnapshot(
+        replaceLastSnapshot(DashboardSnapshot(
             payload: payload, stats: stats, payloadCapturedAt: payloadCapturedAt,
             modelReport: modelReport,
             modelGeneratedAt: modelPayloadGeneratedAt,
             colors: colors, knownYears: knownYears, year: year,
-            agentUsage: agentUsage, trace: trace)
+            agentUsage: agentUsage, trace: trace))
     }
 
     /// Submit the DISK capture. Deliberately separate from `cacheSnapshot()`
@@ -909,12 +915,12 @@ private struct DashboardSnapshot {
     /// No-op until apply() has written a base snapshot.
     private func refreshSnapshotLiveData() {
         guard cachesSnapshot, let snap = Self.lastSnapshot else { return }
-        Self.lastSnapshot = DashboardSnapshot(
+        replaceLastSnapshot(DashboardSnapshot(
             payload: snap.payload, stats: snap.stats, payloadCapturedAt: snap.payloadCapturedAt,
             modelReport: snap.modelReport,
             modelGeneratedAt: snap.modelGeneratedAt,
             colors: snap.colors, knownYears: snap.knownYears, year: snap.year,
-            agentUsage: agentUsage, trace: trace)
+            agentUsage: agentUsage, trace: trace))
     }
 
     /// Periodically re-derive every loaded lens so the popover advances while

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -53,6 +53,9 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
     private var advancePaused = false
     private var pendingGraphs: [String: [CheckedContinuation<UsagePayload, Error>]] = [:]
     private var pendingHourly: [String: [PendingHourly]] = [:]
+    private var blockedTrace = false
+    private var forcedTraceOnce: [TraceBucket]?
+    private var pendingTrace: [CheckedContinuation<[TraceBucket], Never>] = []
 
     init(hourlyResponses: [Set<String>: HourlyReport] = [:]) {
         self.hourlyResponses = hourlyResponses
@@ -62,6 +65,8 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
 
     func blockGraph(year: String?) { blockedGraphYears.insert(Self.key(year)) }
     func blockHourly(year: String?) { blockedHourlyYears.insert(Self.key(year)) }
+    func blockTrace() { blockedTrace = true }
+    func forceNextTrace(_ trace: [TraceBucket]) { forcedTraceOnce = trace }
 
     func hasPendingGraph(year: String?) -> Bool {
         !(pendingGraphs[Self.key(year)] ?? []).isEmpty
@@ -70,6 +75,8 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
     func hasPendingHourly(year: String?) -> Bool {
         !(pendingHourly[Self.key(year)] ?? []).isEmpty
     }
+
+    func hasPendingTrace() -> Bool { !pendingTrace.isEmpty }
 
     func releaseGraph(year: String?) {
         let key = Self.key(year)
@@ -128,6 +135,13 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
                 ?? DemoData.hourlyReport(for: year, clients: $0.clients)
             $0.continuation.resume(returning: report)
         }
+    }
+
+    func releaseTrace(_ trace: [TraceBucket]) {
+        blockedTrace = false
+        let waiting = pendingTrace
+        pendingTrace = []
+        waiting.forEach { $0.resume(returning: trace) }
     }
 
     /// Returned verbatim for the NEXT `graph()` call regardless of the year
@@ -252,7 +266,14 @@ private actor ControlledTurnUsageDataSource: UsageDataSource {
     func agentUsage() async throws -> AgentUsagePayload { DemoData.agentUsage }
 
     func usageTrace(windowSecs: Int64) async throws -> [TraceBucket] {
-        DemoData.trace(windowSecs: windowSecs)
+        if let forcedTraceOnce {
+            self.forcedTraceOnce = nil
+            return forcedTraceOnce
+        }
+        if blockedTrace {
+            return await withCheckedContinuation { pendingTrace.append($0) }
+        }
+        return DemoData.trace(windowSecs: windowSecs)
     }
 
     func tokensPerMin() async throws -> Double { DemoData.tokensPerMin }
@@ -5201,6 +5222,98 @@ enum SelfTest {
             await modelsTask.value
             let survivesLensSwitch = await handoffModel.modelReport != nil
 
+            // #190 — the newest popover model owns the process-static reopen
+            // snapshot. A retired model may still finish its unstructured model
+            // scan and a live-data poll, but neither completion may overwrite the
+            // payload or trace a newly opened model already committed.
+            func snapshotPayload(version: String, year: String) -> UsagePayload {
+                let encoded = try! JSONEncoder().encode(DemoData.payload(for: year))
+                var object = try! JSONSerialization.jsonObject(with: encoded) as! [String: Any]
+                var meta = object["meta"] as! [String: Any]
+                meta["version"] = version
+                object["meta"] = meta
+                let tagged = try! JSONSerialization.data(withJSONObject: object)
+                return try! JSONDecoder().decode(UsagePayload.self, from: tagged)
+            }
+            func snapshotTrace(client: String, tokens: Int64) -> [TraceBucket] {
+                [TraceBucket(
+                    client: client, agent: "snapshot-fixture", model: "snapshot-fixture",
+                    tokens: tokens, messages: 1, tokensPerMin: Double(tokens))]
+            }
+
+            let snapshotYear = "2050"
+            let retiredPayload = snapshotPayload(version: "snapshot-retired", year: snapshotYear)
+            let currentPayload = snapshotPayload(version: "snapshot-current", year: snapshotYear)
+            let retiredTrace = snapshotTrace(client: "snapshot-retired", tokens: 1)
+            let currentTrace = snapshotTrace(client: "snapshot-current", tokens: 2)
+            let snapshotMarkersDiffer =
+                retiredPayload.meta.version != currentPayload.meta.version
+            let snapshotGenerationsCollide =
+                retiredPayload.meta.generatedAt == currentPayload.meta.generatedAt
+
+            let retiredSnapshotSource = ControlledTurnUsageDataSource()
+            await retiredSnapshotSource.forceNextGraphPayload(retiredPayload)
+            let retiredSnapshotModel = DashboardModel(
+                cachesSnapshot: true, source: retiredSnapshotSource, initialYear: snapshotYear)
+            await retiredSnapshotModel.load()
+            let retiredSnapshotSeeded =
+                retiredSnapshotModel.payload?.meta.version == retiredPayload.meta.version
+            await retiredSnapshotSource.blockModel()
+            await retiredSnapshotSource.blockTrace()
+            let retiredModelTask = Task {
+                await retiredSnapshotModel.ensureModelData(for: .overview)
+            }
+            let retiredTraceTask = Task { await retiredSnapshotModel.pollTrace() }
+            let retiredModelParked = await waitUntil {
+                await retiredSnapshotSource.pendingModelCount() == 1
+            }
+            let retiredTraceParked = await waitUntil {
+                await retiredSnapshotSource.hasPendingTrace()
+            }
+
+            let currentSnapshotSource = ControlledTurnUsageDataSource()
+            await currentSnapshotSource.forceNextGraphPayload(currentPayload)
+            await currentSnapshotSource.forceNextTrace(currentTrace)
+            let currentSnapshotModel = DashboardModel(
+                cachesSnapshot: true, source: currentSnapshotSource, initialYear: snapshotYear)
+            let currentRestoredRetired =
+                currentSnapshotModel.payload?.meta.version == retiredPayload.meta.version
+            await currentSnapshotModel.load()
+            let currentTraceTask = Task { await currentSnapshotModel.pollTrace() }
+            let currentTracePublished = await waitUntil {
+                await MainActor.run {
+                    currentSnapshotModel.trace.first?.client == "snapshot-current"
+                }
+            }
+            currentTraceTask.cancel()
+            await currentTraceTask.value
+            let currentSnapshotCommitted =
+                currentSnapshotModel.payload?.meta.version == currentPayload.meta.version
+                && currentTracePublished
+                && currentSnapshotModel.modelReport == nil
+
+            await retiredSnapshotSource.releaseModel()
+            await retiredModelTask.value
+            await retiredSnapshotSource.releaseTrace(retiredTrace)
+            let retiredTracePublished = await waitUntil {
+                await MainActor.run {
+                    retiredSnapshotModel.trace.first?.client == "snapshot-retired"
+                }
+            }
+            retiredTraceTask.cancel()
+            await retiredTraceTask.value
+            let retiredSnapshotWritersSettled =
+                retiredSnapshotModel.modelReport != nil && retiredTracePublished
+
+            let snapshotReopen = DashboardModel(
+                cachesSnapshot: true, source: ControlledTurnUsageDataSource(),
+                initialYear: snapshotYear)
+            let snapshotReopenKeptCurrentPayload =
+                snapshotReopen.payload?.meta.version == currentPayload.meta.version
+            let snapshotReopenKeptCurrentTrace =
+                snapshotReopen.trace.first?.client == "snapshot-current"
+            let snapshotReopenRejectedRetiredModel = snapshotReopen.modelReport == nil
+
             // A year switch must drop the previous year's model report. Two
             // sites enforce it — `setYear` calls `invalidateModel()`, and
             // `apply()` discards a report whose `modelYear` disagrees with the
@@ -5503,6 +5616,16 @@ enum SelfTest {
                 "lensesSkipModel": lensesSkipModel,
                 "modelHeldForA": modelHeldForA,
                 "survivesLensSwitch": survivesLensSwitch,
+                "snapshotMarkersDiffer": snapshotMarkersDiffer,
+                "snapshotGenerationsCollide": snapshotGenerationsCollide,
+                "retiredSnapshotSeeded": retiredSnapshotSeeded,
+                "retiredSnapshotWritersParked": retiredModelParked && retiredTraceParked,
+                "currentSnapshotRestoredRetired": currentRestoredRetired,
+                "currentSnapshotCommitted": currentSnapshotCommitted,
+                "retiredSnapshotWritersSettled": retiredSnapshotWritersSettled,
+                "snapshotReopenKeptCurrentPayload": snapshotReopenKeptCurrentPayload,
+                "snapshotReopenKeptCurrentTrace": snapshotReopenKeptCurrentTrace,
+                "snapshotReopenRejectedRetiredModel": snapshotReopenRejectedRetiredModel,
                 "failedLeftEmpty": failedLeftEmpty,
                 "generationsCollide": generationsCollide,
                 "seededWithoutModel": seededWithoutModel,
@@ -5721,6 +5844,33 @@ enum SelfTest {
             turnTransitionChecks?["survivesLensSwitch"] == true,
             "a lens switch during a model scan still publishes — the cancelled task must "
                 + "not take the only publication path with it")
+        expect(
+            turnTransitionChecks?["snapshotMarkersDiffer"] == true
+                && turnTransitionChecks?["snapshotGenerationsCollide"] == true
+                && turnTransitionChecks?["retiredSnapshotSeeded"] == true,
+            "the reopen-owner fixture starts from distinguishable payloads with the same "
+                + "generatedAt, so timestamp ordering cannot satisfy it")
+        expect(
+            turnTransitionChecks?["retiredSnapshotWritersParked"] == true
+                && turnTransitionChecks?["currentSnapshotRestoredRetired"] == true
+                && turnTransitionChecks?["currentSnapshotCommitted"] == true,
+            "a retired model and trace writer are both parked before a newly opened model "
+                + "restores the old snapshot and commits its replacement")
+        expect(
+            turnTransitionChecks?["retiredSnapshotWritersSettled"] == true,
+            "both retired writers really finish after the replacement snapshot commits — "
+                + "the fixture does not pass by cancelling or abandoning them")
+        expect(
+            turnTransitionChecks?["snapshotReopenKeptCurrentPayload"] == true,
+            "late model publication from a retired dashboard cannot roll back the newest "
+                + "reopen snapshot's payload")
+        expect(
+            turnTransitionChecks?["snapshotReopenRejectedRetiredModel"] == true,
+            "a retired dashboard's late model report cannot enter the newest reopen snapshot")
+        expect(
+            turnTransitionChecks?["snapshotReopenKeptCurrentTrace"] == true,
+            "late live-data publication from a retired dashboard cannot replace the newest "
+                + "reopen snapshot's trace")
         expect(
             turnTransitionChecks?["phantomIssuedNoScan"] == true,
             "no model scan is issued for a phantom slice — a new year paired with the "


### PR DESCRIPTION
## Summary

- make the newest `cachesSnapshot` `DashboardModel` the sole writer of the process-static in-memory reopen snapshot
- route both full snapshot capture and live `agentUsage`/trace refreshes through one owner-checked replacement seam
- add a deterministic equal-generation A-to-B-to-A-to-C fixture that proves retired model and trace writers cannot roll back the next popover's state

## Root cause

`ensureModelReport` deliberately uses an unstructured task so an ordinary lens switch cannot cancel the only publication path. When a popover closed during the synchronous FFI scan, however, the retired model could still reach `publishModel()` and `cacheSnapshot()` after the next popover had already committed a fresher payload. Because `DashboardModel.lastSnapshot` had no instance ownership, that late write replaced the shared reopen cache with the retired model's payload and report.

`refreshSnapshotLiveData()` was a second direct writer to the same static cache, so guarding only `publishModel()` would have left retired trace or quota polling able to replace the current owner's live fields.

## Implementation

Each `cachesSnapshot` model claims `lastSnapshotOwner` after initialization has restored the previous snapshot. `replaceLastSnapshot(_:)` compares that process-local `ObjectIdentifier` before assigning the static cache, and both `cacheSnapshot()` and `refreshSnapshotLiveData()` use the shared seam.

The retired model still completes and updates its own instance-local model or trace state. This preserves lens-switch adoption, same-slice scan coalescing, supersede and ABA request ownership, while preventing only the shared-state rollback after a newer popover model exists.

Disk snapshot capture remains unchanged. The issue's late model publication does not call `submitDiskCapture()`, and this PR does not expand into restart-persistence policy, API, ABI, schema, dependency, or vendored-core changes.

## Verification

The new hermetic fixture uses two payloads with different `meta.version` markers but identical `meta.generatedAt` values. It parks model and trace publication on model A, lets model B restore A and commit the current payload plus trace, then releases both A writers before model C restores the cache. C must retain B's payload and trace and must not inherit A's model report.

Mutation checks, each restored before the final candidate:

- allowing every `cachesSnapshot` instance to write failed the three late-writer assertions
- bypassing the guarded seam in `cacheSnapshot()` failed the payload and retired-model assertions
- bypassing the guarded seam in `refreshSnapshotLiveData()` failed only the trace assertion
- replacing owner identity with `generatedAt` ordering failed under the equal-generation fixture

Final gates:

- `git diff --check`
- `make selftest` — 855 assertions, zero failures
- `make selftest-bundled` — 851 assertions, zero failures
- fresh independent verifier — `CONFIRMED`, no findings or advisories

Live provider smoke was not run because the claim is fully exercised through synthetic `DashboardModel` sources and the smoke path would enter real provider and credential flows without adding lifecycle coverage.

Closes #190
