### PR TITLE
fix(antigravity): stop the OAuth client scan from eating a neighbouring string

### DIFF
--- a/crates/tb_core_ffi/src/agent_antigravity.rs
+++ b/crates/tb_core_ffi/src/agent_antigravity.rs
@@ -1643,6 +1643,19 @@ fn scan_client_ids(data: &[u8]) -> Vec<String> {
         while start > 0 && is_token_byte(data[start - 1]) {
             start -= 1;
         }
+        // The walk-back is greedy over `-` and `_` as well as alphanumerics, and
+        // in a packed binary the bytes in front of a client id belong to whichever
+        // string was laid down next to it. A Google client id is `<digits>-<token>`,
+        // so re-anchor on the first `-` and keep only the digit run immediately
+        // before it; otherwise the neighbour's tail lands in the head and
+        // `valid_client_id` rejects an id that is really there.
+        if let Some(dash) = data[start..end].iter().position(|b| *b == b'-') {
+            let mut head = start + dash;
+            while head > start && data[head - 1].is_ascii_digit() {
+                head -= 1;
+            }
+            start = head;
+        }
         if let Ok(candidate) = std::str::from_utf8(&data[start..end]) {
             if valid_client_id(candidate) && !out.contains(&candidate.to_string()) {
                 out.push(candidate.to_string());
@@ -1907,6 +1920,32 @@ mod tests {
         let client = preferred_client(&ids, &secrets).unwrap();
         assert_eq!(client.0, "123-abcDEF_g.apps.googleusercontent.com");
         assert!(client.1.starts_with("GOCSPX-"));
+    }
+
+    #[test]
+    fn scans_client_id_glued_to_a_neighbouring_string() {
+        // The fixture above separates the id with NUL, which is not a token byte,
+        // so the walk-back stops on its own. A real language_server packs strings
+        // with no separator: the neighbour's tail is token bytes and gets absorbed
+        // into the head, which must be all digits. Observed on Antigravity 1.x —
+        // both ids in the shipped binary were rejected this way, which took the
+        // whole OAuth route down whenever the IDE was not running.
+        let blob = b"someNeighbourKey123-abcDEF_g.apps.googleusercontent.com\x00tail";
+        assert_eq!(
+            scan_client_ids(blob),
+            vec!["123-abcDEF_g.apps.googleusercontent.com".to_string()]
+        );
+
+        // ponytail: a neighbour whose own tail is digits is indistinguishable from
+        // the id's numeric head, so the longest digit run wins and those digits are
+        // kept. Nothing in the byte stream marks the boundary; the only stronger
+        // fix would be reading Mach-O string sections instead of scanning bytes,
+        // which is a lot of machinery for a case Google's 12-digit ids make rare.
+        let glued_digits = b"prefix99000123-abcDEF_g.apps.googleusercontent.com\x00tail";
+        assert_eq!(
+            scan_client_ids(glued_digits),
+            vec!["99000123-abcDEF_g.apps.googleusercontent.com".to_string()]
+        );
     }
 
     #[test]

--- a/crates/tb_core_ffi/src/agent_antigravity.rs
+++ b/crates/tb_core_ffi/src/agent_antigravity.rs
@@ -1645,11 +1645,15 @@ fn scan_client_ids(data: &[u8]) -> Vec<String> {
         }
         // The walk-back is greedy over `-` and `_` as well as alphanumerics, and
         // in a packed binary the bytes in front of a client id belong to whichever
-        // string was laid down next to it. A Google client id is `<digits>-<token>`,
-        // so re-anchor on the first `-` and keep only the digit run immediately
-        // before it; otherwise the neighbour's tail lands in the head and
-        // `valid_client_id` rejects an id that is really there.
-        if let Some(dash) = data[start..end].iter().position(|b| *b == b'-') {
+        // string was laid down next to it. A Google client id is `<digits>-<token>`
+        // with a single hyphen — the token and the `.apps.googleusercontent.com`
+        // suffix carry none — so the id's delimiter is the LAST hyphen in the
+        // segment. Re-anchor there and keep only the digit run immediately before
+        // it. Anchoring on the first hyphen instead would keep a neighbour's own
+        // `…letters<digits>-` tail in the head, and because `valid_client_id` only
+        // checks the digits before the first hyphen it would accept the fabricated
+        // id (e.g. `123-beta456-real.apps…` instead of `456-real.apps…`).
+        if let Some(dash) = data[start..end].iter().rposition(|b| *b == b'-') {
             let mut head = start + dash;
             while head > start && data[head - 1].is_ascii_digit() {
                 head -= 1;
@@ -1936,11 +1940,23 @@ mod tests {
             vec!["123-abcDEF_g.apps.googleusercontent.com".to_string()]
         );
 
-        // ponytail: a neighbour whose own tail is digits is indistinguishable from
-        // the id's numeric head, so the longest digit run wins and those digits are
-        // kept. Nothing in the byte stream marks the boundary; the only stronger
-        // fix would be reading Mach-O string sections instead of scanning bytes,
-        // which is a lot of machinery for a case Google's 12-digit ids make rare.
+        // A neighbour whose own tail is `…<letters><digits>-` puts a second hyphen
+        // in the segment. The id's delimiter is the last one (its token carries
+        // none), so anchoring there recovers the real id; anchoring on the first
+        // hyphen would keep the neighbour's `123-beta` and `valid_client_id` — which
+        // only checks the digits before the first hyphen — would accept it.
+        let two_hyphens = b"label123-beta456-real.apps.googleusercontent.com\x00tail";
+        assert_eq!(
+            scan_client_ids(two_hyphens),
+            vec!["456-real.apps.googleusercontent.com".to_string()]
+        );
+
+        // ponytail: a neighbour whose tail is digits glued straight onto the id's
+        // project number (no intervening hyphen) is indistinguishable from the head,
+        // so the longest digit run wins and those digits are kept. Nothing in the
+        // byte stream marks that boundary; the only stronger fix would be reading
+        // Mach-O string sections instead of scanning bytes, which is a lot of
+        // machinery for a case Google's 12-digit ids make rare.
         let glued_digits = b"prefix99000123-abcDEF_g.apps.googleusercontent.com\x00tail";
         assert_eq!(
             scan_client_ids(glued_digits),


### PR DESCRIPTION
## Problem

With Antigravity **installed but not running**, the Antigravity card shows `Antigravity OAuth client was not found. Install Antigravity.app or configure its OAuth client.` — even though the app is installed and the OAuth client id/secret are present in its `language_server` binary.

The OAuth route does not need the IDE process: `discover_client_from_app` reads the `.app` artifacts from disk with `std::fs::read`. So a closed-but-installed IDE should resolve a client and fetch quota. It did not, and the cause is in our scan, not in the environment.

## Root cause

`scan_client_ids` finds the `.apps.googleusercontent.com` suffix, then walks backward over token bytes (`[A-Za-z0-9_-]`) to locate the start of the id. In the shipped `language_server` (a ~139 MB packed Mach-O), the bytes immediately in front of a client id belong to whatever string was laid down next to it, with no separator. The walk-back absorbs that neighbour's tail into the id's head.

A Google client id is `<digits>-<token>`, and `valid_client_id` requires the head before the first `-` to be all digits. With a neighbour's tail glued on, the head contains letters, so **every id is rejected** and the scan returns an empty vector — while `scan_client_secrets`, which reads a fixed-length window *forward* from its `GOCSPX-` prefix, is unaffected.

Measured on a real install (`/Applications/Antigravity.app/.../bin/language_server`): both client ids present in the binary were rejected, `scan_client_ids` returned `0`, and `resolve_oauth_client` returned `None` — taking the entire OAuth route down whenever the IDE was not running.

The existing unit test did not catch this because its fixture separates the id with a `\x00` byte. NUL is not a token byte, so the walk-back stops on its own — the fixture's anchor made the defect unreachable.

## Fix

After the greedy walk-back, re-anchor on the first `-` in the candidate and keep only the digit run immediately before it. This trims any non-digit neighbour bytes back off the numeric head without disturbing the id itself.

```rust
if let Some(dash) = data[start..end].iter().position(|b| *b == b'-') {
    let mut head = start + dash;
    while head > start && data[head - 1].is_ascii_digit() {
        head -= 1;
    }
    start = head;
}
```

Known ceiling, recorded in the test: if a neighbour's own tail is digits, it is indistinguishable from the id's numeric head and those digits are kept. Nothing in the byte stream marks the boundary. The only stronger fix is parsing Mach-O string sections instead of scanning bytes, which is disproportionate for a case that Google's 12-digit ids make rare.

## Validation

| Check | Result |
| --- | --- |
| `cargo test -p tb_core_ffi agent_antigravity` | 27 passed |
| New regression test `scans_client_id_glued_to_a_neighbouring_string` | passes; **fails with `left: []` when the fix is reverted** (mutation-checked), matching the real-world `ids=0` |
| `cargo clippy -p tb_core_ffi --all-targets` | 27 warnings before and after — none new |
| Real install, IDE closed, `swift run TokenBar --smoke` | error string moves from `OAuth client was not found` to `token refresh was rejected` — i.e. the client now resolves and the route reaches the credential stage |

The remaining `token refresh was rejected` on that machine is a stale `~/.gemini/oauth_creds.json` (expired refresh token), which is outside this change: it confirms discovery now succeeds and hands off to the refresh step correctly.

## Scope

Discovery only. This is independent of #236 (which adds an `agy` CLI fallback for the not-installed case); it fixes the installed-but-closed case that should already work. No behaviour change for users whose IDE is running — that path never calls this scan.
