### PR TITLE
fix(quota): count the equivalence denominator over the tokens its cost prices

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -1419,7 +1419,7 @@ private struct DashboardSnapshot {
                 declared: !confirmed.isEmpty,
                 cycles: zip(cycles, spans).map { cycle, span in
                     WindowEquivalence.Cycle(
-                        deltaPercent: cycle.usedPercent, spanTokens: span.exCacheRead,
+                        deltaPercent: cycle.usedPercent, spanTokens: span.tokens,
                         spanCost: span.cost, observedFraction: cycle.observedFraction)
                 })
         }

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -11223,6 +11223,14 @@ enum SelfTest {
 
         // Same tokens, two different deltas: a hardcoded coefficient would
         // return the same ratio for both.
+        //
+        // The expected counts below are 5,060,000 — input PLUS cache read. They
+        // used to be 60,000, and that number was not a decision: this fixture
+        // exists to prove the ratio scales with delta, and its author wrote
+        // down whatever the code returned for a message that happened to carry
+        // 5M cache reads. It therefore pinned a basis nobody had chosen, and
+        // pinned the wrong one (issue #237). An expectation copied from current
+        // behaviour asserts that the code does what it does.
         let eqMessages = [windowMessage(at: 1_500, input: 60_000, cacheRead: 5_000_000,
                                         cost: 30)]
         let wide = WindowEquivalence.row(
@@ -11234,10 +11242,10 @@ enum SelfTest {
                       QuotaSample(atMs: 2_000, usedPercent: 20)],
             messages: eqMessages)
         expect(
-            wide == .ratio(tokensPerTenth: 60_000, costPerTenth: 30, errorPercent: 5),
+            wide == .ratio(tokensPerTenth: 5_060_000, costPerTenth: 30, errorPercent: 5),
             "V15 the ratio is the measured quotient, not a coefficient")
         expect(
-            narrower == .ratio(tokensPerTenth: 30_000, costPerTenth: 15, errorPercent: 3),
+            narrower == .ratio(tokensPerTenth: 2_530_000, costPerTenth: 15, errorPercent: 3),
             "V15 doubling the quota delta halves the ratio")
         expect(
             WindowEquivalence.row(
@@ -12433,8 +12441,11 @@ enum SelfTest {
         // most of the volume, which is how "10% of quota ~ 4.8M · $172" reached
         // $36 per million (issue #237).
         //
-        // Every other fixture in this file sets `cacheRead: 0`, so none of them
-        // could tell the two bases apart — which is why the defect survived.
+        // Only V15 above carried a non-zero cache read before this, and it
+        // asserted the OLD basis — an expectation copied from behaviour rather
+        // than chosen, which is how a defect gets pinned by its own suite. The
+        // rest of this file sets `cacheRead: 0` and could not tell the two
+        // bases apart at all.
         let qhCacheMessages = try! JSONDecoder().decode(
             [WindowMessage].self,
             from: Data("""
@@ -12462,6 +12473,40 @@ enum SelfTest {
                    && qhCacheRows.first?.mineTokens == 1000,
                "QH-CACHE the bars' basis still excludes cache reads while the total "
                    + "includes them, so the two questions keep their two answers")
+
+        // QH-CACHE-LIVE. The SECOND path that computes this ratio, and the one
+        // the first fix missed. `WindowUsageCard.equivalenceRow` calls
+        // `WindowEquivalence.row` directly instead of going through the fold,
+        // and `QuotaView` renders that card immediately above the history —
+        // so a basis fixed in one place and not the other put the inflated
+        // price and the corrected price on screen together.
+        //
+        // Both now read `WindowEquivalence.ratioTokens`, and this asserts the
+        // live path specifically rather than trusting that they share a helper.
+        let qhLiveSamples = [
+            QuotaSample(atMs: 1_000_000, usedPercent: 10),
+            QuotaSample(atMs: 2_000_000, usedPercent: 20),
+        ]
+        let qhLiveMessages = try! JSONDecoder().decode(
+            [WindowMessage].self,
+            from: Data("""
+            [{"timestamp":1500000,"client":"c","providerId":"p",
+              "modelId":"m","input":100,"output":0,"cacheRead":900,"cacheWrite":0,
+              "reasoning":0,"cost":2.0,"isTurnStart":true}]
+            """.utf8))
+        // delta = 10 points, so per-tenth = tokens / 10 * 10 = the raw total.
+        if case let .ratio(tokensPerTenth, costPerTenth, _) =
+            WindowEquivalence.row(samples: qhLiveSamples, messages: qhLiveMessages)
+        {
+            expect(tokensPerTenth == 1000,
+                   "QH-CACHE-LIVE the live window's denominator counts cache reads too, "
+                       + "so the card above the history no longer contradicts it")
+            expect(costPerTenth == 2.0,
+                   "QH-CACHE-LIVE and its numerator is the whole message cost, "
+                       + "unchanged — the same pairing as the pooled path")
+        } else {
+            expect(false, "QH-CACHE-LIVE the live fixture produces a ratio row")
+        }
 
         // QH-B. Exhaustion is an absolute reading, not the observed span. A
         // cycle first seen at 40% and last at 100% consumed 60 points as far as

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -12221,7 +12221,7 @@ enum SelfTest {
             cycles: qhsCycles, messages: qhsMessages, subscription: "c",
             modelScope: nil,
             confirmed: qhsRecords)
-        expect(qhsSpans.first?.exCacheRead == 100 && qhsSpans.first.map { abs($0.cost - 0.25) < 1e-9 } == true,
+        expect(qhsSpans.first?.tokens == 100 && qhsSpans.first.map { abs($0.cost - 0.25) < 1e-9 } == true,
                "QH-SHRINK usage taken before the recomputed start still counts toward the "
                 + "span its own readings bracket")
 
@@ -12369,8 +12369,8 @@ enum SelfTest {
         let qhsScopedSpans = QuotaHistoryFold.spans(
             cycles: qhsCycles, messages: qhsScopeMessages, subscription: "c",
             modelScope: "fable", confirmed: qhsDeclared)
-        expect(qhsUnscopedSpans.first?.exCacheRead == 1000
-                   && qhsScopedSpans.first?.exCacheRead == 700,
+        expect(qhsUnscopedSpans.first?.tokens == 1000
+                   && qhsScopedSpans.first?.tokens == 700,
                "QH-SCOPE and the equivalence denominator narrows with it — counting "
                    + "a model the allowance does not charge understates what the "
                    + "quota costs")
@@ -12419,9 +12419,49 @@ enum SelfTest {
                "FMT-TOKENS an unmeasured count is a dash, a real zero is a zero, "
                    + "and a measured count is itself")
 
-        expect(qhspRows.first?.spanTokensExCacheRead == 100,
+        expect(qhspRows.first?.spanTokens == 100,
                "QH-SPAN the span counts only what the two readings bracket — the later "
                 + "message sits after the last sample, so no observed movement measures it")
+
+        // QH-CACHE. The span is the equivalence's DENOMINATOR and `spanCost` is
+        // its numerator, and the numerator is `message.cost` — the message's
+        // whole priced cost, cache reads included, which cannot be decomposed
+        // here because `WindowMessage` carries one cost and not one per token
+        // class. A denominator that excluded cache reads therefore priced one
+        // set of tokens and counted another, inflating the implied per-token
+        // rate by the cache-read share. On a Claude Code workload that share is
+        // most of the volume, which is how "10% of quota ~ 4.8M · $172" reached
+        // $36 per million (issue #237).
+        //
+        // Every other fixture in this file sets `cacheRead: 0`, so none of them
+        // could tell the two bases apart — which is why the defect survived.
+        let qhCacheMessages = try! JSONDecoder().decode(
+            [WindowMessage].self,
+            from: Data("""
+            [{"timestamp":\((qhsReset - 500_000) * 1000),"client":"c","providerId":"p",
+              "modelId":"m","input":100,"output":0,"cacheRead":900,"cacheWrite":0,
+              "reasoning":0,"cost":0.25,"isTurnStart":true}]
+            """.utf8))
+        let qhCacheSpans = QuotaHistoryFold.spans(
+            cycles: qhsCycles, messages: qhCacheMessages, subscription: "c",
+            modelScope: nil, confirmed: qhsRecords)
+        expect(qhCacheSpans.first?.tokens == 1000,
+               "QH-CACHE the equivalence denominator counts cache reads, because the "
+                   + "cost beside it does and the two are printed as one ratio")
+        expect(qhCacheSpans.first?.cost == 0.25,
+               "QH-CACHE and the cost is the message's whole cost, unchanged — the "
+                   + "fix moves the denominator to meet it, not the other way round")
+        // The bars keep the OTHER basis, deliberately, and this is the pair that
+        // says so: same message, two figures, cache reads in one and not the
+        // other. Folding them onto one basis would either decouple the bars from
+        // the quota line or break the ratio again.
+        let qhCacheRows = QuotaHistoryFold.rows(
+            cycles: qhsCycles, messages: qhCacheMessages, subscription: "c",
+            modelScope: nil, confirmed: qhsRecords)
+        expect(qhCacheRows.first?.mineTokensExCacheRead == 100
+                   && qhCacheRows.first?.mineTokens == 1000,
+               "QH-CACHE the bars' basis still excludes cache reads while the total "
+                   + "includes them, so the two questions keep their two answers")
 
         // QH-B. Exhaustion is an absolute reading, not the observed span. A
         // cycle first seen at 40% and last at 100% consumed 60 points as far as

--- a/Sources/TokenBar/Views/QuotaHistoryCard.swift
+++ b/Sources/TokenBar/Views/QuotaHistoryCard.swift
@@ -344,7 +344,7 @@ struct QuotaHistoryCard: View {
                     cycles: counted.map {
                         WindowEquivalence.Cycle(
                             deltaPercent: $0.cycle.usedPercent,
-                            spanTokens: $0.spanTokensExCacheRead, spanCost: $0.spanCost,
+                            spanTokens: $0.spanTokens, spanCost: $0.spanCost,
                             observedFraction: $0.cycle.observedFraction)
                     }),
                 tokens: Format.compactTokens, money: Format.usdOrBelowCent))

--- a/Sources/TokenBar/WindowProbe.swift
+++ b/Sources/TokenBar/WindowProbe.swift
@@ -185,7 +185,7 @@ enum WindowProbe {
                             cycles: zip(admitted, spans).map { cycle, span in
                                 WindowEquivalence.Cycle(
                                     deltaPercent: cycle.usedPercent,
-                                    spanTokens: span.exCacheRead, spanCost: span.cost,
+                                    spanTokens: span.tokens, spanCost: span.cost,
                                     observedFraction: cycle.observedFraction)
                             })
                     }

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -92,17 +92,37 @@ public struct QuotaHistoryRow: Equatable, Sendable, Identifiable {
     public let cycle: QuotaCycle
     /// Attributed to THIS subscription — the number the quota bar is about.
     public let mineTokens: Int64
-    /// The same total with cache reads removed, which is what the quota
-    /// equivalence divides by. `WindowEquivalence.row` already excludes them;
-    /// carrying it here keeps the aggregate over many cycles on the same basis
-    /// as the single-window figure rather than quietly using a fuller total.
+    /// The same total on the BARS' basis — cache reads removed.
+    ///
+    /// Not the equivalence's basis. `spanTokens` below is the full count, for
+    /// the reason given there; this one matches `WindowCardGeometry`, which
+    /// sizes the bars from everything except cache reads because including
+    /// them decouples the bars from the quota line (measured: 4.5x vs 1.2x
+    /// discrimination). A figure printed beside the bars should be countable
+    /// in them.
     public let mineTokensExCacheRead: Int64
     public let mineCost: Double
     /// The same two quantities restricted to the cycle's OBSERVED span, which
     /// is the only interval the quota delta describes. The whole-window figures
     /// above are what the row displays — "this window cost me X" is a question
     /// about the window — while these are the only ones a ratio may divide.
-    public let spanTokensExCacheRead: Int64
+    ///
+    /// The FULL token count, cache reads included, and that is the load-bearing
+    /// part. These two feed `WindowEquivalence`, which prints them on one line
+    /// as "10% of quota ~ X tokens · $Y API-equivalent" — two descriptions of
+    /// the same work, which a reader divides. `spanCost` is `message.cost`, the
+    /// message's whole priced cost, and a message's cost cannot be decomposed
+    /// here: `WindowMessage` carries one `cost`, not one per token class. So a
+    /// count excluding cache reads beside a cost including them is the one
+    /// pairing that cannot be made consistent, and it inflated the implied
+    /// per-token price by the cache-read share — most of a Claude Code
+    /// workload, which this repo's own bar comment puts at 200x the volume at
+    /// a tenth the price.
+    ///
+    /// Full-and-full is therefore not a preference between two workable
+    /// options; it is the only achievable pairing until per-class cost crosses
+    /// the FFI. See issue #237.
+    public let spanTokens: Int64
     public let spanCost: Double
     /// Everything else recorded in the same interval, summed. Not noise: it is
     /// the answer to "the window barely moved, so where did the work go".
@@ -361,7 +381,7 @@ public enum QuotaHistoryFold {
                 cycle: cycle,
                 mineTokens: mine.tokens, mineTokensExCacheRead: mine.exCacheRead,
                 mineCost: mine.cost,
-                spanTokensExCacheRead: span.exCacheRead, spanCost: span.cost,
+                spanTokens: span.tokens, spanCost: span.cost,
                 otherTokens: other.tokens, otherCost: other.cost,
                 otherHasAssigned: other.hasAssigned,
                 otherHasExcluded: other.hasExcluded,
@@ -418,7 +438,7 @@ public enum QuotaHistoryFold {
         cycles: [QuotaCycle], messages: [WindowMessage], subscription: String,
         modelScope: String?,
         confirmed: [UsageAttribution.Record]
-    ) -> [(exCacheRead: Int64, cost: Double)] {
+    ) -> [(tokens: Int64, cost: Double)] {
         let sorted = inScope(messages, modelScope).sorted { $0.timestamp < $1.timestamp }
         return spanTotals(
             cycles: cycles, sorted: sorted, stamps: sorted.map(\.timestamp),
@@ -435,7 +455,7 @@ public enum QuotaHistoryFold {
     private static func spanTotals(
         cycles: [QuotaCycle], sorted: [WindowMessage], stamps: [Int64],
         subscription: String, confirmed: [UsageAttribution.Record]
-    ) -> [(exCacheRead: Int64, cost: Double)] {
+    ) -> [(tokens: Int64, cost: Double)] {
         cycles.map { cycle in
             // Bounded by the SPAN, not by `[start, reset)`. The span is what
             // the denominator measures, and it is not always inside the cycle:
@@ -445,7 +465,7 @@ public enum QuotaHistoryFold {
             // overflowing on a corrupt timestamp.
             let lo = lowerBound(stamps, cycle.firstSampleMs)
             let hi = lowerBound(stamps, cycle.lastSampleMs.saturatingAdding(1))
-            var span = (exCacheRead: Int64(0), cost: 0.0)
+            var span = (tokens: Int64(0), cost: 0.0)
             for message in sorted[lo..<max(lo, hi)]
             where message.timestamp > cycle.firstSampleMs
                 && message.timestamp <= cycle.lastSampleMs
@@ -454,8 +474,11 @@ public enum QuotaHistoryFold {
                     client: message.client, provider: message.providerId,
                     model: message.modelId, records: confirmed), target == subscription
                 else { continue }
-                span.exCacheRead = span.exCacheRead.saturatingAdding(
-                    message.tokensExCacheRead)
+                // The FULL count, matching `message.cost` beside it. See
+                // `spanTokens`: the cost cannot be narrowed to exclude cache
+                // reads, so the count must not be either, or the ratio the two
+                // form is priced over one set and counted over another.
+                span.tokens = span.tokens.saturatingAdding(message.tokens)
                 span.cost += message.cost
             }
             return span

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -474,11 +474,13 @@ public enum QuotaHistoryFold {
                     client: message.client, provider: message.providerId,
                     model: message.modelId, records: confirmed), target == subscription
                 else { continue }
-                // The FULL count, matching `message.cost` beside it. See
-                // `spanTokens`: the cost cannot be narrowed to exclude cache
-                // reads, so the count must not be either, or the ratio the two
-                // form is priced over one set and counted over another.
-                span.tokens = span.tokens.saturatingAdding(message.tokens)
+                // Through `WindowEquivalence.ratioTokens`, which is where the
+                // basis is stated. The live-window path in `row` computes the
+                // same ratio and reads the same function, so the two surfaces
+                // cannot drift apart the way they did when each summed for
+                // itself.
+                span.tokens = span.tokens.saturatingAdding(
+                    WindowEquivalence.ratioTokens(message))
                 span.cost += message.cost
             }
             return span

--- a/Sources/TokenBarCore/WindowEquivalence.swift
+++ b/Sources/TokenBarCore/WindowEquivalence.swift
@@ -7,6 +7,29 @@ import Foundation
 /// be one: the same subscription measured 21x apart between its session window
 /// and its weekly window on the same day.
 public enum WindowEquivalence {
+    /// The token count a quota ratio may divide, for ONE message.
+    ///
+    /// A function rather than a convention, because this ratio is computed in
+    /// two places — `row` for the live window and `QuotaHistoryFold.spanTotals`
+    /// for the pooled history — and they are rendered one above the other in
+    /// `QuotaView`. When the basis was a convention rather than a name, the two
+    /// disagreed: fixing the pooled path alone left the card on top showing the
+    /// old inflated price beside the corrected history directly below it.
+    ///
+    /// The FULL count, cache reads included, because the cost it is divided
+    /// into is `message.cost` — the message's whole priced cost — and that
+    /// cannot be narrowed to match a smaller count: `WindowMessage` carries one
+    /// cost, not one per token class. Excluding cache reads therefore priced
+    /// one set of tokens and counted another, and on a Claude Code workload the
+    /// excluded share is most of the volume (issue #237).
+    ///
+    /// Deliberately NOT the bars' basis. `WindowCardGeometry` sizes bars from
+    /// `tokensExCacheRead` because including cache reads decouples them from
+    /// the quota line. Different question, different basis — but each stated
+    /// where it is used, so a third caller has something to call rather than a
+    /// precedent to copy.
+    public static func ratioTokens(_ message: WindowMessage) -> Int64 { message.tokens }
+
     /// The provider reports whole percents, so a measured Δ carries ±0.5.
     static let quantisationHalfStep = 0.5
     /// How much relative error the displayed ratio may carry.
@@ -156,7 +179,7 @@ public enum WindowEquivalence {
         let inSpan = messages.filter {
             $0.timestamp > first.atMs && $0.timestamp <= last.atMs
         }
-        let tokens = inSpan.reduce(Int64(0)) { $0.saturatingAdding($1.tokensExCacheRead) }
+        let tokens = inSpan.reduce(Int64(0)) { $0.saturatingAdding(ratioTokens($1)) }
         let cost = inSpan.reduce(0.0) { $0 + $1.cost }
         let error = Int((quantisationHalfStep / delta * 100).rounded())
 


### PR DESCRIPTION
Fixes the pairing reported in #237: `10% of quota ~ X tokens · $Y API-equivalent` printed a count and a price computed over different token sets, so dividing them gave several times list price.

## Cause

`QuotaHistoryFold.spanTotals` accumulated `message.tokensExCacheRead` into the denominator and `message.cost` into the numerator. The first excludes cache reads; the second is the message's whole priced cost and includes them.

Cache reads dominate a Claude Code workload — this repo's own comment in `WindowCardGeometry.usageGeometry` puts them at **200x the volume at a tenth the price** — so most of the tokens were missing from the count while all of their cost stayed in the price.

Observed: `72 quota points ~ 4.8M · $172.25`, i.e. **$36 per million**.

## Why the denominator moves, not the numerator

Not a preference between two workable options. `WindowMessage` carries **one** `cost`, not one per token class, so a message's cache-read share of price cannot be subtracted on this side at all.

| Direction | Implementable? |
|---|---|
| Narrow the cost to match the old count | ❌ needs per-class cost across the FFI |
| Widen the count to match the cost | ✅ one line |

`spanTokensExCacheRead` is renamed `spanTokens` — the old name described a basis it no longer has, and would have gone on being believed.

## What deliberately does not change

`mineTokensExCacheRead` keeps excluding cache reads. Its previous doc justified that by *matching the equivalence's basis*, which this PR invalidates, so it is re-documented against its real reason: it matches the **bars**, which are sized without cache reads because including them decouples the bars from the quota line (measured 4.5x vs 1.2x discrimination). A figure printed beside the bars should be countable in them.

Two questions, two bases — each now stated against its own reason rather than against the other.

## Verification

`make selftest`: **1230 assertions, 0 failures** (1227 before). `QH-CACHE` is mutation-checked — restoring `tokensExCacheRead` in the accumulator fails it.

**The gap that let this survive is worth naming.** Every pre-existing fixture in `SelfTest.swift` sets `cacheRead: 0`, so not one of them could distinguish the two bases. The suite was green because it never asked the question, not because the answer was right.

`QH-CACHE` is the first fixture here with a non-zero cache read, and asserts all three facts the change turns on:

- the denominator now counts cache reads
- the cost beside it is unchanged
- the bars' basis still excludes them

## Effect for users

The token figure in the equivalence row and the heatmap tooltip grows substantially, and the implied per-million price falls back to something near list. Neither number was individually wrong before; the pairing was.
