### PR TITLE
fix(claude): treat a credential store without `claudeAiOauth` as absent

### DIFF
--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -2564,6 +2564,14 @@ fn resolve_stored_claude_login(raw: &str, source: ClaudeCredentialSource) -> Cla
         Ok(root) => root,
         Err(_) => return ClaudeLoginResolution::Terminal,
     };
+    // A store with no `claudeAiOauth` at all carries no Claude login (e.g. an
+    // mcpOAuth-only Keychain item, issue #219). That is absence, not a malformed
+    // or unreadable credential, so it must not fail closed. `null` is folded in
+    // to match `ClaudeCredentialsRoot`'s own semantics, which cannot tell a null
+    // from a missing key.
+    if matches!(raw_root.get("claudeAiOauth"), None | Some(Value::Null)) {
+        return ClaudeLoginResolution::Absent;
+    }
     let explicitly_logged_out = raw_root
         .get("claudeAiOauth")
         .and_then(Value::as_object)
@@ -5442,6 +5450,95 @@ mod tests {
         assert_eq!(setup_loads.get(), 1);
         assert_eq!(setup_calls.get(), 1);
         scope.cleanup();
+    }
+
+    const MCP_OAUTH_ONLY_STORE: &str =
+        r#"{"mcpOAuth":{"some-server":{"accessToken":"mcp-a","refreshToken":"mcp-r"}}}"#;
+
+    #[test]
+    fn claude_stored_login_resolution_classifies_every_store_shape() {
+        for (raw, expected) in [
+            (MCP_OAUTH_ONLY_STORE, "absent"),
+            (r#"{"claudeAiOauth":null}"#, "absent"),
+            (r#"{"claudeAiOauth":{}}"#, "terminal"),
+            (r#"{"claudeAiOauth":{"accessToken":null}}"#, "terminal"),
+            (
+                r#"{"claudeAiOauth":{"refreshToken":"x"}}"#,
+                "explicit-logout",
+            ),
+            (
+                r#"{"claudeAiOauth":{"accessToken":"a","refreshToken":"r"}}"#,
+                "ready",
+            ),
+        ] {
+            let actual = match resolve_stored_claude_login(raw, ClaudeCredentialSource::Keychain) {
+                ClaudeLoginResolution::Absent => "absent",
+                ClaudeLoginResolution::ExplicitLogout => "explicit-logout",
+                ClaudeLoginResolution::Ready(_) => "ready",
+                ClaudeLoginResolution::Terminal => "terminal",
+            };
+            assert_eq!(actual, expected, "unexpected resolution for {raw}");
+        }
+    }
+
+    /// A Keychain item that holds no Claude login must NOT fall through to
+    /// `~/.claude/.credentials.json`. Deliberate: it is unproven whether the
+    /// mcpOAuth-only shape is the post-logout shape, and if it is, falling
+    /// through would silently resume a stale file token (and write rotated
+    /// tokens back to it). Shadowing a valid file login is the intended
+    /// behavior here — do not "fix" this by adding fall-through.
+    #[test]
+    fn claude_keychain_without_claude_login_does_not_fall_through_to_file() {
+        let file_loads = std::cell::Cell::new(0);
+        let login = load_stored_claude_login_with(
+            || Ok(Some(MCP_OAUTH_ONLY_STORE.to_string())),
+            || {
+                file_loads.set(file_loads.get() + 1);
+                Ok(Some(
+                    r#"{"claudeAiOauth":{"accessToken":"file-access","refreshToken":"file-refresh"}}"#
+                        .to_string(),
+                ))
+            },
+        );
+        assert!(matches!(login, ClaudeLoginResolution::Absent));
+        assert_eq!(file_loads.get(), 0);
+    }
+
+    /// Issue #219: an mcpOAuth-only `Claude Code-credentials` item used to
+    /// resolve to `Terminal` and fail closed with a permanent red error. It is
+    /// absence, so the setup-token fallback must be reached.
+    #[tokio::test]
+    async fn issue_219_mcp_oauth_only_keychain_item_reaches_setup_token() {
+        let login = load_stored_claude_login_with(
+            || Ok(Some(MCP_OAUTH_ONLY_STORE.to_string())),
+            || Ok(None),
+        );
+        assert!(matches!(login, ClaudeLoginResolution::Absent));
+
+        let primary_calls = std::cell::Cell::new(0);
+        let setup_loads = std::cell::Cell::new(0);
+        let setup_calls = std::cell::Cell::new(0);
+        let (source, outcome) = fetch_claude_login_or_setup_with(
+            login,
+            |_| async {
+                primary_calls.set(primary_calls.get() + 1);
+                ("oauth", claude_test_success_outcome())
+            },
+            || {
+                setup_loads.set(setup_loads.get() + 1);
+                Ok(Some(claude_test_setup_token()))
+            },
+            |_| async {
+                setup_calls.set(setup_calls.get() + 1);
+                ("setup-token", claude_test_success_outcome())
+            },
+        )
+        .await;
+        assert_eq!(source, "setup-token");
+        assert!(matches!(outcome, ProviderFetchOutcome::Success { .. }));
+        assert_eq!(primary_calls.get(), 0);
+        assert_eq!(setup_loads.get(), 1);
+        assert_eq!(setup_calls.get(), 1);
     }
 
     fn timeout_diagnostic() -> SafeTransportDiagnostic {


### PR DESCRIPTION
Fixes #219.

## Summary

A `Claude Code-credentials` Keychain item whose JSON carries no `claudeAiOauth` key — the reporter's item contained only `mcpOAuth`, an MCP server's OAuth data — left the Claude quota card permanently stuck on the red `Claude credentials could not be loaded.` error, with the documented `tokenbar-claude-oauth-token` setup-token fallback never even read. Such a store is well-formed JSON that simply holds no Claude login, so it now resolves to `Absent` and the fallback engages.

## Root cause

| Step | Location | Behavior |
|---|---|---|
| Parse | `agent_usage.rs:2678-2680` | missing `claudeAiOauth` returns `Err` |
| Classify | `agent_usage.rs:2581-2584` | every parse `Err` collapses to `ClaudeLoginResolution::Terminal` |
| Dispatch | `agent_usage.rs:1885-1892` | only `Absent` / `ExplicitLogout` reach the setup-token loader; `Terminal` fails closed |

Reproduced before the fix with a unit test feeding `{"mcpOAuth":{"some-server":{"accessToken":"mcp-a","refreshToken":"mcp-r"}}}`: `Terminal`, `setup_loads == 0`, source `"oauth"`, display `CLAUDE_CREDENTIALS_LOAD_ERROR`.

## The change

One guard in `resolve_stored_claude_login`, placed after the JSON parse and before the explicit-logout check:

```rust
if matches!(raw_root.get("claudeAiOauth"), None | Some(Value::Null)) {
    return ClaudeLoginResolution::Absent;
}
```

It is a strict subset of the previous `Terminal` bucket. The `explicitly_logged_out` check requires `claudeAiOauth` to be an object containing `refreshToken`, so a missing key could never have been `ExplicitLogout`. `null` is folded in because `ClaudeCredentialsRoot`'s `Option<T>` fields deserialize JSON null to `None` and cannot tell it from a missing key — leaving null on the `Terminal` side would recreate the same permanent-error trap in another shape.

Unchanged: `{"claudeAiOauth":{}}` → `Terminal`, `{"accessToken":null}` → `Terminal`, blank-access-token logout shape → `ExplicitLogout`, valid credential → `Ready`, invalid JSON → `Terminal`.

## Deliberately not included: Keychain-to-file fall-through

An earlier draft also let a Keychain store holding no Claude login fall through to `~/.claude/.credentials.json`. Pre-approval security review rejected it as P2 and it was dropped.

It is unproven whether the mcpOAuth-only shape is what Claude Code leaves behind after a logout. If it is, fall-through would silently resume a stale file token after logout, keep refreshing it, and write rotated tokens back to that file — exactly what the fail-closed policy from #94 exists to prevent. `claude_credentials_path()` is hardcoded and ignores `CLAUDE_CONFIG_DIR`, so on macOS any file it finds is by definition not what the CLI is currently writing.

An mcpOAuth-only item continuing to shadow a valid file login is therefore intended behavior, pinned by `claude_keychain_without_claude_login_does_not_fall_through_to_file` with the rationale in a doc comment so it is not "fixed" later. Reviving fall-through would first require someone to empirically observe the real shape of that Keychain item after a `claude` logout in a disposable environment.

Refresh and write-back are untouched: `reload_claude_credentials` and `save_claude_credentials` still go through `parse_claude_credentials_data`, which still fails closed if `claudeAiOauth` disappears mid-refresh.

## Deferred, not fixed here

Both surfaced by post-implementation verification, both P4, both recorded rather than silently passed over.

| Finding | Why deferred |
|---|---|
| A `Ready` → mcpOAuth-only → `Ready` sequence now clears the 429 backoff on the intermediate poll, where `Terminal` previously kept it | Pre-existing "logged out clears backoff" semantics reached by more shapes. The gate is consulted only on the `Ready` OAuth path (`:1922-1923`), the setup-token path never reads or arms it, and `blocked_until_for` already self-clears on any binding change. Worst case is one early retry of the same account |
| A top-level JSON value that is not an object (`{}`, `[]`, `123`, `"hello"`) now resolves to `Absent`, so a corrupt store shows the setup prompt instead of the load error | `Value::get` returns `None` for any non-object. No credential exposure, no file fall-through, and no plausible shape for a real `Claude Code-credentials` item — only a less precise message for a corrupted one. Tightening to `raw_root.is_object() && matches!(...)` would restore `Terminal` for these if it ever matters |

## Verification

| Gate | Result |
|---|---|
| `cargo test -p tb_core_ffi` | 378 passed, 0 failed, 2 ignored |
| Mutation: guard → `raw_root.get("claudeAiOauth").is_some()` | 373 passed / 5 failed, exit 101 — assertion failures, not a compile error. Kills both new tests plus three pre-existing precedence/logout tests |
| `cargo clippy -p tb_core_ffi --all-targets --no-deps` | no error; 16 pre-existing warnings, none in the changed ranges |
| `rustfmt --edition 2021 --check --config skip_children=true` | clean |
| `swift run TokenBar --selftest -AppleLanguages '(en)'` | `selftest passed` |

The mutation check exists because a test that cannot fail proves nothing. Independent verification re-ran it in an isolated copy of the crate and confirmed the same five deaths, and confirmed the tested seam is the shipping seam: both new tests call the real `resolve_stored_claude_login` and `fetch_claude_login_or_setup_with`, injecting only the two store loaders, which is what `fetch_claude_inner` itself uses.

## Not verified

No live provider run and no real Keychain was touched at any point — every test input is a literal. The end-to-end path from a real mcpOAuth-only Keychain item to a rendered setup prompt has not been observed on a live machine, because doing so would require overwriting a real `Claude Code-credentials` item.
