### PR TITLE
Count only the scoped model in a model-scoped quota window

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -1372,6 +1372,11 @@ private struct DashboardSnapshot {
             // main actor.
             let spans = QuotaHistoryFold.spans(
                 cycles: cycles, messages: scan.messages, subscription: client,
+                // `key` IS the window's `"<clientId>|<cardId>"`, so each
+                // estimate is narrowed to its own window's scope rather than to
+                // whichever one the card happens to be showing.
+                modelScope: WindowCardLoader.modelScope(
+                    payload: agentUsage, cardId: key),
                 confirmed: confirmed)
             built[key] = WindowEquivalence.aggregate(
                 declared: !confirmed.isEmpty,
@@ -1398,6 +1403,11 @@ private struct DashboardSnapshot {
             // bills it. A row whose usage was declared elsewhere is exactly
             // what the "other" column exists to show.
             subscription: client,
+            // The window these cycles belong to, not the client's default: the
+            // user can select a scoped window, and its history has to answer
+            // for the same allowance the chart above it draws.
+            modelScope: WindowCardLoader.modelScope(
+                payload: agentUsage, cardId: quotaCyclesCardId),
             confirmed: UsageAttribution.confirmed().records)
     }
 

--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -511,6 +511,7 @@
 "On average: lasts until reset" = "均速：可撐到重置";
 "Recently: runs out" = "近期：會用完";
 "%@ scanned rows have no usable timestamp, so no window can count them" = "掃描到 %@ 筆沒有可用的時間戳，任何視窗都無法計入";
+"No local usage matched %@, though this subscription has other usage in this window" = "本機沒有任何用量對應到「%@」，但這個訂閱在此視窗內有其他用量";
 "Quota history could not be read. It will be retried." = "無法讀取額度歷史，稍後會重試。";
 "Other subscriptions in the same hours:" = "同一時段的其他訂閱：";
 "Unclassified usage in the same hours:" = "同一時段的未分類用量：";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -11176,15 +11176,17 @@ enum SelfTest {
         func windowPayload(
             _ agents: [(client: String, windows: [(card: String, key: String,
                                                    resetsAt: String, durationSecs: Int64)])],
-            generation: UInt64 = 7
+            generation: UInt64 = 7,
+            modelScope: String? = nil
         ) -> AgentUsagePayload {
+            let scopeField = modelScope.map { #","modelScope":"\#($0)""# } ?? ""
             let body = agents.map { agent in
                 let windows = agent.windows.map { w in
                     """
                     {"cardId":"\(w.card)","label":"\(w.card)","usedPercent":10,
                      "remainingPercent":90,"resetsAt":"\(w.resetsAt)",
                      "durationSeconds":\(w.durationSecs),
-                     "windowMinutes":\(w.durationSecs / 60),
+                     "windowMinutes":\(w.durationSecs / 60)\(scopeField),
                      "paceStatus":{"state":"learningHistory","windowKey":"\(w.key)",
                                    "durationSeconds":\(w.durationSecs),
                                    "durationSource":"provider","completeCycles":1}}
@@ -11498,6 +11500,122 @@ enum SelfTest {
                 payload: withRecent, clients: ["codex", "claude"], nowMs: wNow * 1000)
                 == (wNow - 3_600 - 604_800) * 1000,
             "L3b a past reset still within one duration keeps bounding the scan")
+
+        // MS. A model-scoped window ("Fable only") must show only that model's
+        // usage. It showed the whole subscription's, so the bars underneath the
+        // curve were explaining a different quota than the one drawn.
+        //
+        // The join is between two naming systems and nothing guarantees they
+        // agree — the provider sends `scope.model.id: null`, so the scope is
+        // its DISPLAY-NAME slug while the rows carry the transcript's canonical
+        // id. These fixtures use the real strings from both sides.
+        expect(ModelScope.covers("fable", modelId: "claude-fable-5"),
+               "MS the provider's display slug matches the transcript's canonical id")
+        expect(!ModelScope.covers("fable", modelId: "claude-sonnet-4-5"),
+               "MS and does not match a different model, or the filter is a no-op")
+        expect(ModelScope.covers("claude-fable-5", modelId: "claude-fable-5-20260101"),
+               "MS a multi-token scope matches when every token is present, so a "
+                   + "display name spelled out in full still lands")
+        expect(!ModelScope.covers("fable-max", modelId: "claude-fable-5"),
+               "MS but a token the id lacks does NOT match — the rule is a subset "
+                   + "test, and this is the under-match the scope note exists for")
+        expect(!ModelScope.covers("", modelId: "claude-fable-5"),
+               "MS an empty scope selects nothing rather than everything")
+
+        let msIso = ISO8601DateFormatter().string(
+            from: Date(timeIntervalSince1970: Double(wNow + 3_600)))
+        let msPayload = windowPayload([
+            (client: "codex", windows: [(card: "weekly_scoped.fable.v1",
+                                         key: "weekly_scoped.fable.v1",
+                                         resetsAt: msIso, durationSecs: 604_800)]),
+        ], modelScope: "fable")
+        let msMessages = try! JSONDecoder().decode(
+            [WindowMessage].self,
+            from: Data("""
+            [{"timestamp":\((wNow - 1_000) * 1000),"client":"codex","providerId":"anthropic",
+              "modelId":"claude-fable-5","input":700,"output":0,"cacheRead":0,"cacheWrite":0,
+              "reasoning":0,"cost":1.0,"isTurnStart":true},
+             {"timestamp":\((wNow - 900) * 1000),"client":"codex","providerId":"anthropic",
+              "modelId":"claude-sonnet-4-5","input":300,"output":0,"cacheRead":0,"cacheWrite":0,
+              "reasoning":0,"cost":0.5,"isTurnStart":true}]
+            """.utf8))
+        // Declared, or `isMine` rejects every row and all three cases below
+        // pass on an empty set rather than on the filter.
+        let msConfirmed = [UsageAttribution.Record(
+            client: "codex", provider: "anthropic", state: .assigned("codex"))]
+        let msScan = UnionScan(
+            fromMs: (wNow - 604_800) * 1000, untilMs: wNow * 1000,
+            capturedAt: Date(), messages: msMessages)
+        let msStage1 = WindowCardLoader.quotaHalf(
+            payload: msPayload, clientId: "codex", attempted: true,
+            curve: { _, _, _ in
+                windowCurve(resetAtSecs: wNow + 3_600, durationSecs: 604_800,
+                            at: [(wNow - 2_000, 4), (wNow - 500, 9)])
+            },
+            nowMs: wNow * 1000)
+        if case let .quotaOnly(msQuota, _) = msStage1 {
+            expect(msQuota.modelScope == "fable",
+                   "MS the scope reaches stage 1 from the payload, so stage 2 does "
+                       + "not re-derive it from the window key")
+            let msHalf = WindowCardLoader.usageHalf(
+                quota: msQuota, scan: msScan, confirmed: msConfirmed)
+            expect(msHalf?.1.mine.map(\.modelId) == ["claude-fable-5"],
+                   "MS a scoped window counts only the model its allowance is about")
+            expect(msHalf?.1.scopeMatchedNothing == false,
+                   "MS and does not claim the scope missed when it matched")
+        } else {
+            expect(false, "MS the scoped fixture reaches stage 1")
+        }
+
+        // The other direction, or the filter is satisfied by dropping
+        // everything: the same scan against an UNSCOPED window keeps both rows.
+        let msUnscoped = windowPayload([
+            (client: "codex", windows: [(card: "weekly.v1", key: "weekly.v1",
+                                         resetsAt: msIso, durationSecs: 604_800)]),
+        ])
+        let msUnscopedStage1 = WindowCardLoader.quotaHalf(
+            payload: msUnscoped, clientId: "codex", attempted: true,
+            curve: { _, _, _ in
+                windowCurve(resetAtSecs: wNow + 3_600, durationSecs: 604_800,
+                            at: [(wNow - 2_000, 4), (wNow - 500, 9)])
+            },
+            nowMs: wNow * 1000)
+        if case let .quotaOnly(msQuota, _) = msUnscopedStage1 {
+            expect(msQuota.modelScope == nil,
+                   "MS a window the provider did not narrow carries no scope")
+            let msHalf = WindowCardLoader.usageHalf(
+                quota: msQuota, scan: msScan, confirmed: msConfirmed)
+            expect(msHalf?.1.mine.count == 2,
+                   "MS and an unscoped window still counts the whole subscription")
+        } else {
+            expect(false, "MS the unscoped fixture reaches stage 1")
+        }
+
+        // MS-MISS. The join finding nothing is reported, not drawn as an idle
+        // week. Empty bars under a moving curve state that the user did no
+        // work, which is a claim this card has no evidence for.
+        let msMissPayload = windowPayload([
+            (client: "codex", windows: [(card: "weekly_scoped.ghost.v1",
+                                         key: "weekly_scoped.ghost.v1",
+                                         resetsAt: msIso, durationSecs: 604_800)]),
+        ], modelScope: "ghost")
+        let msMissStage1 = WindowCardLoader.quotaHalf(
+            payload: msMissPayload, clientId: "codex", attempted: true,
+            curve: { _, _, _ in
+                windowCurve(resetAtSecs: wNow + 3_600, durationSecs: 604_800,
+                            at: [(wNow - 2_000, 4), (wNow - 500, 9)])
+            },
+            nowMs: wNow * 1000)
+        if case let .quotaOnly(msQuota, _) = msMissStage1 {
+            let msHalf = WindowCardLoader.usageHalf(
+                quota: msQuota, scan: msScan, confirmed: msConfirmed)
+            expect(msHalf?.1.mine.isEmpty == true
+                       && msHalf?.1.scopeMatchedNothing == true,
+                   "MS-MISS a scope that matches nothing says so, rather than "
+                       + "presenting an empty window as a quiet week")
+        } else {
+            expect(false, "MS-MISS the unmatched fixture reaches stage 1")
+        }
 
         // L2a. `usageHalf` consumes a scan rather than issuing one: the single
         // scan is structural. It must also refuse a scan that starts too late,

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -12139,6 +12139,7 @@ enum SelfTest {
             client: "c", provider: "p", state: .assigned("c"))]
         let qhsSpans = QuotaHistoryFold.spans(
             cycles: qhsCycles, messages: qhsMessages, subscription: "c",
+            modelScope: nil,
             confirmed: qhsRecords)
         expect(qhsSpans.first?.exCacheRead == 100 && qhsSpans.first.map { abs($0.cost - 0.25) < 1e-9 } == true,
                "QH-SHRINK usage taken before the recomputed start still counts toward the "
@@ -12160,6 +12161,7 @@ enum SelfTest {
             """.utf8))
         let qhspRows = QuotaHistoryFold.rows(
             cycles: qhsCycles, messages: qhspMessages, subscription: "c",
+            modelScope: nil,
             confirmed: qhsRecords)
         expect(qhspRows.first?.mineTokensExCacheRead == 800,
                "QH-SPAN the cycle column counts everything charged to the window")
@@ -12220,6 +12222,7 @@ enum SelfTest {
             """.utf8))
         let qhoRows = QuotaHistoryFold.rows(
             cycles: qhsCycles, messages: qhoMessages, subscription: "c",
+            modelScope: nil,
             confirmed: [UsageAttribution.Record(
                 client: "z", provider: "p", state: .assigned("other"))])
         expect(qhoRows.first?.otherTokens == 1000,
@@ -12245,6 +12248,7 @@ enum SelfTest {
             """.utf8))
         let qhoCostRows = QuotaHistoryFold.rows(
             cycles: qhsCycles, messages: qhoCostOnly, subscription: "c",
+            modelScope: nil,
             confirmed: [UsageAttribution.Record(
                 client: "z", provider: "p", state: .assigned("other"))])
         // QH-SCOPE. The chart, these history rows and the equivalence spans are
@@ -12267,6 +12271,7 @@ enum SelfTest {
             client: "c", provider: "anthropic", state: .assigned("c"))]
         let qhsUnscopedRows = QuotaHistoryFold.rows(
             cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
+            modelScope: nil,
             confirmed: qhsDeclared)
         let qhsScopedRows = QuotaHistoryFold.rows(
             cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
@@ -12279,6 +12284,7 @@ enum SelfTest {
                    + "allowance charges")
         let qhsUnscopedSpans = QuotaHistoryFold.spans(
             cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
+            modelScope: nil,
             confirmed: qhsDeclared)
         let qhsScopedSpans = QuotaHistoryFold.spans(
             cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
@@ -12300,6 +12306,7 @@ enum SelfTest {
         // outstanding question they had already answered.
         let qhxRows = QuotaHistoryFold.rows(
             cycles: qhsCycles, messages: qhoMessages, subscription: "c",
+            modelScope: nil,
             confirmed: [
                 UsageAttribution.Record(
                     client: "z", provider: "p", state: .assigned("other")),
@@ -12447,7 +12454,7 @@ enum SelfTest {
                 attributedMessage(at: 125_000_000, client: "unknown", provider: "nowhere",
                                   model: "x", tokens: 3, cost: 5),
             ],
-            subscription: "claude", confirmed: qhConfirmed)
+            subscription: "claude", modelScope: nil, confirmed: qhConfirmed)
 
         let older = qhRows[1]
         expect(older.mineTokens == 10 && older.mineCost == 1,

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -11591,6 +11591,26 @@ enum SelfTest {
             expect(false, "MS the unscoped fixture reaches stage 1")
         }
 
+        // MS-KEY. The history rows and the equivalence estimate hold a
+        // `"<clientId>|<cardId>"` and no `UsageWindow`, so they ask for the
+        // scope by that key. Without one lookup they would each parse it out of
+        // the window-key string — three parsers for one fact.
+        expect(WindowCardLoader.modelScope(
+                   payload: msPayload, cardId: "codex|weekly_scoped.fable.v1") == "fable",
+               "MS-KEY a window's scope is addressable by the same key every other "
+                   + "surface uses to name it")
+        expect(WindowCardLoader.modelScope(
+                   payload: msUnscoped, cardId: "codex|weekly.v1") == nil,
+               "MS-KEY and an unscoped window answers nil, so the lookup is not "
+                   + "simply returning whatever it finds first")
+        expect(WindowCardLoader.modelScope(
+                   payload: msPayload, cardId: "codex|no.such.window.v1") == nil
+                   && WindowCardLoader.modelScope(
+                       payload: msPayload, cardId: "ghost|weekly_scoped.fable.v1") == nil
+                   && WindowCardLoader.modelScope(payload: msPayload, cardId: nil) == nil,
+               "MS-KEY an unknown card, an unknown client and a missing key all "
+                   + "answer nil rather than the wrong window's scope")
+
         // MS-MISS. The join finding nothing is reported, not drawn as an idle
         // week. Empty bars under a moving curve state that the user did no
         // work, which is a claim this card has no evidence for.
@@ -12227,6 +12247,48 @@ enum SelfTest {
             cycles: qhsCycles, messages: qhoCostOnly, subscription: "c",
             confirmed: [UsageAttribution.Record(
                 client: "z", provider: "p", state: .assigned("other"))])
+        // QH-SCOPE. The chart, these history rows and the equivalence spans are
+        // three surfaces of ONE quota. Narrowing only the chart made them
+        // disagree about the same window — corrected bars above, uncorrected
+        // "past windows" underneath, counting Sonnet against a Fable
+        // allowance. The rule lives in the fold so it cannot be applied at two
+        // of the three.
+        let qhsScopeMessages = try! JSONDecoder().decode(
+            [WindowMessage].self,
+            from: Data("""
+            [{"timestamp":\((qhsReset - 500_000) * 1000),"client":"c","providerId":"anthropic",
+              "modelId":"claude-fable-5","input":700,"output":0,"cacheRead":0,"cacheWrite":0,
+              "reasoning":0,"cost":1.0,"isTurnStart":true},
+             {"timestamp":\((qhsReset - 400_000) * 1000),"client":"c","providerId":"anthropic",
+              "modelId":"claude-sonnet-4-5","input":300,"output":0,"cacheRead":0,"cacheWrite":0,
+              "reasoning":0,"cost":0.5,"isTurnStart":true}]
+            """.utf8))
+        let qhsDeclared = [UsageAttribution.Record(
+            client: "c", provider: "anthropic", state: .assigned("c"))]
+        let qhsUnscopedRows = QuotaHistoryFold.rows(
+            cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
+            confirmed: qhsDeclared)
+        let qhsScopedRows = QuotaHistoryFold.rows(
+            cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
+            modelScope: "fable", confirmed: qhsDeclared)
+        expect(qhsUnscopedRows.first?.mineTokens == 1000,
+               "QH-SCOPE without a scope the history counts every model, so the "
+                   + "scoped case below is a narrowing rather than an empty fixture")
+        expect(qhsScopedRows.first?.mineTokens == 700,
+               "QH-SCOPE a scoped window's history counts only the model its "
+                   + "allowance charges")
+        let qhsUnscopedSpans = QuotaHistoryFold.spans(
+            cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
+            confirmed: qhsDeclared)
+        let qhsScopedSpans = QuotaHistoryFold.spans(
+            cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
+            modelScope: "fable", confirmed: qhsDeclared)
+        expect(qhsUnscopedSpans.first?.exCacheRead == 1000
+                   && qhsScopedSpans.first?.exCacheRead == 700,
+               "QH-SCOPE and the equivalence denominator narrows with it — counting "
+                   + "a model the allowance does not charge understates what the "
+                   + "quota costs")
+
         expect(qhoCostRows.first?.otherHasUnattributed == true,
                "QH-OTHER an unclassified contribution that arrives as cost with no "
                    + "tokens is still unclassified — the label cannot be decided by "

--- a/Sources/TokenBar/Views/WindowUsageCard.swift
+++ b/Sources/TokenBar/Views/WindowUsageCard.swift
@@ -114,6 +114,7 @@ struct WindowUsageCard: View {
                 chart(geo).zIndex(1)
                 legend(geo).frame(height: Self.legendHeight)
                 undatedNote(usage)
+                scopeNote(usage, label: quota.windowLabel)
                 Group {
                     if let usage {
                         equivalenceRow(
@@ -415,6 +416,24 @@ struct WindowUsageCard: View {
     /// not exist to be recovered. Saying "not in these totals" on every card
     /// therefore claimed each card had lost a row that may belong to another
     /// subscription entirely — a per-card claim the data cannot support.
+    /// The scope join found nothing. Said, not drawn as an idle week.
+    ///
+    /// The scope is the provider's display name and the rows carry the
+    /// transcript's model id; when those do not line up the honest report is
+    /// that the filter matched nothing, because empty bars under a moving curve
+    /// read as "you did no work", which is a claim about the user's week that
+    /// this card has no evidence for.
+    @ViewBuilder
+    private func scopeNote(_ usage: WindowUsageHalf?, label: String) -> some View {
+        if let usage, usage.scopeMatchedNothing {
+            Text("No local usage matched %@, though this subscription has other usage in this window"
+                .localized(label))
+                .font(.system(size: 9))
+                .foregroundStyle(.orange)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     @ViewBuilder
     private func undatedNote(_ usage: WindowUsageHalf?) -> some View {
         if let usage, usage.undatedCount > 0 {

--- a/Sources/TokenBar/WindowCardLoader.swift
+++ b/Sources/TokenBar/WindowCardLoader.swift
@@ -296,9 +296,7 @@ enum WindowCardLoader {
         // moves a naming mismatch from "we found no usage" to "there is no
         // window". The blast radius of the heuristic stays inside the totals.
         let subscription = scan.slice(from: start, to: min(end, quota.nowMs)).filter(isMine)
-        let mine = quota.modelScope.map { scope in
-            subscription.filter { ModelScope.covers(scope, modelId: $0.modelId) }
-        } ?? subscription
+        let mine = QuotaHistoryFold.inScope(subscription, quota.modelScope)
         let geo = WindowCardGeometry.usageGeometry(
             windowStartMs: start, windowEndMs: end, nowMs: min(quota.nowMs, end),
             samples: quota.samples, messages: mine)
@@ -350,6 +348,26 @@ enum WindowCardLoader {
         // union scan, through its oldest entry's `evidenceStartMs`.
         return QuotaHistoryFold.considered(QuotaHistoryFold.cycles(
             points: curve.points))
+    }
+
+    /// The model scope of one window, addressed the way every other surface
+    /// addresses a window: by its `"<clientId>|<cardId>"`.
+    ///
+    /// The history rows and the equivalence estimate are keyed that way and
+    /// have no `UsageWindow` in hand, so without this they would each re-derive
+    /// the scope from the window key string — three parsers for one fact, which
+    /// is how they drift.
+    static func modelScope(payload: AgentUsagePayload?, cardId: String?) -> String? {
+        guard let payload, let cardId,
+              let separator = cardId.firstIndex(of: "|")
+        else { return nil }
+        let clientId = String(cardId[cardId.startIndex..<separator])
+        let card = String(cardId[cardId.index(after: separator)...])
+        return payload.agents
+            .first { $0.clientId == clientId }?
+            .uniqueCardWindows
+            .first { $0.cardId == card }?
+            .modelScope
     }
 
     /// The `"<clientId>|<cardId>"` the card is currently showing, or nil when

--- a/Sources/TokenBar/WindowCardLoader.swift
+++ b/Sources/TokenBar/WindowCardLoader.swift
@@ -200,7 +200,8 @@ enum WindowCardLoader {
             candidates: candidates, resolution: resolved, samples: samples,
             resetMs: window.resetsAt.flatMap(parseISO8601Ms),
             durationMs: window.durationSeconds.map { $0 * 1000 },
-            placementPending: pending, nowMs: nowMs), scanFailed: false)
+            placementPending: pending, nowMs: nowMs,
+            modelScope: window.modelScope), scanFailed: false)
     }
 
     /// The earliest interval start across every candidate window of every
@@ -272,7 +273,8 @@ enum WindowCardLoader {
             windowLabel: quota.windowLabel, candidates: quota.candidates,
             resolution: resolved, samples: quota.samples,
             resetMs: quota.resetMs, durationMs: quota.durationMs,
-            placementPending: false, nowMs: quota.nowMs)
+            placementPending: false, nowMs: quota.nowMs,
+            modelScope: quota.modelScope)
 
         guard let (start, end) = interval(resolved) else {
             return (settled, WindowUsageHalf(mine: [], bars: [], hits: []))
@@ -280,13 +282,31 @@ enum WindowCardLoader {
         // A scan that starts after this window did cannot answer for it.
         guard scan.covers(start: start) else { return nil }
 
-        let mine = scan.slice(from: start, to: min(end, quota.nowMs)).filter(isMine)
+        // Two predicates, applied to different questions on purpose.
+        //
+        // `isMine` answers "is this the subscription's usage" and decides where
+        // the window IS — it is what `firstUsageAfterReset` above consumes.
+        // `inScope` answers "is this the model the allowance counts" and
+        // decides only what the card DISPLAYS.
+        //
+        // The scope is deliberately NOT applied to placement. A scoped weekly
+        // window is anchored by the provider's own reset, so narrowing the
+        // placement probe buys no accuracy — while a scope join that matches
+        // nothing would turn the card blank instead of merely empty, which
+        // moves a naming mismatch from "we found no usage" to "there is no
+        // window". The blast radius of the heuristic stays inside the totals.
+        let subscription = scan.slice(from: start, to: min(end, quota.nowMs)).filter(isMine)
+        let mine = quota.modelScope.map { scope in
+            subscription.filter { ModelScope.covers(scope, modelId: $0.modelId) }
+        } ?? subscription
         let geo = WindowCardGeometry.usageGeometry(
             windowStartMs: start, windowEndMs: end, nowMs: min(quota.nowMs, end),
             samples: quota.samples, messages: mine)
         return (settled, WindowUsageHalf(
             mine: mine, bars: geo.bars, hits: geo.hits,
-            undatedCount: scan.undatedCount))
+            undatedCount: scan.undatedCount,
+            scopeMatchedNothing: quota.modelScope != nil
+                && mine.isEmpty && !subscription.isEmpty))
     }
 
     static func interval(_ s: WindowResolution) -> (start: Int64, end: Int64)? {

--- a/Sources/TokenBar/WindowCardLoading.swift
+++ b/Sources/TokenBar/WindowCardLoading.swift
@@ -25,6 +25,10 @@ struct WindowQuotaHalf: Sendable {
     /// card cannot state one answer and then replace it with another.
     let placementPending: Bool
     let nowMs: Int64
+    /// The provider-declared model scope of this window, carried from stage 1
+    /// so stage 2 filters the usage it displays to the model the allowance is
+    /// actually about. Nil for every window the provider did not narrow.
+    let modelScope: String?
 }
 
 /// Stage 2. The product of the union scan, already attributed and already
@@ -40,6 +44,15 @@ struct WindowUsageHalf: Sendable {
     /// than another's. Carried so the card can disclose the omission, never so
     /// it can claim the omission was its own.
     var undatedCount: Int = 0
+    /// The window declared a model scope and NOTHING in this subscription's
+    /// usage matched it, while unscoped usage exists.
+    ///
+    /// Carried because the scope is a join between the provider's display name
+    /// and the transcript's model id, and a join that finds nothing looks
+    /// exactly like a week with no work in it. Drawing empty bars under a
+    /// moving curve would state a fact about the user's week that this card
+    /// cannot support; saying the scope matched nothing states what happened.
+    var scopeMatchedNothing: Bool = false
 }
 
 /// What the card is, at any moment. Five cases, exhaustive by construction:

--- a/Sources/TokenBar/WindowProbe.swift
+++ b/Sources/TokenBar/WindowProbe.swift
@@ -174,7 +174,12 @@ enum WindowProbe {
                         }
                         let spans = QuotaHistoryFold.spans(
                             cycles: admitted, messages: messages,
-                            subscription: agent.clientId, confirmed: confirmed)
+                            subscription: agent.clientId,
+                            // The probe measures the SHIPPING calculation, so
+                            // it has to narrow the same way. A sweep run on a
+                            // scoped window without this tunes a constant
+                            // against numbers the app never computes.
+                            modelScope: w.modelScope, confirmed: confirmed)
                         return WindowEquivalence.aggregate(
                             declared: !confirmed.isEmpty,
                             cycles: zip(admitted, spans).map { cycle, span in

--- a/Sources/TokenBarCore/AgentUsage.swift
+++ b/Sources/TokenBarCore/AgentUsage.swift
@@ -282,6 +282,16 @@ public struct UsageWindow: Decodable, Sendable {
     /// validated current-cycle evidence passes the v3 quality gate.
     /// Missing or null is state-dependent in the v3 contract.
     public let historicalPace: HistoricalPace?
+    /// The model this window's allowance is scoped to, as the provider's own
+    /// display-name slug — `fable` for a "Fable only" weekly limit. Nil for
+    /// every window the provider did not narrow.
+    ///
+    /// Emitted by the engine only where the provider DECLARES a scope
+    /// (`limits[].scope.model`). It is never inferred from a label here or
+    /// there: "Designs" and "Daily Routines" are narrow windows whose scope is
+    /// not a model, and a flat `seven_day_opus` field says nothing about scope
+    /// at all.
+    public let modelScope: String?
 
     // Defaults preserve existing pure Swift linear fixtures. A v3 status is
     // validated below; the legacy default deliberately does not derive a
@@ -291,8 +301,10 @@ public struct UsageWindow: Decodable, Sendable {
         resetsAt: String? = nil, resetText: String? = nil,
         windowMinutes: Int64? = nil, historicalPace: HistoricalPace? = nil,
         cardId: String? = nil, durationSeconds: Int64? = nil,
-        paceStatus: PaceStatus = .legacyMissing
+        paceStatus: PaceStatus = .legacyMissing,
+        modelScope: String? = nil
     ) {
+        self.modelScope = modelScope
         precondition(
             Self.usagePercentageValidationError(
                 usedPercent: usedPercent,
@@ -342,7 +354,7 @@ public struct UsageWindow: Decodable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case cardId, label, usedPercent, remainingPercent, resetsAt, resetText
-        case windowMinutes, paceStatus, historicalPace
+        case windowMinutes, paceStatus, historicalPace, modelScope
     }
 
     public init(from decoder: Decoder) throws {
@@ -354,6 +366,10 @@ public struct UsageWindow: Decodable, Sendable {
         let resetText = try container.decodeIfPresent(String.self, forKey: .resetText)
         let windowMinutes = try container.decodeIfPresent(Int64.self, forKey: .windowMinutes)
         let historicalPace = try container.decodeIfPresent(HistoricalPace.self, forKey: .historicalPace)
+        // Absent is the ordinary answer — the engine omits the key for every
+        // unscoped window — so `decodeIfPresent` is correct here and is NOT the
+        // conflation the other optional fields on this type warn about.
+        self.modelScope = try container.decodeIfPresent(String.self, forKey: .modelScope)
 
         if let message = Self.usagePercentageValidationError(
             usedPercent: usedPercent,

--- a/Sources/TokenBarCore/ModelScope.swift
+++ b/Sources/TokenBarCore/ModelScope.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Whether a locally recorded model belongs to a window's declared model scope.
+///
+/// This is a JOIN BETWEEN TWO NAMING SYSTEMS, and saying so is the point. The
+/// scope arrives as the provider's display-name slug — `fable`, from a limit
+/// entry whose `scope.model.display_name` is "Fable" — while the model on a
+/// message is the canonical id the local transcript carried, `claude-fable-5`.
+/// Nothing guarantees the two agree, and the engine cannot close the gap for
+/// us: the live `oauth/usage` payload reports `scope.model.id: null`, so the
+/// display name is the only identity the provider actually sends.
+///
+/// A join like this fails silently by default — the bars simply stop matching
+/// the curve, which is the one thing the card exists to explain. So the rule is
+/// deliberately narrow, stated once, and its failure is made visible by
+/// `WindowUsageHalf.scopeMatchedNothing` rather than left to look like an idle
+/// week.
+public enum ModelScope {
+    /// Lowercase alphanumeric runs. The same shape `claude_slug` produces on
+    /// the Rust side, so `Fable` and `claude-fable-5` decompose comparably.
+    static func tokens(_ value: String) -> [String] {
+        value.lowercased().split(whereSeparator: { !$0.isNumber && !$0.isLetter }).map(String.init)
+    }
+
+    /// True when every token of the scope appears in the model id.
+    ///
+    /// Subset rather than equality, because the two systems name at different
+    /// granularities: the provider says "Fable" where the transcript says
+    /// `claude-fable-5`. Subset rather than substring, because a substring test
+    /// is not a rule anyone can state — it matches on accidents of spelling and
+    /// cannot be reasoned about when a new model appears.
+    ///
+    /// Over-matching is bounded by the engine, not by this function: a scope
+    /// naming every model (`all-models`, or a name ending in it) never reaches
+    /// the wire, so there is no scope here broad enough to select a whole
+    /// subscription.
+    ///
+    /// Under-matching — a display name carrying a word the id does not, so
+    /// nothing matches — is the failure this cannot rule out, and is exactly
+    /// why the caller reports an empty scoped result instead of drawing it as
+    /// zero usage.
+    public static func covers(_ scope: String, modelId: String) -> Bool {
+        let wanted = tokens(scope)
+        guard !wanted.isEmpty else { return false }
+        let present = Set(tokens(modelId))
+        return wanted.allSatisfy(present.contains)
+    }
+}

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -281,6 +281,7 @@ public enum QuotaHistoryFold {
     /// unassigned usage lands in the other column rather than being dropped,
     /// because an unclassified source still consumed real time in that window.
     /// `modelScope` narrows the fold to the model a window's allowance counts,
+    /// and has NO DEFAULT on purpose — see the note on `spans`.
     /// for a provider-scoped window like Claude's "Fable only" weekly limit.
     /// Nil means the window is not scoped and every model counts.
     ///
@@ -292,7 +293,7 @@ public enum QuotaHistoryFold {
     /// applied at two of three call sites.
     public static func rows(
         cycles: [QuotaCycle], messages: [WindowMessage], subscription: String,
-        modelScope: String? = nil,
+        modelScope: String?,
         confirmed: [UsageAttribution.Record]
     ) -> [QuotaHistoryRow] {
         // Sorted once, then each cycle takes a contiguous slice: the naive
@@ -404,9 +405,18 @@ public enum QuotaHistoryFold {
     /// quota delta by the usage that produced it, so counting a model the
     /// allowance does not charge inflates the denominator and understates the
     /// price of the quota.
+    ///
+    /// No default value, and the omission is the safeguard. When this argument
+    /// defaulted to nil, `--window-probe` kept compiling unchanged and silently
+    /// began measuring something the shipping path no longer computes — and
+    /// that probe exists to tune `consideredCycles` against the shipping
+    /// calculation, so a divergence there invalidates the measurement rather
+    /// than merely differing from it. A required argument turns "a caller
+    /// forgot" into a build error, which is the only version of this rule that
+    /// cannot be forgotten again.
     public static func spans(
         cycles: [QuotaCycle], messages: [WindowMessage], subscription: String,
-        modelScope: String? = nil,
+        modelScope: String?,
         confirmed: [UsageAttribution.Record]
     ) -> [(exCacheRead: Int64, cost: Double)] {
         let sorted = inScope(messages, modelScope).sorted { $0.timestamp < $1.timestamp }

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -280,14 +280,25 @@ public enum QuotaHistoryFold {
     /// only when the user's own declaration assigns it there; excluded and
     /// unassigned usage lands in the other column rather than being dropped,
     /// because an unclassified source still consumed real time in that window.
+    /// `modelScope` narrows the fold to the model a window's allowance counts,
+    /// for a provider-scoped window like Claude's "Fable only" weekly limit.
+    /// Nil means the window is not scoped and every model counts.
+    ///
+    /// Applied HERE rather than by the caller, and that is the point of the
+    /// parameter existing. The current-window chart, these history rows and the
+    /// equivalence spans are three surfaces of one quota; narrowing only the
+    /// chart made them disagree about the same window — corrected bars above,
+    /// uncorrected "past windows" underneath. A rule the fold owns cannot be
+    /// applied at two of three call sites.
     public static func rows(
         cycles: [QuotaCycle], messages: [WindowMessage], subscription: String,
+        modelScope: String? = nil,
         confirmed: [UsageAttribution.Record]
     ) -> [QuotaHistoryRow] {
         // Sorted once, then each cycle takes a contiguous slice: the naive
         // filter-per-cycle is O(cycles x messages), and on live data that is
         // 15 x 45,844 walks of the whole array on the main actor.
-        let sorted = messages.sorted { $0.timestamp < $1.timestamp }
+        let sorted = inScope(messages, modelScope).sorted { $0.timestamp < $1.timestamp }
         let stamps = sorted.map(\.timestamp)
         let spans = spanTotals(
             cycles: cycles, sorted: sorted, stamps: stamps,
@@ -389,14 +400,26 @@ public enum QuotaHistoryFold {
     ///
     /// Returned parallel to `cycles`, one entry each, so a caller that already
     /// has the sorted array pays no second sort.
+    /// Same `modelScope` contract as `rows`: the equivalence estimate divides a
+    /// quota delta by the usage that produced it, so counting a model the
+    /// allowance does not charge inflates the denominator and understates the
+    /// price of the quota.
     public static func spans(
         cycles: [QuotaCycle], messages: [WindowMessage], subscription: String,
+        modelScope: String? = nil,
         confirmed: [UsageAttribution.Record]
     ) -> [(exCacheRead: Int64, cost: Double)] {
-        let sorted = messages.sorted { $0.timestamp < $1.timestamp }
+        let sorted = inScope(messages, modelScope).sorted { $0.timestamp < $1.timestamp }
         return spanTotals(
             cycles: cycles, sorted: sorted, stamps: sorted.map(\.timestamp),
             subscription: subscription, confirmed: confirmed)
+    }
+
+    /// The messages a scoped window may count. One statement of the rule, so
+    /// the three surfaces of a window cannot apply it differently.
+    public static func inScope(_ messages: [WindowMessage], _ scope: String?) -> [WindowMessage] {
+        guard let scope else { return messages }
+        return messages.filter { ModelScope.covers(scope, modelId: $0.modelId) }
     }
 
     private static func spanTotals(

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -563,6 +563,18 @@ pub struct UsageWindow {
     contract_duration: Option<DurationEvidence>,
     pace_status: PaceStatusPayload,
     historical_pace: Option<HistoricalPacePayload>,
+    /// The model this window's allowance is scoped to, as the provider's own
+    /// display-name slug — `fable` for a "Fable only" weekly limit.
+    ///
+    /// Set ONLY where the provider declares a scope (`limits[].scope.model`),
+    /// never inferred from a label. "Designs" and "Daily Routines" are windows
+    /// with a narrow scope that is not a MODEL, and a flat `seven_day_opus`
+    /// field says nothing about scope at all — guessing from those is how a
+    /// filter starts excluding usage the allowance actually counts.
+    ///
+    /// The display name rather than `scope.model.id` for the reason the card id
+    /// uses it: the live payload reports `id: null` while the field exists.
+    model_scope: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -588,6 +600,8 @@ struct UsageWindowWire<'a> {
     pace_status: &'a PaceStatusPayload,
     #[serde(skip_serializing_if = "Option::is_none")]
     historical_pace: Option<&'a HistoricalPacePayload>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model_scope: Option<&'a str>,
 }
 
 impl Serialize for UsageWindow {
@@ -606,6 +620,7 @@ impl Serialize for UsageWindow {
             window_minutes: self.duration_seconds.map(|seconds| seconds / 60),
             pace_status: &self.pace_status,
             historical_pace: self.historical_pace.as_ref(),
+            model_scope: self.model_scope.as_deref(),
         }
         .serialize(serializer)
     }
@@ -667,6 +682,10 @@ impl UsageWindow {
                 reason: Some("windowIdentity".to_string()),
             },
             historical_pace: None,
+            // Absent by default and attached only by the adapter that has a
+            // provider-declared scope. A window nobody scoped must read as
+            // "not scoped", never as "scoped to nothing".
+            model_scope: None,
         };
         window.refresh_initial_pace_status();
         window
@@ -718,6 +737,18 @@ impl UsageWindow {
 
     /// Attach provider-semantic presentation and history identity plus the
     /// frozen provider/contract duration evidence.
+    /// Attach the provider-declared model scope. Separate from `with_identity`
+    /// because identity is emitted for every window and scope only for the few
+    /// the provider narrows — folding it in would make every call site state a
+    /// scope it does not have.
+    pub(crate) fn with_model_scope(mut self, slug: impl Into<String>) -> Self {
+        let slug = slug.into();
+        if !slug.is_empty() {
+            self.model_scope = Some(slug);
+        }
+        self
+    }
+
     pub(crate) fn with_identity(
         mut self,
         card_id: impl Into<String>,
@@ -4400,12 +4431,17 @@ fn append_claude_scoped_windows(
             label, percent, resets_at, now,
         )
         .map(|window| {
-            window.with_identity(
-                window_key.clone(),
-                Some(window_key),
-                None,
-                Some(DurationEvidence::contract(7 * 24 * 60 * 60)),
-            )
+            window
+                .with_identity(
+                    window_key.clone(),
+                    Some(window_key),
+                    None,
+                    Some(DurationEvidence::contract(7 * 24 * 60 * 60)),
+                )
+                // The same slug the identity is derived from, so a consumer
+                // filtering usage by scope and a consumer keying history by
+                // window cannot disagree about which model this is.
+                .with_model_scope(slug.clone())
         }) {
             windows.push(window);
         }
@@ -7356,6 +7392,48 @@ mod tests {
             windows[0].resets_at.as_deref(),
             Some("2026-08-10T00:00:00.000Z")
         );
+        // The scope reaches the consumer, and it is the DISPLAY-NAME slug.
+        // `scope.model.id` here is "claude/fable.5:promo" — deliberately
+        // unlike the slug, so an implementation that switched to the id
+        // would fail rather than coincide. The live payload reports that id
+        // as null anyway, which is why identity comes from the display name.
+        assert_eq!(windows[0].model_scope.as_deref(), Some("fable"));
+        let wire = serde_json::to_value(&windows[0]).expect("serialize window");
+        assert_eq!(wire["modelScope"], "fable");
+    }
+
+    /// A window nobody scoped must say so by ABSENCE, not by an empty string.
+    ///
+    /// "Designs" and "Daily Routines" are narrow windows whose scope is not a
+    /// model, and the flat `seven_day_*` fields declare no scope at all. A
+    /// consumer filtering usage by scope has to be able to tell "not scoped"
+    /// from "scoped to something", and the key is omitted rather than emitted
+    /// null so the distinction survives the wire.
+    #[test]
+    fn an_unscoped_claude_window_carries_no_model_scope() {
+        let usage = ClaudeUsageResponse {
+            seven_day: Some(ClaudeWindow {
+                utilization: Some(23.0),
+                resets_at: None,
+            }),
+            seven_day_design: Some(ClaudeWindow {
+                utilization: Some(0.0),
+                resets_at: None,
+            }),
+            ..Default::default()
+        };
+        let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        let windows = claude_windows(&usage, now);
+        assert!(!windows.is_empty());
+        for window in &windows {
+            assert_eq!(window.model_scope, None, "{}", window.label);
+            let wire = serde_json::to_value(window).expect("serialize window");
+            assert!(
+                wire.get("modelScope").is_none(),
+                "{} emitted a modelScope key",
+                window.label
+            );
+        }
     }
 
     #[test]
@@ -10900,6 +10978,7 @@ mod tests {
                     reason: reason.map(|value| value.to_string()),
                 },
                 historical_pace,
+                model_scope: None,
             }
         }
 


### PR DESCRIPTION
A model-scoped quota window — Claude's "Fable only" weekly limit — drew the **whole subscription's** usage under its curve. The line is the fable allowance; the bars underneath are supposed to be the usage that moved it.

## What changed

| | |
|---|---|
| **Engine** | `UsageWindow.modelScope`, set from the same `claude_slug(display_name)` the window key is derived from |
| **Join** | `ModelScope.covers` — every token of the scope appears in the model id |
| **Filter** | applied to the usage the card **displays**, not to where the window is placed |
| **Disclosure** | a scope that matches nothing says so, instead of drawing an idle week |

## The part worth reviewing

This is **a join between two naming systems**, and the engine cannot close the gap: the live `oauth/usage` payload reports `scope.model.id: null`, so the provider's display-name slug (`fable`) is the only identity it sends, while the rows carry the transcript's canonical id (`claude-fable-5`).

The rule is a **token-subset** test rather than substring, because a substring test is not a rule anyone can state — it matches on accidents of spelling and cannot be reasoned about when a new model appears.

- **Over-matching** is bounded upstream: a scope naming every model never reaches the wire (`claude_is_all_models_slug`), so no scope here can select a whole subscription.
- **Under-matching** is the failure this cannot rule out, and is handled by disclosure rather than by a cleverer rule.

Scope is set **only** where the provider declares one (`limits[].scope.model`), never inferred from a label. "Designs" and "Daily Routines" are narrow windows whose scope is not a *model*, and a flat `seven_day_opus` field says nothing about scope at all.

The filter deliberately does **not** apply to window placement. A scoped weekly window is anchored by the provider's own reset, so narrowing the placement probe buys no accuracy — while a join matching nothing would turn the card blank instead of merely empty, moving a naming mismatch from "we found no usage" to "there is no window".

## Verification

`cargo test -p tb_core_ffi` 373 passed / 0 failed. `make selftest` 1176 assertions / 0 failures (1165 before).

Mutation-checked **on each side of the FFI separately**, because the Swift cases build their payload from JSON and cannot see the Rust side:

- Rust, `.with_model_scope(slug)` removed → `maps_claude_fable_scoped_weekly_limit` fails, and the Swift suite stays green — which is why they are run apart.
- Swift, the filter removed → the scoped case and the no-match case fail, while the unscoped case still passes.

The Rust fixture's `scope.model.id` is `"claude/fable.5:promo"`, deliberately unlike the slug, so an implementation that switched to the id would fail rather than coincide.

`covers` is asserted on real strings from both naming systems, positive and negative, including the under-match (`fable-max` vs `claude-fable-5`) the disclosure exists for.

**Not covered by an assertion:** the card's rendering of the scope note. It is a `Text` in a view builder; the condition it renders is asserted at the layer below.
