### PR TITLE
fix(grok): read the weekly window from the credit pool, not the product row

### DIFF
--- a/crates/tb_core_ffi/src/agent_grok.rs
+++ b/crates/tb_core_ffi/src/agent_grok.rs
@@ -52,6 +52,23 @@ const MONTHLY_TIMEOUT_SECS: u64 = 5;
 /// exactly (not by substring) so `..._BIWEEKLY` / `..._NOT_WEEKLY` can't pass.
 const WEEKLY_PERIOD_TYPE: &str = "USAGE_PERIOD_TYPE_WEEKLY";
 const WEEKLY_WINDOW_KEY: &str = "billing.weekly.v1";
+/// The weekly pace series, versioned apart from the card id on purpose.
+///
+/// Quota history keys a series by (provider, account scope, window key) and
+/// fits run-out forecasts over that exact series. Every sample recorded before
+/// the pool fix holds the `GrokBuild` product share, and every sample after it
+/// holds the whole weekly credit pool; for anyone who also spends credits
+/// outside the CLI those are different quantities, and a fit spanning the
+/// splice would report a burn rate nothing consumed. `v2` starts a clean
+/// series, and the stale `v1` one falls out through the ordinary
+/// inactive-series eviction.
+///
+/// The card id deliberately stays `v1`: it is what a stored tray or card window
+/// selection is written against, and moving it would leave anyone who pinned
+/// the weekly window pointing at a card that no longer exists. Losing a few
+/// cycles of pace history is the intended cost here; silently unresolving a
+/// saved selection is not.
+const WEEKLY_PACE_SERIES_KEY: &str = "billing.weekly.v2";
 const MONTHLY_WINDOW_KEY: &str = "billing.monthly.v1";
 
 pub(crate) struct GrokData {
@@ -445,7 +462,7 @@ fn weekly_window(config: &BillingConfig, now: DateTime<Utc>) -> Option<UsageWind
     )
     .with_identity(
         WEEKLY_WINDOW_KEY,
-        Some(WEEKLY_WINDOW_KEY.to_string()),
+        Some(WEEKLY_PACE_SERIES_KEY.to_string()),
         period.duration,
         None,
     );
