### PR TITLE
fix(scan): only invalidate and bump when the scan roots actually moved

### DIFF
--- a/Sources/TokenBar/ClaudeExtraRoots.swift
+++ b/Sources/TokenBar/ClaudeExtraRoots.swift
@@ -252,6 +252,39 @@ enum ClaudeExtraRoots {
         UserDefaults.standard.removeObject(forKey: appliedConfigDirsKey)
     }
 
+    /// Whether THIS PROCESS has installed the account registry at least once.
+    ///
+    /// `appliedConfigDirsJSON` answers "does this list differ from what a
+    /// PREVIOUS install recorded", which is the wrong question on a process's
+    /// first install: the Rust account registry is process-memory state and
+    /// starts empty regardless of what an earlier process persisted, so a
+    /// relaunch with an unchanged account list installs into an EMPTY
+    /// registry while the persisted marker already says "unchanged" — the
+    /// comparison reports no move for a transition that is, in this process,
+    /// real.
+    ///
+    /// The consequence was not a cosmetic staleness. `TrayAnimator` starts its
+    /// quota poll immediately at launch, before `apply`'s install has
+    /// necessarily finished, and its FIRST fetch can race the setter and read
+    /// only the primary account. That result is applied because nothing had
+    /// signalled `RegistryChange` to move the epoch it checks against — and
+    /// the loop's own recovery is `RegistryChange.sleep(upTo: 300, ...)`,
+    /// which needs exactly the signal this flag exists to guarantee. Without
+    /// it, a missing account could stay missing from the tray gauge for the
+    /// full five minutes even though the registry had held it since launch.
+    @MainActor private static var didInstallConfigDirsThisProcess = false
+
+    /// The canonical empty-account-list payload, compared against directly
+    /// rather than checking the source list for emptiness — the check has to
+    /// run on the same encoded string `install` already holds.
+    private static let emptyConfigDirsJSON = configDirsPayloadJSON([])
+
+    /// Test seam only: forget that this process has installed anything.
+    @MainActor
+    static func resetInstalledConfigDirsThisProcessForTesting() {
+        didInstallConfigDirsThisProcess = false
+    }
+
     /// Test seam only: forget the coalescing claim, or a test that applies the
     /// same list a second time silently measures the skip path.
     @MainActor
