### PR TITLE
fix(format): promote the unit when a compact mantissa rounds up to 1000

### DIFF
--- a/Sources/TokenBar/Format.swift
+++ b/Sources/TokenBar/Format.swift
@@ -8,10 +8,17 @@ enum Format {
         let value = Double(count)
         let scaled: Double
         let suffix: String
+        // Tier boundaries sit at the ROUNDING boundary, not at the unit: the
+        // `>= 100` arm below prints `%.0f`, so 999_500_000 scales to 999.5 and
+        // carries to "1000M" — a mantissa that has left its own tier. Promoting
+        // at 999_500 / 999_500_000 renders those bands as "1M" / "1B" instead.
+        // Every value outside the two half-unit bands picks the same tier it
+        // always did. (The top of the B tier has nowhere to promote to, so
+        // 999.5B still prints "1000B".)
         switch value {
-        case 1_000_000_000...:
+        case 999_500_000...:
             (scaled, suffix) = (value / 1_000_000_000, "B")
-        case 1_000_000...:
+        case 999_500...:
             (scaled, suffix) = (value / 1_000_000, "M")
         case 1_000...:
             (scaled, suffix) = (value / 1_000, "K")

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -12117,6 +12117,23 @@ enum SelfTest {
                    && Format.money(tokens: 2_100_000, cost: 0.003) == "<$0.01",
                "QH-MONEY tokens with no price get a dash rather than a false total, "
                    + "while a window that genuinely spent nothing still reads $0.00")
+        // FMT-TIER. `compactTokens` picked its unit from the raw value and only
+        // then rounded the mantissa, so a `%.0f` carry out of 999.5 published a
+        // mantissa that had left its own tier: "1000M", "1000K".
+        expect(Format.compactTokens(999_500_000) == "1B"
+                   && Format.compactTokens(999_999_999) == "1B"
+                   && Format.compactTokens(999_500) == "1M"
+                   && Format.compactTokens(999_999) == "1M",
+               "FMT-TIER a mantissa that rounds up to 1000 is promoted to the next "
+                   + "unit rather than printed as \"1000M\" / \"1000K\"")
+        expect(Format.compactTokens(999_499_999) == "999M"
+                   && Format.compactTokens(999_499) == "999K"
+                   && Format.compactTokens(1_000_000_000) == "1B"
+                   && Format.compactTokens(1_234_567) == "1.2M"
+                   && Format.compactTokens(12_345) == "12.3K"
+                   && Format.compactTokens(999) == "999",
+               "FMT-TIER every value outside the two half-unit bands renders exactly "
+                   + "as it did before the promotion was added")
         // QH-REASON. "Not enough history" is a false sentence for three of the
         // states that reach the heatmap tooltip's fallback: their history is
         // sufficient and each fails for its own reason.


### PR DESCRIPTION
Fixes the compact-token tier boundary reported in #241, with the source-traced range table confirmed against a build.

## Root cause

`Format.compactTokens` selected its unit from the raw value and only then rounded the scaled mantissa, so a carry out of the mantissa was never reflected in the suffix.

| tokens | before | after |
|---|---|---|
| 999,400,000 | `999M` | `999M` |
| 999,500,000 | `1000M` | `1B` |
| 999,999,999 | `1000M` | `1B` |
| 1,000,000,000 | `1B` | `1B` |
| 999,499 | `999K` | `999K` |
| 999,500 | `1000K` | `1M` |
| 999,999 | `1000K` | `1M` |

The `>= 100` arm is what makes the boundary reachable; below 100 the `"%.1f"` form cannot carry into the next unit.

## Change

The report offered two shapes — re-check the tier after rounding, or move the thresholds to the rounding boundaries. This takes the second: `999_500_000...` selects `B`, `999_500...` selects `M`. It keeps the switch a single pass, and every value outside the two half-unit bands picks exactly the tier it always did.

> The top of the `B` tier has no unit to promote into, so 999.5B still prints `1000B`. Unchanged, and called out in the comment so the asymmetry does not read as an oversight.

The tray title is the surface the report was filed against, but the function is shared, so the same string was reachable from the popover, the daily/monthly/hourly/models/quota views, and the Discord presence band. `DiscordPresence.tokenBand` keeps its own `< 1_000` guard and is unaffected.

## Verification

Two `FMT-TIER` assertions beside the existing `QH-MONEY` format block:

| Assertion | Role |
|---|---|
| 999,500,000 and 999,999,999 to `1B`; 999,500 and 999,999 to `1M` | Old-fail/new-pass |
| 999,499,999 to `999M`; 999,499 to `999K`; 1,000,000,000, 1,234,567, 12,345, 999 unchanged | Non-trigger regression |

Mutation check: restoring the old thresholds fails the first and leaves the second green.

Local gates: `cargo test`, `cargo clippy --workspace --all-targets`, `make build`, `make selftest`, `swift run TokenBar --smoke`.

## Cross-port contract

The report's last question was which side is authoritative. This one is: the C# `TokenBar.Core.Format` is a per-file port of `Sources/TokenBarCore`, and `CompactTokens` carries the same branch structure with the same defect. The shared `crosscheck/fixtures/format.json` also names two cases after the old output — `compact-999999-thousandK` and `compact-999999999-thousandM` — so those names describe a string this side no longer produces.

The mirrored change and the fixture renames therefore belong in the Windows repository, and the two ports disagree on exactly those two cases until that lands. A companion PR is going up there.

Reported by @charlychiu, whose report included the affected range, the root cause, both candidate fixes, the verification shape, and the cross-port implication.

Refs #241