@@ -1194,7 +1211,7 @@ mod tests {
         assert_eq!(data.windows[0].label_for_test(), "Weekly");
         assert_eq!(
             data.windows[0].pace_window_key_for_test(),
-            Some("billing.weekly.v1")
+            Some("billing.weekly.v2")
         );
         assert!((data.windows[0].remaining_for_test() - 96.0).abs() < 0.01);
         // [1] Monthly: 216/15000 = 1.44% used -> 98.56% remaining, resets 2026-08-01.
@@ -1537,7 +1554,7 @@ mod tests {
         assert_eq!(data.windows[0].window_minutes_for_test(), Some(10_080));
         assert_eq!(
             data.windows[0].pace_window_key_for_test(),
-            Some("billing.weekly.v1")
+            Some("billing.weekly.v2")
         );
         assert!((data.windows[0].remaining_for_test() - 96.0).abs() < 0.01);
         assert_eq!(
@@ -1724,7 +1741,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(wire["cardId"], "billing.weekly.v1");
-        assert_eq!(wire["paceStatus"]["windowKey"], "billing.weekly.v1");
+        assert_eq!(wire["paceStatus"]["windowKey"], "billing.weekly.v2");
         assert_eq!(wire["paceStatus"]["state"], "learningDuration");
         assert!(wire["resetsAt"].as_str().is_some());
         assert!(wire["paceStatus"].get("durationSeconds").is_none());
@@ -1751,7 +1768,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(wire["cardId"], "billing.weekly.v1");
-        assert_eq!(wire["paceStatus"]["windowKey"], "billing.weekly.v1");
+        assert_eq!(wire["paceStatus"]["windowKey"], "billing.weekly.v2");
         assert_eq!(wire["paceStatus"]["durationSeconds"], 86_400);
         assert_eq!(wire["paceStatus"]["durationSource"], "provider");
 
@@ -1777,7 +1794,7 @@ mod tests {
                 weekly_window(&config, parse_timestamp("2026-07-17T12:00:00Z").unwrap()).unwrap();
             let wire = serde_json::to_value(&window).unwrap();
             assert_eq!(
-                wire["paceStatus"]["windowKey"], "billing.weekly.v1",
+                wire["paceStatus"]["windowKey"], "billing.weekly.v2",
                 "{label}"
             );
             assert_eq!(wire["paceStatus"]["state"], "unavailable", "{label}");

--- a/crates/tb_core_ffi/src/agent_grok.rs
+++ b/crates/tb_core_ffi/src/agent_grok.rs
@@ -33,10 +33,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const GROK_TOKEN_URL: &str = "https://auth.x.ai/oauth2/token";
-/// Weekly SuperGrok credits meter. Returns `creditUsagePercent` / a `GrokBuild`
-/// product percent over a weekly `currentPeriod`. Right after a weekly reset,
-/// with no usage recorded yet, xAI OMITS those percent fields — the period is
-/// still reported, so that state is a genuine 0%, not an error.
+/// Weekly SuperGrok credits meter. Returns `creditUsagePercent` — the shared
+/// weekly credit pool — plus a `productUsage[]` decomposition of that same pool,
+/// over a weekly `currentPeriod`. Right after a weekly reset, with no usage
+/// recorded yet, xAI OMITS those percent fields — the period is still reported,
+/// so that state is a genuine 0%, not an error.
 const GROK_CREDITS_URL: &str = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 /// Monthly included-allowance meter. The default view reports `monthlyLimit` +
 /// `used` over a monthly billing period (percent = used / monthlyLimit).
@@ -479,10 +480,25 @@ enum WeeklyPercent {
     Invalid,
 }
 
-/// Prefer `GrokBuild.usagePercent`; only when that field is absent (product
-/// missing or key omitted) fall through to `creditUsagePercent`. A present but
-/// unparsable/out-of-range value on the chosen field is `Invalid`, not `Absent`.
+/// Prefer `creditUsagePercent`; only when that field is absent fall through to
+/// the `GrokBuild` product row. A present but unparsable/out-of-range value on
+/// the chosen field is `Invalid`, not `Absent`.
+///
+/// `creditUsagePercent` is the weekly credit *pool* — the meter that decides
+/// when requests start being refused. `productUsage[]` decomposes that same
+/// pool per product (`GrokBuild`, `GrokChat`, `Api`, ...), so a product row is
+/// at most the pool figure and is under it by whatever the other products
+/// spent. Reading `GrokBuild` as the window therefore under-reported depletion
+/// for anyone who also used Grok outside the CLI, and said "4% left" against an
+/// exhausted pool (issue #240). The product row survives only as a fallback for
+/// a payload that omits the pool percent entirely.
 fn weekly_used_percent(config: &BillingConfig) -> WeeklyPercent {
+    if let Some(raw) = config.credit_usage_percent.as_deref() {
+        return match valid_percentage(raw) {
+            Some(pct) => WeeklyPercent::Value(pct),
+            None => WeeklyPercent::Invalid,
+        };
+    }
     if let Some(products) = config.product_usage.as_ref() {
         for product in products {
             let name = product.product.as_deref().unwrap_or("");
@@ -493,18 +509,12 @@ fn weekly_used_percent(config: &BillingConfig) -> WeeklyPercent {
                         None => WeeklyPercent::Invalid,
                     };
                 }
-                // GrokBuild row present but usagePercent key omitted — try overall.
+                // GrokBuild row present but usagePercent key omitted.
                 break;
             }
         }
     }
-    match config.credit_usage_percent.as_deref() {
-        Some(raw) => match valid_percentage(raw) {
-            Some(pct) => WeeklyPercent::Value(pct),
-            None => WeeklyPercent::Invalid,
-        },
-        None => WeeklyPercent::Absent,
-    }
+    WeeklyPercent::Absent
 }
 
 /// Monthly included-allowance window: percent = used / monthlyLimit. Only
@@ -1312,7 +1322,7 @@ mod tests {
     }
 
     #[test]
-    fn prefers_grok_build_product_percent() {
+    fn prefers_overall_credit_percent_over_product_row() {
         let config: BillingConfig = serde_json::from_str(
             r#"{
                 "creditUsagePercent": 50.0,
@@ -1324,19 +1334,54 @@ mod tests {
         )
         .unwrap();
         match weekly_used_percent(&config) {
-            WeeklyPercent::Value(pct) => assert!((pct - 4.0).abs() < 0.01),
-            other => panic!("expected Value(4.0), got {other:?}"),
+            WeeklyPercent::Value(pct) => assert!((pct - 50.0).abs() < 0.01),
+            other => panic!("expected Value(50.0), got {other:?}"),
         }
     }
 
     #[test]
-    fn falls_back_to_overall_credit_percent() {
+    fn exhausted_pool_is_zero_remaining_not_the_product_share() {
+        // Issue #240: the pool is spent, but the CLI's own share of it is 96%,
+        // so reading the product row published "4% left" on a subscription that
+        // was refusing requests.
+        let credits = r#"{
+            "config": {
+                "currentPeriod": {
+                    "type": "USAGE_PERIOD_TYPE_WEEKLY",
+                    "start": "2026-07-15T00:00:00+00:00",
+                    "end": "2026-07-22T00:00:00+00:00"
+                },
+                "creditUsagePercent": 100.0,
+                "productUsage": [
+                    { "product": "GrokChat", "usagePercent": 4.0 },
+                    { "product": "GrokBuild", "usagePercent": 96.0 }
+                ]
+            }
+        }"#;
+        let data = build_grok_data(
+            credits,
+            None,
+            &test_credentials(),
+            now(),
+            scope_none(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(data.windows.len(), 1);
+        assert!(
+            data.windows[0].remaining_for_test().abs() < 0.01,
+            "exhausted weekly pool must publish 0% remaining, got {}",
+            data.windows[0].remaining_for_test()
+        );
+    }
+
+    #[test]
+    fn falls_back_to_product_percent_without_overall_credit() {
         let config: BillingConfig = serde_json::from_str(
             r#"{
-                "creditUsagePercent": 12.5,
                 "productUsage": [
-                    { "product": "GrokChat" },
-                    { "product": "GrokBuild" }
+                    { "product": "GrokChat", "usagePercent": 10.0 },
+                    { "product": "GrokBuild", "usagePercent": 12.5 }
                 ]
             }"#,
         )
@@ -1349,25 +1394,36 @@ mod tests {
 
     #[test]
     fn rejects_invalid_usage_percentages_before_wire() {
-        let invalid_product: BillingConfig = serde_json::from_str(
+        let invalid_credit: BillingConfig = serde_json::from_str(
             r#"{
-                "creditUsagePercent": 12.5,
+                "creditUsagePercent": 150.0,
                 "productUsage": [
-                    { "product": "GrokBuild", "usagePercent": 150.0 }
+                    { "product": "GrokBuild", "usagePercent": 12.5 }
                 ]
             }"#,
         )
         .unwrap();
-        // Present-but-out-of-range GrokBuild fails that field; do not fall back.
-        assert_eq!(
-            weekly_used_percent(&invalid_product),
-            WeeklyPercent::Invalid
-        );
+        // Present-but-out-of-range pool percent fails that field; do not fall back.
+        assert_eq!(weekly_used_percent(&invalid_credit), WeeklyPercent::Invalid);
 
         for invalid in ["1e400", r#""NaN""#] {
+            let malformed_credit: BillingConfig = serde_json::from_str(&format!(
+                r#"{{
+                    "creditUsagePercent": {invalid},
+                    "productUsage": [
+                        {{ "product": "GrokBuild", "usagePercent": 12.5 }}
+                    ]
+                }}"#
+            ))
+            .unwrap();
+            assert_eq!(
+                weekly_used_percent(&malformed_credit),
+                WeeklyPercent::Invalid
+            );
+
+            // Same rule on the fallback field when the pool percent is absent.
             let malformed_product: BillingConfig = serde_json::from_str(&format!(
                 r#"{{
-                    "creditUsagePercent": 12.5,
                     "productUsage": [
                         {{ "product": "GrokBuild", "usagePercent": {invalid} }}
                     ]
@@ -1384,7 +1440,7 @@ mod tests {
             r#"{
                 "creditUsagePercent": -1.0,
                 "productUsage": [
-                    { "product": "GrokBuild", "usagePercent": 150.0 }
+                    { "product": "GrokBuild", "usagePercent": 4.0 }
                 ]
             }"#,
         )

--- a/crates/tb_core_ffi/src/agent_grok.rs
+++ b/crates/tb_core_ffi/src/agent_grok.rs
@@ -173,11 +173,13 @@ struct UsagePeriod {
     end: Option<String>,
 }
 
+/// One product's share of the weekly credit pool. The `product` name is
+/// deliberately not decoded: no product is privileged any more, because a
+/// share cannot answer the pool window whichever product it belongs to, and
+/// any product's usage refutes an empty week equally.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ProductUsage {
-    #[serde(default)]
-    product: Option<String>,
     #[serde(default)]
     usage_percent: Option<Box<RawValue>>,
 }
@@ -497,9 +499,8 @@ enum WeeklyPercent {
     Invalid,
 }
 
-/// Prefer `creditUsagePercent`; only when that field is absent fall through to
-/// the `GrokBuild` product row. A present but unparsable/out-of-range value on
-/// the chosen field is `Invalid`, not `Absent`.
+/// `creditUsagePercent` is the only field that can answer this window. A
+/// present but unparsable/out-of-range value is `Invalid`, not `Absent`.
 ///
 /// `creditUsagePercent` is the weekly credit *pool* — the meter that decides
 /// when requests start being refused. `productUsage[]` decomposes that same
@@ -507,8 +508,18 @@ enum WeeklyPercent {
 /// at most the pool figure and is under it by whatever the other products
 /// spent. Reading `GrokBuild` as the window therefore under-reported depletion
 /// for anyone who also used Grok outside the CLI, and said "4% left" against an
-/// exhausted pool (issue #240). The product row survives only as a fallback for
-/// a payload that omits the pool percent entirely.
+/// exhausted pool (issue #240).
+///
+/// That is why no product row is read as a *value*, not even as a fallback: a
+/// share of the pool is not a reading of the pool, and one recorded under the
+/// weekly pace series would splice a second quantity into it the moment a later
+/// refresh restored the pool field.
+///
+/// A product row can still *refute*. Absent percent fields are read as an empty
+/// week further down, and since the pool is at least as full as any single
+/// product's share, a product reporting usage proves the week is not empty. A
+/// present `usagePercent` that is not a parsable zero therefore fails the
+/// reading closed rather than letting a fabricated 0% through.
 fn weekly_used_percent(config: &BillingConfig) -> WeeklyPercent {
     if let Some(raw) = config.credit_usage_percent.as_deref() {
         return match valid_percentage(raw) {
@@ -516,22 +527,17 @@ fn weekly_used_percent(config: &BillingConfig) -> WeeklyPercent {
             None => WeeklyPercent::Invalid,
         };
     }
-    if let Some(products) = config.product_usage.as_ref() {
-        for product in products {
-            let name = product.product.as_deref().unwrap_or("");
-            if name.eq_ignore_ascii_case("GrokBuild") {
-                if let Some(usage_percent) = product.usage_percent.as_deref() {
-                    return match valid_percentage(usage_percent) {
-                        Some(pct) => WeeklyPercent::Value(pct),
-                        None => WeeklyPercent::Invalid,
-                    };
-                }
-                // GrokBuild row present but usagePercent key omitted.
-                break;
-            }
-        }
+    let usage_seen = config.product_usage.iter().flatten().any(|product| {
+        product
+            .usage_percent
+            .as_deref()
+            .is_some_and(|raw| valid_percentage(raw) != Some(0.0))
+    });
+    if usage_seen {
+        WeeklyPercent::Invalid
+    } else {
+        WeeklyPercent::Absent
     }
-    WeeklyPercent::Absent
 }
 
 /// Monthly included-allowance window: percent = used / monthlyLimit. Only
@@ -1393,8 +1399,11 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_product_percent_without_overall_credit() {
-        let config: BillingConfig = serde_json::from_str(
+    fn product_rows_refute_an_empty_week_but_never_supply_the_pool() {
+        // No pool percent, but the rows show usage. The old fallback answered
+        // 12.5 here, which would have spliced a product share into the pace
+        // series the next time the pool field came back.
+        let usage_seen: BillingConfig = serde_json::from_str(
             r#"{
                 "productUsage": [
                     { "product": "GrokChat", "usagePercent": 10.0 },
@@ -1403,10 +1412,27 @@ mod tests {
             }"#,
         )
         .unwrap();
-        match weekly_used_percent(&config) {
-            WeeklyPercent::Value(pct) => assert!((pct - 12.5).abs() < 0.01),
-            other => panic!("expected Value(12.5), got {other:?}"),
-        }
+        assert_eq!(weekly_used_percent(&usage_seen), WeeklyPercent::Invalid);
+
+        // A GrokBuild row alone is no more of a pool reading than the pair.
+        let build_only: BillingConfig = serde_json::from_str(
+            r#"{ "productUsage": [ { "product": "GrokBuild", "usagePercent": 12.5 } ] }"#,
+        )
+        .unwrap();
+        assert_eq!(weekly_used_percent(&build_only), WeeklyPercent::Invalid);
+
+        // Explicit zeros do not refute the empty week, so a freshly reset week
+        // that itemizes its products still reads as 0% rather than erroring.
+        let all_zero: BillingConfig = serde_json::from_str(
+            r#"{
+                "productUsage": [
+                    { "product": "GrokChat", "usagePercent": 0.0 },
+                    { "product": "GrokBuild", "usagePercent": 0 }
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(weekly_used_percent(&all_zero), WeeklyPercent::Absent);
     }
 
     #[test]
@@ -1438,7 +1464,9 @@ mod tests {
                 WeeklyPercent::Invalid
             );
 
-            // Same rule on the fallback field when the pool percent is absent.
+            // With the pool percent absent, an unreadable product row is not a
+            // parsable zero, so it refutes the empty week rather than passing
+            // a fabricated 0% through.
             let malformed_product: BillingConfig = serde_json::from_str(&format!(
                 r#"{{
                     "productUsage": [


### PR DESCRIPTION
Fixes the Grok weekly meter reported in #240: an exhausted subscription showed **4% remaining** in TokenBar while two other trackers on the same menu bar showed 0% remaining / 100% used.

## Root cause

`weekly_used_percent` preferred `config.productUsage[]`'s `GrokBuild` row and consulted `config.creditUsagePercent` only when that row was missing or carried no `usagePercent` key. Those two fields are not the same quantity.

| Field | What it is |
|---|---|
| `config.creditUsagePercent` | The shared weekly SuperGrok credit pool — the meter that decides when requests start being refused |
| `config.productUsage[].usagePercent` | A per-product decomposition of that same pool (`GrokBuild`, `GrokChat`, `Api`, ...) |

A product row is therefore at most the pool figure, and sits under it by whatever the other products spent. Reading the CLI's own row as the window under-reported depletion for anyone who also used Grok outside the CLI — which is exactly the reported shape: the pool was at 100% while `GrokBuild`'s share of it was ~96%, so the card published "4% left" against a subscription that was refusing requests.

Three independent implementations of the same endpoint treat the pool percent as the headline weekly meter and the product rows as extra per-product detail: [Orca](https://github.com/stablyai/orca/blob/main/src/main/rate-limits/grok-fetcher.ts) (`mapWeeklyCredits` reads `creditUsagePercent` only), [oh-my-pi](https://github.com/can1357/oh-my-pi/blob/main/packages/ai/src/usage/xai-oauth.ts) (`SuperGrok Weekly Credits` from `creditUsagePercent`, one additional limit per `productUsage` entry), and CodexBar (`config.creditUsagePercent`, falling back to `onDemandUsed / onDemandCap`).

## Change

The preference is inverted. `creditUsagePercent` decides the weekly window; the `GrokBuild` row survives only as a fallback for a payload that omits the pool percent entirely.

Everything else about the meter is unchanged:

> A present-but-unparsable or out-of-range value on whichever field was chosen is still `Invalid` rather than a synthesized 0%. A truly absent percent is still read as an empty week only when a self-contained weekly `currentPeriod` proves the meter exists. A weekly window is still required for the card to render at all, and the monthly meter stays additive best-effort.

## Data continuity

Window identity (`billing.weekly.v1`), period parsing, and the refresh sequence are untouched, so recorded quota history continues on the same key. Existing rows hold the old per-product share, so a user who spends credits outside the CLI will see the weekly figure step up once at first refresh. This is worth a line in the release notes — a figure that jumps upward reads as a defect if it arrives unannounced.

## Verification

| Test | Role |
|---|---|
| `exhausted_pool_is_zero_remaining_not_the_product_share` | Old-fail/new-pass. Drives `build_grok_data` with the issue's shape (pool 100, `GrokBuild` 96) and asserts 0% remaining |
| `prefers_overall_credit_percent_over_product_row` | Old-fail/new-pass. Pool 50 wins over a `GrokBuild` row of 4 (was `prefers_grok_build_product_percent`) |
| `falls_back_to_product_percent_without_overall_credit` | Non-trigger regression. No pool percent present, product row still read |
| `rejects_invalid_usage_percentages_before_wire` | Malformed values moved onto the now-chosen field, plus the same rule for the fallback field |

Mutation check: restoring only the preference order fails the first two and the invalid-value test while the fallback case stays green.

Local gates: `cargo fmt --all -- --check` (clean on the touched file), `cargo test`, `cargo clippy --workspace --all-targets`, `make build`, `make selftest`, `swift run TokenBar --smoke`.

Reported by @terry-deephow.

Refs #240