@@ -475,7 +508,18 @@ enum ClaudeExtraRoots {
                 // the registry that is now installed rather than the one it
                 // replaced — same reason the scan side records before its own
                 // invalidation, below.
-                guard recordAppliedConfigDirsAndReportChange(configDirsJSON) else { return }
+                let recordedChange = recordAppliedConfigDirsAndReportChange(configDirsJSON)
+                // The persisted comparison alone is not enough: it reports no
+                // change whenever THIS process's list happens to match what a
+                // PREVIOUS process installed, even on this process's first
+                // install into a Rust registry that starts empty regardless.
+                // `TrayAnimator`'s launch-time poll races that first install
+                // directly, so the first non-empty install of a process must
+                // wake pollers even when the persisted marker already agrees.
+                let firstNonEmptyInstall = !didInstallConfigDirsThisProcess
+                    && configDirsJSON != Self.emptyConfigDirsJSON
+                didInstallConfigDirsThisProcess = true
+                guard recordedChange || firstNonEmptyInstall else { return }
                 // Same order as below and for the same reason: a poll woken
                 // before the throttle is dropped is answered from the payload
                 // built for the account set that just changed.

--- a/Sources/TokenBar/ClaudeExtraRoots.swift
+++ b/Sources/TokenBar/ClaudeExtraRoots.swift
@@ -157,9 +157,28 @@ enum ClaudeExtraRoots {
     /// Record what the setter actually installed. A failed call leaves the
     /// registry holding whatever it held, so the stored value must not move.
     static func recordApplied(_ requestedJSON: String, result: ExtraScanPathsResult?) {
-        guard let result else { return }
-        UserDefaults.standard.set(
-            registeredJSON(requestedJSON, rejected: result.rejected), forKey: appliedKey)
+        _ = recordAppliedAndReportChange(requestedJSON, result: result)
+    }
+
+    /// Record, and report whether the installed registry actually MOVED.
+    ///
+    /// The distinction is the whole cost question. `apply` runs at launch and
+    /// on every Settings save, not only when the list changes, so "an apply
+    /// ran" has never implied "something changed" — yet the cache drop and the
+    /// generation bump were both unconditional. Every launch therefore dropped
+    /// every scan-derived cache and advanced the number the views key their
+    /// reloads on, and a popover already open when that landed paid a forced,
+    /// cache-bypassing rescan for a registry identical to the one already
+    /// installed.
+    @discardableResult
+    static func recordAppliedAndReportChange(
+        _ requestedJSON: String, result: ExtraScanPathsResult?
+    ) -> Bool {
+        guard let result else { return false }
+        let json = registeredJSON(requestedJSON, rejected: result.rejected)
+        guard json != appliedPayloadJSON else { return false }
+        UserDefaults.standard.set(json, forKey: appliedKey)
+        return true
     }
 
     /// `requestedJSON` minus the paths the setter refused, in the same shape.
@@ -409,7 +428,24 @@ enum ClaudeExtraRoots {
                 // Before the invalidation and the generation bump, so anything
                 // they restart reads the registry that is now installed rather
                 // than the one it replaced.
-                recordApplied(json, result: result)
+                let moved = recordAppliedAndReportChange(json, result: result)
+                // Both of these exist to undo work done under the OLD roots,
+                // so both are gated on the roots having actually moved.
+                //
+                // They were unconditional, and the launch-time `apply()` is
+                // unconditional too, so every launch dropped every scan-derived
+                // cache and advanced the generation the views key their reloads
+                // on. A popover already open when that landed took a forced,
+                // cache-bypassing rescan on top of its initial load — the
+                // registry being identical to the one already installed.
+                //
+                // `apply` is called on a schedule and on every Settings save,
+                // not only when the list changes, so "it ran" has never implied
+                // "something changed". Only the comparison does.
+                guard moved else {
+                    completion?(result)
+                    return
+                }
                 // The engine dropped its own caches inside the setter. These
                 // are the Swift ones, which answer without asking it — see
                 // `invalidateScanDerivedCaches`. Unconditional on `completion`,

--- a/Sources/TokenBar/ClaudeExtraRoots.swift
+++ b/Sources/TokenBar/ClaudeExtraRoots.swift
@@ -208,6 +208,50 @@ enum ClaudeExtraRoots {
         UserDefaults.standard.removeObject(forKey: appliedKey)
     }
 
+    /// The account registry's own applied marker — the same idea as
+    /// `appliedKey` above, for the OTHER registry `install` writes.
+    ///
+    /// It has to be a separate persisted value, not a reuse of `appliedKey` or
+    /// of `lastApplied` below. `appliedKey` answers a question about scan
+    /// roots; this one answers "which accounts is the quota side fetching",
+    /// and the two payloads are built from the same configured list but are
+    /// not the same string — a directory the scanner refuses is still absent
+    /// from `appliedPayloadJSON` while it is present here. And `lastApplied`
+    /// is in-memory and resets to nil every launch, which is exactly the case
+    /// that needed catching: at launch there is no PREVIOUS apply for
+    /// `lastApplied` to differ from, so a comparison against it always reports
+    /// a change, on every process start, whether or not the account list
+    /// actually differs from what a previous process already installed.
+    static let appliedConfigDirsKey = "tokenbar.claude.extraRootsAppliedConfigDirs"
+
+    /// Overridable for the same reason `appliedProvider` is.
+    nonisolated(unsafe) static var appliedConfigDirsProvider: @Sendable () -> String = {
+        UserDefaults.standard.string(forKey: appliedConfigDirsKey) ?? configDirsPayloadJSON([])
+    }
+
+    static var appliedConfigDirsJSON: String { appliedConfigDirsProvider() }
+
+    /// Record, and report whether the account registry actually moved.
+    ///
+    /// No `result` parameter, unlike the scan side's twin: `setClaudeConfigDirs`
+    /// returns nothing for `install` to check, so there is no partial-failure
+    /// case to gate persistence on — the list is either installed or it is not
+    /// attempted, and `install` always attempts it.
+    @discardableResult
+    static func recordAppliedConfigDirsAndReportChange(_ configDirsJSON: String) -> Bool {
+        guard configDirsJSON != appliedConfigDirsJSON else { return false }
+        UserDefaults.standard.set(configDirsJSON, forKey: appliedConfigDirsKey)
+        return true
+    }
+
+    /// Test seam only: back to the pre-apply state.
+    static func resetAppliedConfigDirsForTesting() {
+        appliedConfigDirsProvider = {
+            UserDefaults.standard.string(forKey: appliedConfigDirsKey) ?? configDirsPayloadJSON([])
+        }
+        UserDefaults.standard.removeObject(forKey: appliedConfigDirsKey)
+    }
+
     /// Test seam only: forget the coalescing claim, or a test that applies the
     /// same list a second time silently measures the skip path.
     @MainActor
@@ -417,6 +461,21 @@ enum ClaudeExtraRoots {
             // installed yet, which is the reason it was placed after the setter
             // in the first place.
             Task { @MainActor in
+                // Gated the same way the scan side is, and for the same
+                // reason: `install` runs at launch and on every Settings save,
+                // not only when the account list changes, so an unconditional
+                // wake here paid the same repeated cost `recordAppliedAndReportChange`
+                // exists to remove — just on the other registry. `lastApplied`
+                // above cannot catch the launch case, because it starts nil
+                // every process and a comparison against nil always reports a
+                // change; `appliedConfigDirsJSON` is persisted across launches,
+                // which is what the comparison needs to be meaningful here.
+                //
+                // Recorded before the wake, so anything the wake restarts reads
+                // the registry that is now installed rather than the one it
+                // replaced — same reason the scan side records before its own
+                // invalidation, below.
+                guard recordAppliedConfigDirsAndReportChange(configDirsJSON) else { return }
                 // Same order as below and for the same reason: a poll woken
                 // before the throttle is dropped is answered from the payload
                 // built for the account set that just changed.

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -13592,6 +13592,28 @@ enum SelfTest {
                    + "holds what it held")
         ClaudeExtraRoots.resetAppliedForTesting()
 
+        // CE-CONFIG-MOVED. The account registry's own twin of CE-MOVED. `install`
+        // wakes the quota throttle and every sleeping poller between its two
+        // setters, and that wake was unconditional in exactly the way the scan
+        // side's cache-drop and generation-bump were — `install` runs at launch
+        // and on every Settings save, and `lastApplied` cannot catch the launch
+        // case because it is in-memory and starts nil every process, so a
+        // comparison against it always reports a change on the first apply of
+        // a run. `appliedConfigDirsJSON` is persisted, which is what makes the
+        // comparison mean something across a relaunch.
+        ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
+        let ceCfgFirst = ClaudeExtraRoots.configDirsPayloadJSON(["/tmp/tokenbar-cfg-moved"])
+        expect(ClaudeExtraRoots.recordAppliedConfigDirsAndReportChange(ceCfgFirst),
+               "CE-CONFIG-MOVED installing an account list that differs reports a change")
+        expect(!ClaudeExtraRoots.recordAppliedConfigDirsAndReportChange(ceCfgFirst),
+               "CE-CONFIG-MOVED and installing the SAME list again reports none — the "
+                   + "launch case, and the one that was paying for an unnecessary wake")
+        expect(ClaudeExtraRoots.recordAppliedConfigDirsAndReportChange(
+                   ClaudeExtraRoots.configDirsPayloadJSON(["/tmp/tokenbar-cfg-moved-2"])),
+               "CE-CONFIG-MOVED a genuinely different list still reports a change, so "
+                   + "the gate is a comparison rather than a one-shot latch")
+        ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
+
         // isRejectedRoot: home and root are refused; an ordinary subfolder is not.
         let ceHome = FileManager.default.homeDirectoryForCurrentUser.path
         expect(
@@ -13916,11 +13938,19 @@ enum SelfTest {
         // blocks on a semaphore and never returns until the assertion is made.
         // It blocks `applyQueue`, never the main actor, or the wake it is
         // waiting for could not run and this would deadlock rather than fail.
+        //
+        // `configDirsJSON` here must genuinely differ from what
+        // `resetAppliedConfigDirsForTesting` leaves as the baseline, or the
+        // CE-CONFIG-MOVED gate this exercise now runs through would report no
+        // change and the wake would never fire — this test would then be
+        // asserting a deadlock timeout rather than the order it names.
+        ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
+        let m3oConfigDirs = ClaudeExtraRoots.configDirsPayloadJSON(["/tmp/tokenbar-m3o"])
         let m3oWokeBeforeScan: Bool? = awaitMainActorValue {
             let gate = DispatchSemaphore(value: 0)
             let before = ClaudeExtraRoots.RegistryChange.epoch
             ClaudeExtraRoots.installForTesting(
-                json: "{}", configDirsJSON: "[]",
+                json: "{}", configDirsJSON: m3oConfigDirs,
                 setConfigDirs: { _ in },
                 setScanPaths: { _ in
                     gate.wait()
@@ -13941,6 +13971,31 @@ enum SelfTest {
             "M3-o the quota pollers were not woken until the scan-root probe "
                 + "returned, so a stalled mount leaves the cards on the previous "
                 + "account set for the whole filesystem timeout")
+
+        // M3-o2. The mirror of M3-o, and the half that proves the gate GATES
+        // rather than merely not breaking the case above. Re-installing the
+        // SAME account list `install` just recorded as applied must not wake
+        // anything: that is the launch call and every no-op Settings save,
+        // and before this fix it woke every poller and dropped the quota
+        // throttle for a registry identical to the one already installed.
+        let m3oNotWoken: Bool? = awaitMainActorValue {
+            let before = ClaudeExtraRoots.RegistryChange.epoch
+            let done = ThrottleGate()
+            ClaudeExtraRoots.installForTesting(
+                json: "{}", configDirsJSON: m3oConfigDirs,
+                setConfigDirs: { _ in },
+                setScanPaths: { _ in nil },
+                then: { _ in Task { await done.open() } })
+            await done.wait()
+            ClaudeExtraRoots.resetApplyClaimForTesting()
+            return ClaudeExtraRoots.RegistryChange.epoch == before
+        }
+        expect(
+            m3oNotWoken == true,
+            "M3-o2 re-applying the SAME account list wakes no poller, so an "
+                + "unchanged registry — the launch case above all — costs "
+                + "nothing on the quota side")
+        ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
 
         // M3-p. A payload fetched under the previous registry must not be
         // applied, only dropped.

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -13565,6 +13565,33 @@ enum SelfTest {
                "CE-APPLIED a process that has never applied compares against the "
                    + "empty registry, which is what the engine holds then")
 
+        // CE-MOVED. `apply` runs at launch and on every Settings save, not only
+        // when the list changes, so "an apply ran" never implied "something
+        // changed". Both consequences of an apply — dropping every Swift-side
+        // scan cache and advancing the generation views key their reloads on —
+        // were unconditional, so every launch paid for both. A popover already
+        // open when that landed took a forced, cache-bypassing rescan for a
+        // registry identical to the one already installed.
+        ClaudeExtraRoots.resetAppliedForTesting()
+        let ceOK = try! JSONDecoder().decode(
+            ExtraScanPathsResult.self,
+            from: Data(#"{"registeredCount":1,"unreadable":[],"rejected":[]}"#.utf8))
+        let ceFirst = ClaudeExtraRoots.payloadJSON(["/tmp/tokenbar-moved"])
+        expect(ClaudeExtraRoots.recordAppliedAndReportChange(ceFirst, result: ceOK),
+               "CE-MOVED installing a registry that differs reports a change")
+        expect(!ClaudeExtraRoots.recordAppliedAndReportChange(ceFirst, result: ceOK),
+               "CE-MOVED and installing the SAME registry again reports none — which "
+                   + "is the launch case, and the one that was paying for a rescan")
+        expect(ClaudeExtraRoots.recordAppliedAndReportChange(
+                   ClaudeExtraRoots.payloadJSON(["/tmp/tokenbar-moved-2"]), result: ceOK),
+               "CE-MOVED a genuinely different registry still reports a change, so the "
+                   + "gate is a comparison rather than a one-shot latch")
+        expect(!ClaudeExtraRoots.recordAppliedAndReportChange(
+                   ClaudeExtraRoots.payloadJSON(["/tmp/tokenbar-moved-3"]), result: nil),
+               "CE-MOVED a failed setter reports no change, because the registry still "
+                   + "holds what it held")
+        ClaudeExtraRoots.resetAppliedForTesting()
+
         // isRejectedRoot: home and root are refused; an ordinary subfolder is not.
         let ceHome = FileManager.default.homeDirectoryForCurrentUser.path
         expect(

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -13997,6 +13997,66 @@ enum SelfTest {
                 + "nothing on the quota side")
         ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
 
+        // M3-o3. The relaunch case `appliedConfigDirsJSON` alone cannot see.
+        //
+        // A user with a persisted extra account quits and reopens the app.
+        // `apply()` reads the SAME account list this new process's persisted
+        // marker already recorded from the PREVIOUS process — so the
+        // persisted comparison reports no change — while the Rust registry in
+        // THIS process starts genuinely empty. `TrayAnimator` starts polling
+        // immediately at launch and can race that first install, reading only
+        // the primary account; without a wake, nothing corrects that reading
+        // for up to five minutes. Set up exactly that: the persisted marker
+        // already agrees with what is about to install, and this process has
+        // installed nothing yet.
+        let m3oRelaunch = ClaudeExtraRoots.configDirsPayloadJSON(["/tmp/tokenbar-m3o-relaunch"])
+        let m3oRelaunchWoke: Bool? = awaitMainActorValue {
+            ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
+            _ = ClaudeExtraRoots.recordAppliedConfigDirsAndReportChange(m3oRelaunch)
+            ClaudeExtraRoots.resetInstalledConfigDirsThisProcessForTesting()
+            let before = ClaudeExtraRoots.RegistryChange.epoch
+            let done = ThrottleGate()
+            ClaudeExtraRoots.installForTesting(
+                json: "{}", configDirsJSON: m3oRelaunch,
+                setConfigDirs: { _ in },
+                setScanPaths: { _ in nil },
+                then: { _ in Task { await done.open() } })
+            await done.wait()
+            ClaudeExtraRoots.resetApplyClaimForTesting()
+            return ClaudeExtraRoots.RegistryChange.epoch != before
+        }
+        expect(
+            m3oRelaunchWoke == true,
+            "M3-o3 the first install of a process wakes pollers even when the "
+                + "persisted marker already matches, because the Rust registry "
+                + "does not persist across a relaunch the way the marker does")
+
+        // M3-o4. The same first-install case, but with nothing configured.
+        // Waking pollers for an empty registry that stays empty corrects
+        // nothing and reintroduces exactly the cost this fix removes, so the
+        // "first install" exemption applies only to a non-empty list.
+        let m3oEmptyRelaunchWoke: Bool? = awaitMainActorValue {
+            ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
+            ClaudeExtraRoots.resetInstalledConfigDirsThisProcessForTesting()
+            let before = ClaudeExtraRoots.RegistryChange.epoch
+            let done = ThrottleGate()
+            ClaudeExtraRoots.installForTesting(
+                json: "{}", configDirsJSON: ClaudeExtraRoots.configDirsPayloadJSON([]),
+                setConfigDirs: { _ in },
+                setScanPaths: { _ in nil },
+                then: { _ in Task { await done.open() } })
+            await done.wait()
+            ClaudeExtraRoots.resetApplyClaimForTesting()
+            let woke = ClaudeExtraRoots.RegistryChange.epoch != before
+            ClaudeExtraRoots.resetInstalledConfigDirsThisProcessForTesting()
+            return woke
+        }
+        expect(
+            m3oEmptyRelaunchWoke == false,
+            "M3-o4 a first install with no accounts configured does not wake "
+                + "pollers — there is nothing for the extra wake to correct")
+        ClaudeExtraRoots.resetAppliedConfigDirsForTesting()
+
         // M3-p. A payload fetched under the previous registry must not be
         // applied, only dropped.
         //


### PR DESCRIPTION
`ClaudeExtraRoots.apply()` dropped every Swift-side scan-derived cache and advanced the generation views key their reloads on — **both unconditionally, on every call**.

`apply()` runs at launch (`AppDelegate:90`) and on every Settings save, not only when the list changes. So "an apply ran" has never implied "something changed", and every launch invalidated the reopen snapshot, the union scan, the hourly cache and the attributed series' rows, then moved the generation. A popover already open when that landed additionally took `reloadForRootChange()` — a forced, cache-bypassing full graph refresh — **for a registry byte-identical to the one already installed**.

The AppDelegate site at `:387` was already value-gated on the persisted list. This puts the same test where it belongs: on the value the setter actually installed, so it covers the launch call and any future caller too.

## Measured — and this is NOT the cold-start regression

Timed `usage_graph::run`, the computation the dashboard's "Loading usage…" actually waits on, at `v1.13.3` and at `7323eda5`. Same corpus (119 days), same machine, three runs each, through a throwaway `#[ignore]` probe rather than the app's own probes (those enter the provider credential path).

| | run 0 | run 1 | run 2 |
|---|---|---|---|
| `v1.13.3` | 3516 ms | 3087 ms | 3038 ms |
| `main` | 4290 ms | 2810 ms | 2995 ms |

The warm runs are the comparable ones: **the scan did not get slower.** `run 0` differs by first-touch I/O and is n=1.

The engine is cleared by inspection as well. The vendored revision moved this release (`731a2dcc` → `fc2941eb`) but that diff is **92 insertions, 0 deletions, one new function** — parser and scanner untouched, so the graph computation is the same code on both sides.

So this PR removes real waste on a path the user waits on, and it is **not established as the cause** of the slow cold start that prompted the investigation. Stated rather than implied, because a fix landing next to a complaint invites being credited with it.

## Verification

`make selftest`: 1186 assertions, 0 failures (1182 before).

`CE-MOVED` asserts all four states, because the second alone is satisfied by a function that never reports a change:

- a differing registry reports a change
- the **same** registry reported again does not — that is the launch case, and the one that was paying
- a genuinely different registry still does, so the gate is a comparison rather than a one-shot latch
- a failed setter does not, because the registry still holds what it held
