### PR TITLE
refactor(test): share the credential-refresh crash matrix

### DIFF
--- a/crates/tb_core_ffi/src/agent_account_scope.rs
+++ b/crates/tb_core_ffi/src/agent_account_scope.rs
@@ -1870,6 +1870,156 @@ pub(crate) mod test_support {
             )
         }
     }
+
+    /// Shared refresh-transaction test vocabulary, reused by every provider's
+    /// refresh tests (Codex/Claude in `agent_usage.rs`, `agent_antigravity.rs`,
+    /// `agent_grok.rs`). Consolidated under issue #166 so the checkpoint-crash
+    /// matrix and its terminal/transient failure shapes are defined once instead
+    /// of once per provider.
+    ///
+    /// Injects a terminal "injected crash" failure at a chosen `RefreshCheckpoint`
+    /// and lets every other checkpoint pass through untouched.
+    pub(crate) fn checkpoint_at(
+        target: Option<RefreshCheckpoint>,
+    ) -> impl FnMut(RefreshCheckpoint) -> Result<(), crate::agent_usage::ProviderFetchFailure> {
+        move |checkpoint| {
+            if Some(checkpoint) == target {
+                Err(crate::agent_usage::ProviderFetchFailure::terminal(
+                    "injected crash",
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// A refresh attempt that failed with the marker `checkpoint_at` injects
+    /// must surface as a terminal failure carrying that exact display text,
+    /// never a transient one a caller might retry into a half-applied state.
+    pub(crate) fn assert_injected_crash(failure: &crate::agent_usage::ProviderFetchFailure) {
+        assert!(
+            matches!(
+                failure,
+                crate::agent_usage::ProviderFetchFailure::Terminal { display }
+                    if display == "injected crash"
+            ),
+            "checkpoint crash must surface as a terminal \"injected crash\" failure"
+        );
+    }
+
+    /// A transport failure during the refresh request must carry the binding
+    /// resolved from the lock-reloaded credential, never the caller's outer
+    /// (possibly stale) binding, and must remain transient rather than
+    /// collapsing into a terminal one just because the network call failed.
+    pub(crate) fn assert_transient_used_lock_reloaded_binding(
+        failure: crate::agent_usage::ProviderFetchFailure,
+        expected: crate::agent_usage::ProviderCacheBinding,
+    ) {
+        match failure {
+            crate::agent_usage::ProviderFetchFailure::Transient {
+                attempt_binding, ..
+            } => assert_eq!(attempt_binding, Some(expected)),
+            crate::agent_usage::ProviderFetchFailure::Terminal { .. } => {
+                panic!("timeout must remain transient")
+            }
+        }
+    }
+
+    /// The four-checkpoint durable-state matrix (issue #166 section 5), run
+    /// once per provider through that provider's real refresh transaction.
+    ///
+    /// A failure injected at a given `RefreshCheckpoint` must always surface as
+    /// `assert_injected_crash`, and the durable state left behind must match
+    /// exactly the combination the provider declares through `persisted_at`
+    /// (whether the credential document was durably swapped for the new one)
+    /// and `metadata_changed_at` (whether account-scope lineage metadata was
+    /// durably written) for that checkpoint. Providers legitimately disagree on
+    /// these predicates — Codex persists the credential document before its
+    /// lineage/metadata write, while Claude, Antigravity, and Grok persist
+    /// metadata first — so callers supply the two predicates rather than this
+    /// helper assuming one production ordering.
+    type BoxedRefreshResult<'a> = std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), crate::agent_usage::ProviderFetchFailure>>
+                + 'a,
+        >,
+    >;
+
+    // ponytail: this is a test-only conformance-matrix runner whose whole job is
+    // taking one small callback per provider-specific seam (setup, run, stored-
+    // marker read, two ordering predicates) plus the fixture constants those
+    // callbacks need; splitting it into a builder/struct would be an unrequested
+    // abstraction for a single call site per provider.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn assert_refresh_crash_boundaries<
+        Setup,
+        Run,
+        StoredIsNew,
+        PersistedAt,
+        MetadataChangedAt,
+    >(
+        tag_prefix: &str,
+        semantic_source: &str,
+        old_marker: &[u8],
+        new_marker: &[u8],
+        setup: Setup,
+        run: Run,
+        stored_is_new: StoredIsNew,
+        persisted_at: PersistedAt,
+        metadata_changed_at: MetadataChangedAt,
+    ) where
+        Setup: Fn(&str) -> (TestRefreshScope, PathBuf, AccountScope, Vec<u8>, String),
+        Run: for<'a> Fn(
+            &'a TestRefreshScope,
+            &'a Path,
+            Option<RefreshCheckpoint>,
+        ) -> BoxedRefreshResult<'a>,
+        StoredIsNew: Fn(&Path) -> bool,
+        PersistedAt: Fn(RefreshCheckpoint) -> bool,
+        MetadataChangedAt: Fn(RefreshCheckpoint) -> bool,
+    {
+        for boundary in [
+            RefreshCheckpoint::Reloaded,
+            RefreshCheckpoint::NetworkReturned,
+            RefreshCheckpoint::MetadataHandled,
+            RefreshCheckpoint::CredentialsPersisted,
+        ] {
+            let (scope, path, old_scope, before, location) = setup(&format!("{tag_prefix}-crash"));
+            let failure = run(&scope, &path, Some(boundary)).await.unwrap_err();
+            assert_injected_crash(&failure);
+            assert_eq!(
+                stored_is_new(&path),
+                persisted_at(boundary),
+                "credential persistence at {boundary:?}"
+            );
+            if metadata_changed_at(boundary) {
+                assert_ne!(
+                    scope.metadata_bytes(),
+                    before,
+                    "lineage metadata at {boundary:?}"
+                );
+                assert_eq!(
+                    scope
+                        .resolve_current(semantic_source, &location, old_marker)
+                        .unwrap(),
+                    old_scope
+                );
+                assert_eq!(
+                    scope
+                        .resolve_current(semantic_source, &location, new_marker)
+                        .unwrap(),
+                    old_scope
+                );
+            } else {
+                assert_eq!(
+                    scope.metadata_bytes(),
+                    before,
+                    "lineage metadata at {boundary:?}"
+                );
+            }
+            scope.cleanup();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tb_core_ffi/src/agent_account_scope.rs
+++ b/crates/tb_core_ffi/src/agent_account_scope.rs
@@ -1938,7 +1938,7 @@ pub(crate) mod test_support {
     pub(crate) async fn assert_refresh_crash_boundaries<
         Setup,
         Run,
-        StoredIsNew,
+        StoredMarker,
         PersistedAt,
         MetadataChangedAt,
     >(
@@ -1948,7 +1948,7 @@ pub(crate) mod test_support {
         new_marker: &[u8],
         setup: Setup,
         run: Run,
-        stored_is_new: StoredIsNew,
+        stored_marker: StoredMarker,
         persisted_at: PersistedAt,
         metadata_changed_at: MetadataChangedAt,
     ) where
@@ -1958,7 +1958,7 @@ pub(crate) mod test_support {
             &'a Path,
             Option<RefreshCheckpoint>,
         ) -> BoxedRefreshResult<'a>,
-        StoredIsNew: Fn(&Path) -> bool,
+        StoredMarker: Fn(&Path) -> Vec<u8>,
         PersistedAt: Fn(RefreshCheckpoint) -> bool,
         MetadataChangedAt: Fn(RefreshCheckpoint) -> bool,
     {
@@ -1971,11 +1971,13 @@ pub(crate) mod test_support {
             let (scope, path, old_scope, before, location) = setup(&format!("{tag_prefix}-crash"));
             let failure = run(&scope, &path, Some(boundary)).await.unwrap_err();
             assert_injected_crash(&failure);
-            assert_eq!(
-                stored_is_new(&path),
-                persisted_at(boundary),
-                "credential persistence at {boundary:?}"
-            );
+            let stored = stored_marker(&path);
+            let expected: &[u8] = if persisted_at(boundary) {
+                new_marker
+            } else {
+                old_marker
+            };
+            assert_eq!(stored, expected, "credential persistence at {boundary:?}");
             if metadata_changed_at(boundary) {
                 assert_ne!(
                     scope.metadata_bytes(),

--- a/crates/tb_core_ffi/src/agent_account_scope.rs
+++ b/crates/tb_core_ffi/src/agent_account_scope.rs
@@ -1877,8 +1877,7 @@ pub(crate) mod test_support {
     /// matrix and its terminal/transient failure shapes are defined once instead
     /// of once per provider.
     ///
-    /// Injects a terminal "injected crash" failure at a chosen `RefreshCheckpoint`
-    /// and lets every other checkpoint pass through untouched.
+    /// Injects a terminal "injected crash" failure at one `RefreshCheckpoint`.
     pub(crate) fn checkpoint_at(
         target: Option<RefreshCheckpoint>,
     ) -> impl FnMut(RefreshCheckpoint) -> Result<(), crate::agent_usage::ProviderFetchFailure> {
@@ -1893,9 +1892,7 @@ pub(crate) mod test_support {
         }
     }
 
-    /// A refresh attempt that failed with the marker `checkpoint_at` injects
-    /// must surface as a terminal failure carrying that exact display text,
-    /// never a transient one a caller might retry into a half-applied state.
+    /// `checkpoint_at`'s injected failure must be terminal, not transient.
     pub(crate) fn assert_injected_crash(failure: &crate::agent_usage::ProviderFetchFailure) {
         assert!(
             matches!(
@@ -1907,10 +1904,8 @@ pub(crate) mod test_support {
         );
     }
 
-    /// A transport failure during the refresh request must carry the binding
-    /// resolved from the lock-reloaded credential, never the caller's outer
-    /// (possibly stale) binding, and must remain transient rather than
-    /// collapsing into a terminal one just because the network call failed.
+    /// A transport failure must carry the lock-reloaded binding, not the
+    /// outer one, and must stay transient rather than become terminal.
     pub(crate) fn assert_transient_used_lock_reloaded_binding(
         failure: crate::agent_usage::ProviderFetchFailure,
         expected: crate::agent_usage::ProviderCacheBinding,
@@ -1925,19 +1920,6 @@ pub(crate) mod test_support {
         }
     }
 
-    /// The four-checkpoint durable-state matrix (issue #166 section 5), run
-    /// once per provider through that provider's real refresh transaction.
-    ///
-    /// A failure injected at a given `RefreshCheckpoint` must always surface as
-    /// `assert_injected_crash`, and the durable state left behind must match
-    /// exactly the combination the provider declares through `persisted_at`
-    /// (whether the credential document was durably swapped for the new one)
-    /// and `metadata_changed_at` (whether account-scope lineage metadata was
-    /// durably written) for that checkpoint. Providers legitimately disagree on
-    /// these predicates — Codex persists the credential document before its
-    /// lineage/metadata write, while Claude, Antigravity, and Grok persist
-    /// metadata first — so callers supply the two predicates rather than this
-    /// helper assuming one production ordering.
     type BoxedRefreshResult<'a> = std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<(), crate::agent_usage::ProviderFetchFailure>>
@@ -1945,11 +1927,13 @@ pub(crate) mod test_support {
         >,
     >;
 
-    // ponytail: this is a test-only conformance-matrix runner whose whole job is
-    // taking one small callback per provider-specific seam (setup, run, stored-
-    // marker read, two ordering predicates) plus the fixture constants those
-    // callbacks need; splitting it into a builder/struct would be an unrequested
-    // abstraction for a single call site per provider.
+    /// The four-checkpoint durable-state matrix, run through a provider's real
+    /// refresh transaction. `persisted_at`/`metadata_changed_at` are supplied
+    /// by the caller rather than assumed, because Codex genuinely persists the
+    /// credential document before its metadata write while Claude, Antigravity,
+    /// and Grok persist metadata first.
+    // ponytail: many small callbacks, not a builder/struct, for a single call
+    // site per provider.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn assert_refresh_crash_boundaries<
         Setup,
@@ -2018,6 +2002,43 @@ pub(crate) mod test_support {
                 );
             }
             scope.cleanup();
+        }
+    }
+
+    /// A failed refresh must be terminal (unlike `assert_injected_crash`,
+    /// this doesn't pin the exact display text).
+    pub(crate) fn assert_terminal(failure: &crate::agent_usage::ProviderFetchFailure) {
+        assert!(
+            matches!(
+                failure,
+                crate::agent_usage::ProviderFetchFailure::Terminal { .. }
+            ),
+            "expected a terminal failure, got {failure:?}"
+        );
+    }
+
+    /// A refresh rejected because the durable target changed underneath it
+    /// concurrently must leave the concurrent writer's bytes untouched and
+    /// transfer no lineage metadata. `concurrent_bytes` is `None` for a
+    /// concurrent logout that removed the file; `new_value_needle` must not
+    /// appear anywhere in what's left on disk.
+    pub(crate) fn assert_concurrent_target_untouched(
+        failure: &crate::agent_usage::ProviderFetchFailure,
+        scope: &TestRefreshScope,
+        metadata_before: &[u8],
+        path: &Path,
+        concurrent_bytes: Option<&[u8]>,
+        new_value_needle: &str,
+    ) {
+        assert_terminal(failure);
+        assert_eq!(scope.metadata_bytes(), metadata_before);
+        match concurrent_bytes {
+            Some(expected) => {
+                let stored_bytes = fs::read(path).unwrap();
+                assert_eq!(stored_bytes, expected);
+                assert!(!String::from_utf8_lossy(&stored_bytes).contains(new_value_needle));
+            }
+            None => assert!(!path.exists()),
         }
     }
 }

--- a/crates/tb_core_ffi/src/agent_antigravity.rs
+++ b/crates/tb_core_ffi/src/agent_antigravity.rs
@@ -3101,17 +3101,9 @@ mod tests {
         ));
     }
 
-    fn checkpoint_at(
-        target: Option<RefreshCheckpoint>,
-    ) -> impl FnMut(RefreshCheckpoint) -> Result<(), ProviderFetchFailure> {
-        move |checkpoint| {
-            if Some(checkpoint) == target {
-                Err(ProviderFetchFailure::terminal("injected crash"))
-            } else {
-                Ok(())
-            }
-        }
-    }
+    use crate::agent_account_scope::test_support::{
+        assert_refresh_crash_boundaries, assert_transient_used_lock_reloaded_binding, checkpoint_at,
+    };
 
     async fn test_refresh_response(
         refresh_token: String,
@@ -3362,58 +3354,25 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_crash_boundaries_and_scope_gate_use_production_sequence() {
-        for boundary in [
-            RefreshCheckpoint::Reloaded,
-            RefreshCheckpoint::NetworkReturned,
-            RefreshCheckpoint::MetadataHandled,
-            RefreshCheckpoint::CredentialsPersisted,
-        ] {
-            let (scope, path, old_scope, before, location) = setup_refresh("antigravity-crash");
-            let failure = run_refresh(&scope, &path, Some(boundary))
-                .await
-                .unwrap_err();
-            assert!(matches!(
-                failure,
-                ProviderFetchFailure::Terminal { ref display } if display == "injected crash"
-            ));
-            assert_eq!(
-                stored_refresh_token(&path),
-                if boundary == RefreshCheckpoint::CredentialsPersisted {
-                    "antigravity-new-refresh"
-                } else {
-                    "antigravity-old-refresh"
-                }
-            );
-            if matches!(
-                boundary,
-                RefreshCheckpoint::Reloaded | RefreshCheckpoint::NetworkReturned
-            ) {
-                assert_eq!(scope.metadata_bytes(), before);
-            } else {
-                assert_ne!(scope.metadata_bytes(), before);
-                assert_eq!(
-                    scope
-                        .resolve_current(
-                            "google-oauth-creds",
-                            &location,
-                            b"antigravity-old-refresh",
-                        )
-                        .unwrap(),
-                    old_scope
-                );
-                assert_eq!(
-                    scope
-                        .resolve_current(
-                            "google-oauth-creds",
-                            &location,
-                            b"antigravity-new-refresh",
-                        )
-                        .unwrap(),
-                    old_scope
-                );
-            }
-            scope.cleanup();
-        }
+        assert_refresh_crash_boundaries(
+            "antigravity",
+            "google-oauth-creds",
+            b"antigravity-old-refresh",
+            b"antigravity-new-refresh",
+            setup_refresh,
+            |scope, path, crash| {
+                Box::pin(async move { run_refresh(scope, path, crash).await.map(|_| ()) })
+            },
+            |path| stored_refresh_token(path) == "antigravity-new-refresh",
+            |boundary| boundary == RefreshCheckpoint::CredentialsPersisted,
+            |boundary| {
+                matches!(
+                    boundary,
+                    RefreshCheckpoint::MetadataHandled | RefreshCheckpoint::CredentialsPersisted
+                )
+            },
+        )
+        .await;
 
         let (scope, path, old_scope, before, location) = setup_refresh("antigravity-metadata-fail");
         scope.fail_metadata_save();
@@ -3506,12 +3465,7 @@ mod tests {
         .await
         .unwrap_err();
 
-        match failure {
-            ProviderFetchFailure::Transient {
-                attempt_binding, ..
-            } => assert_eq!(attempt_binding, Some(expected)),
-            ProviderFetchFailure::Terminal { .. } => panic!("timeout must remain transient"),
-        }
+        assert_transient_used_lock_reloaded_binding(failure, expected);
         scope.cleanup();
     }
 }

--- a/crates/tb_core_ffi/src/agent_antigravity.rs
+++ b/crates/tb_core_ffi/src/agent_antigravity.rs
@@ -3102,7 +3102,8 @@ mod tests {
     }
 
     use crate::agent_account_scope::test_support::{
-        assert_refresh_crash_boundaries, assert_transient_used_lock_reloaded_binding, checkpoint_at,
+        assert_concurrent_target_untouched, assert_refresh_crash_boundaries,
+        assert_transient_used_lock_reloaded_binding, checkpoint_at,
     };
 
     async fn test_refresh_response(
@@ -3202,16 +3203,19 @@ mod tests {
         .await
         .unwrap_err();
 
-        assert!(matches!(failure, ProviderFetchFailure::Terminal { .. }));
-        let stored_bytes = std::fs::read(&path).unwrap();
-        assert_eq!(stored_bytes, B_BYTES);
-        assert!(!String::from_utf8_lossy(&stored_bytes).contains("antigravity-new"));
+        assert_concurrent_target_untouched(
+            &failure,
+            &scope,
+            &before,
+            &path,
+            Some(B_BYTES),
+            "antigravity-new",
+        );
         let stored = load_remote_credentials(&path).unwrap();
         assert_eq!(stored["access_token"], "account-b-access");
         assert_eq!(stored["refresh_token"], "account-b-refresh");
         assert_eq!(stored["id_token"], "account-b-id");
         assert_eq!(stored["sibling"]["writer"], "b");
-        assert_eq!(scope.metadata_bytes(), before);
         scope.cleanup();
     }
 
@@ -3339,15 +3343,14 @@ mod tests {
             .await
             .unwrap_err();
 
-            assert!(matches!(failure, ProviderFetchFailure::Terminal { .. }));
-            assert_eq!(scope.metadata_bytes(), before);
-            if let Some(expected) = current_bytes {
-                let stored = std::fs::read(&path).unwrap();
-                assert_eq!(stored, expected);
-                assert!(!String::from_utf8_lossy(&stored).contains("antigravity-new"));
-            } else {
-                assert!(!path.exists());
-            }
+            assert_concurrent_target_untouched(
+                &failure,
+                &scope,
+                &before,
+                &path,
+                current_bytes,
+                "antigravity-new",
+            );
             scope.cleanup();
         }
     }

--- a/crates/tb_core_ffi/src/agent_antigravity.rs
+++ b/crates/tb_core_ffi/src/agent_antigravity.rs
@@ -3366,7 +3366,7 @@ mod tests {
             |scope, path, crash| {
                 Box::pin(async move { run_refresh(scope, path, crash).await.map(|_| ()) })
             },
-            |path| stored_refresh_token(path) == "antigravity-new-refresh",
+            |path| stored_refresh_token(path).into_bytes(),
             |boundary| boundary == RefreshCheckpoint::CredentialsPersisted,
             |boundary| {
                 matches!(

--- a/crates/tb_core_ffi/src/agent_grok.rs
+++ b/crates/tb_core_ffi/src/agent_grok.rs
@@ -2164,17 +2164,9 @@ mod tests {
         ));
     }
 
-    fn checkpoint_at(
-        target: Option<RefreshCheckpoint>,
-    ) -> impl FnMut(RefreshCheckpoint) -> Result<(), ProviderFetchFailure> {
-        move |checkpoint| {
-            if Some(checkpoint) == target {
-                Err(ProviderFetchFailure::terminal("injected crash"))
-            } else {
-                Ok(())
-            }
-        }
-    }
+    use crate::agent_account_scope::test_support::{
+        assert_refresh_crash_boundaries, assert_transient_used_lock_reloaded_binding, checkpoint_at,
+    };
 
     #[tokio::test]
     async fn whitespace_refresh_evidence_never_binds_across_access_tokens() {
@@ -2738,50 +2730,25 @@ mod tests {
 
     #[tokio::test]
     async fn refresh_crash_boundaries_and_scope_gate_use_production_sequence() {
-        for boundary in [
-            RefreshCheckpoint::Reloaded,
-            RefreshCheckpoint::NetworkReturned,
-            RefreshCheckpoint::MetadataHandled,
-            RefreshCheckpoint::CredentialsPersisted,
-        ] {
-            let (scope, path, old_scope, before, location) = setup_refresh("grok-crash");
-            let failure = run_refresh(&scope, &path, Some(boundary))
-                .await
-                .unwrap_err();
-            assert!(matches!(
-                failure,
-                ProviderFetchFailure::Terminal { ref display } if display == "injected crash"
-            ));
-            assert_eq!(
-                stored_refresh_token(&path),
-                if boundary == RefreshCheckpoint::CredentialsPersisted {
-                    "grok-new-refresh"
-                } else {
-                    "grok-old-refresh"
-                }
-            );
-            if matches!(
-                boundary,
-                RefreshCheckpoint::Reloaded | RefreshCheckpoint::NetworkReturned
-            ) {
-                assert_eq!(scope.metadata_bytes(), before);
-            } else {
-                assert_ne!(scope.metadata_bytes(), before);
-                assert_eq!(
-                    scope
-                        .resolve_current("grok-auth-json", &location, b"grok-old-refresh")
-                        .unwrap(),
-                    old_scope
-                );
-                assert_eq!(
-                    scope
-                        .resolve_current("grok-auth-json", &location, b"grok-new-refresh")
-                        .unwrap(),
-                    old_scope
-                );
-            }
-            scope.cleanup();
-        }
+        assert_refresh_crash_boundaries(
+            "grok",
+            "grok-auth-json",
+            b"grok-old-refresh",
+            b"grok-new-refresh",
+            setup_refresh,
+            |scope, path, crash| {
+                Box::pin(async move { run_refresh(scope, path, crash).await.map(|_| ()) })
+            },
+            |path| stored_refresh_token(path) == "grok-new-refresh",
+            |boundary| boundary == RefreshCheckpoint::CredentialsPersisted,
+            |boundary| {
+                matches!(
+                    boundary,
+                    RefreshCheckpoint::MetadataHandled | RefreshCheckpoint::CredentialsPersisted
+                )
+            },
+        )
+        .await;
 
         let (scope, path, old_scope, before, location) = setup_refresh("grok-metadata-fail");
         scope.fail_metadata_save();
@@ -2880,12 +2847,7 @@ mod tests {
         .await
         .unwrap_err();
 
-        match failure {
-            ProviderFetchFailure::Transient {
-                attempt_binding, ..
-            } => assert_eq!(attempt_binding, Some(expected)),
-            ProviderFetchFailure::Terminal { .. } => panic!("timeout must remain transient"),
-        }
+        assert_transient_used_lock_reloaded_binding(failure, expected);
         scope.cleanup();
     }
 }

--- a/crates/tb_core_ffi/src/agent_grok.rs
+++ b/crates/tb_core_ffi/src/agent_grok.rs
@@ -2739,7 +2739,7 @@ mod tests {
             |scope, path, crash| {
                 Box::pin(async move { run_refresh(scope, path, crash).await.map(|_| ()) })
             },
-            |path| stored_refresh_token(path) == "grok-new-refresh",
+            |path| stored_refresh_token(path).into_bytes(),
             |boundary| boundary == RefreshCheckpoint::CredentialsPersisted,
             |boundary| {
                 matches!(

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -1779,9 +1779,7 @@ async fn fetch_claude_accounts() -> Vec<AgentUsageSnapshot> {
 /// work is entirely network wait.
 const MAX_ACCOUNT_FETCHES_IN_FLIGHT: usize = 4;
 
-async fn join_local_ordered<T: 'static>(
-    futures: Vec<Pin<Box<dyn Future<Output = T>>>>,
-) -> Vec<T> {
+async fn join_local_ordered<T: 'static>(futures: Vec<Pin<Box<dyn Future<Output = T>>>>) -> Vec<T> {
     tokio::task::LocalSet::new()
         .run_until(async move {
             let mut slots: Vec<Option<T>> = (0..futures.len()).map(|_| None).collect();
@@ -1790,11 +1788,15 @@ async fn join_local_ordered<T: 'static>(
             let mut queued = 0usize;
             loop {
                 while queued < MAX_ACCOUNT_FETCHES_IN_FLIGHT {
-                    let Some((index, future)) = pending.next() else { break };
+                    let Some((index, future)) = pending.next() else {
+                        break;
+                    };
                     tasks.spawn_local(async move { (index, future.await) });
                     queued += 1;
                 }
-                let Some(joined) = tasks.join_next().await else { break };
+                let Some(joined) = tasks.join_next().await else {
+                    break;
+                };
                 queued -= 1;
                 // A panicking fetch drops that one result rather than taking
                 // the whole publication down. Every real provider failure
@@ -2193,12 +2195,12 @@ where
             history_scope: claude_history_scope_with(None, resolve),
         };
     };
-    let history_scope = if credentials.scope_slot.semantic_source == CLAUDE_CONFIG_DIR_KEYCHAIN_SOURCE
-    {
-        claude_history_scope_with(Some(dir), resolve)
-    } else {
-        Err(AccountScopeError::NoTrustedEvidence)
-    };
+    let history_scope =
+        if credentials.scope_slot.semantic_source == CLAUDE_CONFIG_DIR_KEYCHAIN_SOURCE {
+            claude_history_scope_with(Some(dir), resolve)
+        } else {
+            Err(AccountScopeError::NoTrustedEvidence)
+        };
     ClaudeAccountIdentity {
         account_key: Some(dir.to_string()),
         history_scope,
@@ -3892,10 +3894,11 @@ fn reload_claude_credentials(original: &ClaudeCredentials) -> Result<ClaudeCrede
             let account = claude_keychain_account().ok_or_else(|| {
                 "Claude Keychain account could not be captured during refresh.".to_string()
             })?;
-            let raw =
-                load_claude_credentials_from_keychain_item(CLAUDE_KEYCHAIN_SERVICE, Some(&account))?.ok_or_else(|| {
-                    "Claude Keychain credentials disappeared during refresh.".to_string()
-                })?;
+            let raw = load_claude_credentials_from_keychain_item(
+                CLAUDE_KEYCHAIN_SERVICE,
+                Some(&account),
+            )?
+            .ok_or_else(|| "Claude Keychain credentials disappeared during refresh.".to_string())?;
             let mut credentials =
                 parse_claude_credentials_data(&raw, ClaudeCredentialSource::Keychain)?;
             credentials.keychain_account = Some(account);
@@ -4204,8 +4207,11 @@ fn validate_claude_keychain_target(
         credentials,
         || Ok(claude_keychain_account()),
         |captured_account| {
-            load_claude_credentials_from_keychain_item(CLAUDE_KEYCHAIN_SERVICE, Some(captured_account))
-                .map_err(|_| ())
+            load_claude_credentials_from_keychain_item(
+                CLAUDE_KEYCHAIN_SERVICE,
+                Some(captured_account),
+            )
+            .map_err(|_| ())
         },
     )
     .map(|_| ())
@@ -4234,8 +4240,11 @@ fn save_claude_credentials_to_keychain(
         credentials,
         || Ok(claude_keychain_account()),
         |captured_account| {
-            load_claude_credentials_from_keychain_item(CLAUDE_KEYCHAIN_SERVICE, Some(captured_account))
-                .map_err(|_| ())
+            load_claude_credentials_from_keychain_item(
+                CLAUDE_KEYCHAIN_SERVICE,
+                Some(captured_account),
+            )
+            .map_err(|_| ())
         },
     )?;
 
@@ -5500,10 +5509,7 @@ mod tests {
                     peak.set(peak.get().max(live.get()));
                     // Later entries finish FIRST, so input order and completion
                     // order disagree for every pair.
-                    tokio::time::sleep(Duration::from_millis(
-                        ((total - index) * 10) as u64,
-                    ))
-                    .await;
+                    tokio::time::sleep(Duration::from_millis(((total - index) * 10) as u64)).await;
                     live.set(live.get() - 1);
                     index
                 }));
@@ -5980,16 +5986,21 @@ mod tests {
 
         assert_eq!(
             payload.quota_curve_series(),
-            ["session.v1", "weekly.v1", "sonnet.weekly.v1", "weekly_scoped.fable.v1"]
-                .map(|window_key| (
-                    None,
-                    SeriesKey::new(
-                        "claude",
-                        &HistoryScope::for_test(trusted.as_str()),
-                        window_key
-                    )
-                ))
-                .to_vec()
+            [
+                "session.v1",
+                "weekly.v1",
+                "sonnet.weekly.v1",
+                "weekly_scoped.fable.v1"
+            ]
+            .map(|window_key| (
+                None,
+                SeriesKey::new(
+                    "claude",
+                    &HistoryScope::for_test(trusted.as_str()),
+                    window_key
+                )
+            ))
+            .to_vec()
         );
         scope.cleanup();
     }
@@ -6388,15 +6399,24 @@ mod tests {
             },
             Err(failure) => ProviderFetchOutcome::Failure(failure),
         };
-        let snapshot =
-            apply_provider_outcome_with(&cache, "copilot", None, "oauth", response_at, outcome, |_| {})
-                .unwrap();
+        let snapshot = apply_provider_outcome_with(
+            &cache,
+            "copilot",
+            None,
+            "oauth",
+            response_at,
+            outcome,
+            |_| {},
+        )
+        .unwrap();
 
         assert!(snapshot.error.is_none());
         assert_eq!(snapshot.windows.len(), 1);
         assert!((snapshot.windows[0].remaining_percent - 60.0).abs() < 0.01);
         assert!(snapshot.windows[0].resets_at.is_none());
-        let cached = lock_last_good(&cache).entries[&account_slot("copilot", None)].snapshot.clone();
+        let cached = lock_last_good(&cache).entries[&account_slot("copilot", None)]
+            .snapshot
+            .clone();
         assert_eq!(cached.updated_at, snapshot.updated_at);
         assert_eq!(cached.windows.len(), 1);
         assert!(cached.error.is_none());
@@ -6599,7 +6619,9 @@ mod tests {
             )
             .unwrap();
             assert!(result.windows.is_empty());
-            assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("codex", None)));
+            assert!(!lock_last_good(&cache)
+                .entries
+                .contains_key(&account_slot("codex", None)));
         }
 
         let cache = Mutex::new(ProviderLastGoodCache::default());
@@ -6625,7 +6647,9 @@ mod tests {
             |_| panic!("absent must not enrich"),
         )
         .is_none());
-        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("codex", None)));
+        assert!(!lock_last_good(&cache)
+            .entries
+            .contains_key(&account_slot("codex", None)));
         scope.cleanup();
     }
 
@@ -6669,7 +6693,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(anonymous.windows.len(), 1);
-        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("antigravity", None)));
+        assert!(!lock_last_good(&cache)
+            .entries
+            .contains_key(&account_slot("antigravity", None)));
 
         apply_provider_outcome_with(
             &cache,
@@ -6699,7 +6725,9 @@ mod tests {
         )
         .unwrap();
         assert!(live_empty.windows.is_empty());
-        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("antigravity", None)));
+        assert!(!lock_last_good(&cache)
+            .entries
+            .contains_key(&account_slot("antigravity", None)));
 
         apply_provider_outcome_with(
             &cache,
@@ -6733,7 +6761,9 @@ mod tests {
         .unwrap();
         assert!(invalid.windows.is_empty());
         assert_eq!(enrich_calls.get(), 0);
-        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("antigravity", None)));
+        assert!(!lock_last_good(&cache)
+            .entries
+            .contains_key(&account_slot("antigravity", None)));
         scope.cleanup();
     }
 
@@ -9116,17 +9146,9 @@ mod tests {
         }
     }
 
-    fn checkpoint_at(
-        target: Option<RefreshCheckpoint>,
-    ) -> impl FnMut(RefreshCheckpoint) -> Result<(), ProviderFetchFailure> {
-        move |checkpoint| {
-            if Some(checkpoint) == target {
-                Err(ProviderFetchFailure::terminal("injected crash"))
-            } else {
-                Ok(())
-            }
-        }
-    }
+    use crate::agent_account_scope::test_support::{
+        assert_refresh_crash_boundaries, assert_transient_used_lock_reloaded_binding, checkpoint_at,
+    };
 
     async fn codex_test_response(
         refresh_token: String,
@@ -9494,53 +9516,35 @@ mod tests {
     #[tokio::test]
     async fn codex_refresh_crash_boundaries_and_scope_gate_use_production_sequence() {
         // These checkpoints model process stops, not a cross-resource transaction:
-        // after credential persistence, metadata may still be the pre-refresh bytes.
-        for boundary in [
-            RefreshCheckpoint::Reloaded,
-            RefreshCheckpoint::NetworkReturned,
-            RefreshCheckpoint::CredentialsPersisted,
-            RefreshCheckpoint::MetadataHandled,
-        ] {
-            let (scope, path, old_scope, before, location) = setup_codex_refresh("codex-crash");
-            let failure = run_codex_refresh(&scope, &path, Some(boundary))
-                .await
-                .unwrap_err();
-            assert!(matches!(
-                failure,
-                ProviderFetchFailure::Terminal { ref display } if display == "injected crash"
-            ));
-            let credentials_persisted = matches!(
-                boundary,
-                RefreshCheckpoint::CredentialsPersisted | RefreshCheckpoint::MetadataHandled
-            );
-            let stored = load_codex_credentials_from(&path).unwrap();
-            assert_eq!(
-                stored.refresh_token.as_deref(),
-                Some(if credentials_persisted {
-                    "codex-new-refresh"
-                } else {
-                    "codex-old-refresh"
-                })
-            );
-            if boundary == RefreshCheckpoint::MetadataHandled {
-                assert_ne!(scope.metadata_bytes(), before);
-                assert_eq!(
-                    scope
-                        .resolve_current("codex-auth-json", &location, b"codex-old-refresh")
-                        .unwrap(),
-                    old_scope
-                );
-                assert_eq!(
-                    scope
-                        .resolve_current("codex-auth-json", &location, b"codex-new-refresh")
-                        .unwrap(),
-                    old_scope
-                );
-            } else {
-                assert_eq!(scope.metadata_bytes(), before);
-            }
-            scope.cleanup();
-        }
+        // Codex persists the credential document before its metadata/lineage
+        // write, the opposite order from Claude/Antigravity/Grok, so only
+        // `MetadataHandled` — not `CredentialsPersisted` — has durably written
+        // lineage metadata.
+        assert_refresh_crash_boundaries(
+            "codex",
+            "codex-auth-json",
+            b"codex-old-refresh",
+            b"codex-new-refresh",
+            setup_codex_refresh,
+            |scope, path, crash| {
+                Box::pin(async move { run_codex_refresh(scope, path, crash).await.map(|_| ()) })
+            },
+            |path| {
+                load_codex_credentials_from(path)
+                    .unwrap()
+                    .refresh_token
+                    .as_deref()
+                    == Some("codex-new-refresh")
+            },
+            |boundary| {
+                matches!(
+                    boundary,
+                    RefreshCheckpoint::CredentialsPersisted | RefreshCheckpoint::MetadataHandled
+                )
+            },
+            |boundary| boundary == RefreshCheckpoint::MetadataHandled,
+        )
+        .await;
 
         let (scope, path, old_scope, before, location) = setup_codex_refresh("codex-metadata-fail");
         let auth_before = fs::read(&path).unwrap();
@@ -9670,12 +9674,7 @@ mod tests {
         .await
         .unwrap_err();
 
-        match failure {
-            ProviderFetchFailure::Transient {
-                attempt_binding, ..
-            } => assert_eq!(attempt_binding, Some(expected)),
-            ProviderFetchFailure::Terminal { .. } => panic!("timeout must remain transient"),
-        }
+        assert_transient_used_lock_reloaded_binding(failure, expected);
         scope.cleanup();
     }
 
@@ -10552,51 +10551,43 @@ mod tests {
 
     #[tokio::test]
     async fn claude_refresh_crash_boundaries_and_scope_gate_use_production_sequence() {
-        for boundary in [
-            RefreshCheckpoint::Reloaded,
-            RefreshCheckpoint::NetworkReturned,
-            RefreshCheckpoint::MetadataHandled,
-            RefreshCheckpoint::CredentialsPersisted,
-        ] {
-            let (scope, path, original, old_scope, before, location) =
-                setup_claude_refresh("claude-crash");
-            let failure = run_claude_refresh(&scope, &path, &original, Some(boundary))
-                .await
-                .unwrap_err();
-            assert!(matches!(
-                failure,
-                ProviderFetchFailure::Terminal { ref display } if display == "injected crash"
-            ));
-            assert_eq!(
-                stored_claude_refresh_token(&path).as_deref(),
-                Some(if boundary == RefreshCheckpoint::CredentialsPersisted {
-                    "claude-new-refresh"
-                } else {
-                    "claude-old-refresh"
+        // `setup_claude_refresh` also returns the `ClaudeCredentials` template
+        // `run_claude_refresh` needs to reload against; the shared crash-boundary
+        // runner's setup/run split doesn't carry that extra value, so stash it in
+        // a cell shared between the two closures for each fresh iteration.
+        let original_slot: std::rc::Rc<std::cell::RefCell<Option<ClaudeCredentials>>> =
+            std::rc::Rc::new(std::cell::RefCell::new(None));
+        let setup_slot = std::rc::Rc::clone(&original_slot);
+        let run_slot = std::rc::Rc::clone(&original_slot);
+        assert_refresh_crash_boundaries(
+            "claude",
+            "claude-login-file",
+            b"claude-old-refresh",
+            b"claude-new-refresh",
+            move |tag| {
+                let (scope, path, original, old_scope, metadata, location) =
+                    setup_claude_refresh(tag);
+                *setup_slot.borrow_mut() = Some(original);
+                (scope, path, old_scope, metadata, location)
+            },
+            move |scope, path, crash| {
+                let original = run_slot.borrow().clone().unwrap();
+                Box::pin(async move {
+                    run_claude_refresh(scope, path, &original, crash)
+                        .await
+                        .map(|_| ())
                 })
-            );
-            if matches!(
-                boundary,
-                RefreshCheckpoint::Reloaded | RefreshCheckpoint::NetworkReturned
-            ) {
-                assert_eq!(scope.metadata_bytes(), before);
-            } else {
-                assert_ne!(scope.metadata_bytes(), before);
-                assert_eq!(
-                    scope
-                        .resolve_current("claude-login-file", &location, b"claude-old-refresh")
-                        .unwrap(),
-                    old_scope
-                );
-                assert_eq!(
-                    scope
-                        .resolve_current("claude-login-file", &location, b"claude-new-refresh")
-                        .unwrap(),
-                    old_scope
-                );
-            }
-            scope.cleanup();
-        }
+            },
+            |path| stored_claude_refresh_token(path).as_deref() == Some("claude-new-refresh"),
+            |boundary| boundary == RefreshCheckpoint::CredentialsPersisted,
+            |boundary| {
+                matches!(
+                    boundary,
+                    RefreshCheckpoint::MetadataHandled | RefreshCheckpoint::CredentialsPersisted
+                )
+            },
+        )
+        .await;
 
         let (scope, path, original, old_scope, before, location) =
             setup_claude_refresh("claude-metadata-fail");
@@ -10719,12 +10710,7 @@ mod tests {
         .await
         .unwrap_err();
 
-        match failure {
-            ProviderFetchFailure::Transient {
-                attempt_binding, ..
-            } => assert_eq!(attempt_binding, Some(expected)),
-            ProviderFetchFailure::Terminal { .. } => panic!("timeout must remain transient"),
-        }
+        assert_transient_used_lock_reloaded_binding(failure, expected);
         scope.cleanup();
     }
 
@@ -11674,10 +11660,14 @@ mod tests {
         // Clearing one account must not evict the other.
         lock_last_good(&cache).clear(&second);
         assert!(
-            lock_last_good(&cache).clean_for(&primary, &binding).is_some(),
+            lock_last_good(&cache)
+                .clean_for(&primary, &binding)
+                .is_some(),
             "clearing the second account evicted the primary"
         );
-        assert!(lock_last_good(&cache).clean_for(&second, &binding).is_none());
+        assert!(lock_last_good(&cache)
+            .clean_for(&second, &binding)
+            .is_none());
         scope.cleanup();
     }
 
@@ -11799,7 +11789,9 @@ mod tests {
             .as_array()
             .unwrap()
             .iter()
-            .filter(|entry| entry["providerId"] == "claude" && entry["accountScope"] == account_scope)
+            .filter(|entry| {
+                entry["providerId"] == "claude" && entry["accountScope"] == account_scope
+            })
             .cloned()
             .collect()
     }
@@ -11819,15 +11811,17 @@ mod tests {
             scope.resolve_history(provider, authoritative)
         };
 
-        let primary =
-            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let extra = claude_account_identity_with(
             Some(G_TEST_CONFIG_DIR),
             &claude_config_dir_test_credentials(G_TEST_CONFIG_DIR),
             resolve,
         );
 
-        assert_eq!(primary.account_key, None, "the primary publishes no accountKey");
+        assert_eq!(
+            primary.account_key, None,
+            "the primary publishes no accountKey"
+        );
         assert_eq!(extra.account_key.as_deref(), Some(G_TEST_CONFIG_DIR));
 
         let primary_scope = primary
@@ -11868,8 +11862,7 @@ mod tests {
             .resolve_current("fixture", "g3-account", b"g3-marker")
             .unwrap();
 
-        let primary =
-            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let extra = claude_account_identity_with(
             Some(G_TEST_CONFIG_DIR),
             &claude_config_dir_test_credentials(G_TEST_CONFIG_DIR),
@@ -11889,7 +11882,8 @@ mod tests {
                 &history_path,
             )
         });
-        let after_primary: Value = serde_json::from_slice(&fs::read(&history_path).unwrap()).unwrap();
+        let after_primary: Value =
+            serde_json::from_slice(&fs::read(&history_path).unwrap()).unwrap();
         let primary_series_before = claude_series_for(&after_primary, &primary_scope);
         assert_eq!(
             primary_series_before.len(),
@@ -11899,14 +11893,18 @@ mod tests {
 
         let mut extra_snapshot =
             claude_identity_test_snapshot(&extra, account_scope.clone(), 77.0, now + 600);
-        enrich_snapshot_with(&mut extra_snapshot, now + 600, |active, observations, at| {
-            crate::agent_quota_history::record_observations_at_path_and_evaluate(
-                active,
-                observations,
-                at,
-                &history_path,
-            )
-        });
+        enrich_snapshot_with(
+            &mut extra_snapshot,
+            now + 600,
+            |active, observations, at| {
+                crate::agent_quota_history::record_observations_at_path_and_evaluate(
+                    active,
+                    observations,
+                    at,
+                    &history_path,
+                )
+            },
+        );
         let after_extra: Value = serde_json::from_slice(&fs::read(&history_path).unwrap()).unwrap();
 
         assert_eq!(
@@ -11952,8 +11950,7 @@ mod tests {
             .unwrap();
 
         let now = 1_800_000_000_i64;
-        let primary =
-            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let mut primary_snapshot =
             claude_identity_test_snapshot(&primary, account_scope.clone(), 20.0, now);
         enrich_snapshot_with(&mut primary_snapshot, now, |active, observations, at| {
@@ -11984,15 +11981,19 @@ mod tests {
         let writes = std::cell::Cell::new(0);
         let mut extra_snapshot =
             claude_identity_test_snapshot(&extra, account_scope, 77.0, now + 600);
-        enrich_snapshot_with(&mut extra_snapshot, now + 600, |active, observations, at| {
-            writes.set(writes.get() + 1);
-            crate::agent_quota_history::record_observations_at_path_and_evaluate(
-                active,
-                observations,
-                at,
-                &history_path,
-            )
-        });
+        enrich_snapshot_with(
+            &mut extra_snapshot,
+            now + 600,
+            |active, observations, at| {
+                writes.set(writes.get() + 1);
+                crate::agent_quota_history::record_observations_at_path_and_evaluate(
+                    active,
+                    observations,
+                    at,
+                    &history_path,
+                )
+            },
+        );
         assert_eq!(writes.get(), 0, "it opened a history transaction anyway");
         assert_eq!(
             fs::read(&history_path).unwrap(),
@@ -12028,8 +12029,7 @@ mod tests {
             .unwrap();
 
         let now = 1_800_000_000_i64;
-        let primary =
-            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let mut primary_snapshot =
             claude_identity_test_snapshot(&primary, account_scope.clone(), 20.0, now);
         enrich_snapshot_with(&mut primary_snapshot, now, |active, observations, at| {
@@ -12078,7 +12078,11 @@ mod tests {
                     &history_path,
                 )
             });
-            assert_eq!(writes.get(), 0, "{semantic_source} opened a history transaction");
+            assert_eq!(
+                writes.get(),
+                0,
+                "{semantic_source} opened a history transaction"
+            );
         }
 
         assert_eq!(
@@ -12112,11 +12116,22 @@ mod tests {
         let reads = std::cell::Cell::new(0);
         let loaded = load_claude_config_dir_credentials_with(G_TEST_CONFIG_DIR, |dir| {
             reads.set(reads.get() + 1);
-            assert_eq!(dir, Some(G_TEST_CONFIG_DIR), "it read another account's item");
+            assert_eq!(
+                dir,
+                Some(G_TEST_CONFIG_DIR),
+                "it read another account's item"
+            );
             Ok(None)
         });
-        assert!(loaded.is_err(), "a missing item must not fall back to the primary's credential");
-        assert_eq!(reads.get(), 1, "one configured account costs exactly one read");
+        assert!(
+            loaded.is_err(),
+            "a missing item must not fall back to the primary's credential"
+        );
+        assert_eq!(
+            reads.get(),
+            1,
+            "one configured account costs exactly one read"
+        );
         // ...and there are no configured directories until the setter is called.
         assert!(crate::claude_config_dirs::snapshot().is_empty());
 
@@ -12233,14 +12248,18 @@ mod tests {
             recovered.account_key, None,
             "the recovered card is not the primary's"
         );
-        assert!(recovered.error.is_some(), "a failed round must still report the failure");
+        assert!(
+            recovered.error.is_some(),
+            "a failed round must still report the failure"
+        );
 
         // The extra account kept its own entry through all three rounds.
-        assert!(
-            lock_last_good(&cache)
-                .clean_for(&account_slot("claude", Some(G_TEST_CONFIG_DIR)), &extra_binding)
-                .is_some()
-        );
+        assert!(lock_last_good(&cache)
+            .clean_for(
+                &account_slot("claude", Some(G_TEST_CONFIG_DIR)),
+                &extra_binding
+            )
+            .is_some());
         scope.cleanup();
     }
 

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -1779,7 +1779,9 @@ async fn fetch_claude_accounts() -> Vec<AgentUsageSnapshot> {
 /// work is entirely network wait.
 const MAX_ACCOUNT_FETCHES_IN_FLIGHT: usize = 4;
 
-async fn join_local_ordered<T: 'static>(futures: Vec<Pin<Box<dyn Future<Output = T>>>>) -> Vec<T> {
+async fn join_local_ordered<T: 'static>(
+    futures: Vec<Pin<Box<dyn Future<Output = T>>>>,
+) -> Vec<T> {
     tokio::task::LocalSet::new()
         .run_until(async move {
             let mut slots: Vec<Option<T>> = (0..futures.len()).map(|_| None).collect();
@@ -1788,15 +1790,11 @@ async fn join_local_ordered<T: 'static>(futures: Vec<Pin<Box<dyn Future<Output =
             let mut queued = 0usize;
             loop {
                 while queued < MAX_ACCOUNT_FETCHES_IN_FLIGHT {
-                    let Some((index, future)) = pending.next() else {
-                        break;
-                    };
+                    let Some((index, future)) = pending.next() else { break };
                     tasks.spawn_local(async move { (index, future.await) });
                     queued += 1;
                 }
-                let Some(joined) = tasks.join_next().await else {
-                    break;
-                };
+                let Some(joined) = tasks.join_next().await else { break };
                 queued -= 1;
                 // A panicking fetch drops that one result rather than taking
                 // the whole publication down. Every real provider failure
@@ -2195,12 +2193,12 @@ where
             history_scope: claude_history_scope_with(None, resolve),
         };
     };
-    let history_scope =
-        if credentials.scope_slot.semantic_source == CLAUDE_CONFIG_DIR_KEYCHAIN_SOURCE {
-            claude_history_scope_with(Some(dir), resolve)
-        } else {
-            Err(AccountScopeError::NoTrustedEvidence)
-        };
+    let history_scope = if credentials.scope_slot.semantic_source == CLAUDE_CONFIG_DIR_KEYCHAIN_SOURCE
+    {
+        claude_history_scope_with(Some(dir), resolve)
+    } else {
+        Err(AccountScopeError::NoTrustedEvidence)
+    };
     ClaudeAccountIdentity {
         account_key: Some(dir.to_string()),
         history_scope,
@@ -3894,11 +3892,10 @@ fn reload_claude_credentials(original: &ClaudeCredentials) -> Result<ClaudeCrede
             let account = claude_keychain_account().ok_or_else(|| {
                 "Claude Keychain account could not be captured during refresh.".to_string()
             })?;
-            let raw = load_claude_credentials_from_keychain_item(
-                CLAUDE_KEYCHAIN_SERVICE,
-                Some(&account),
-            )?
-            .ok_or_else(|| "Claude Keychain credentials disappeared during refresh.".to_string())?;
+            let raw =
+                load_claude_credentials_from_keychain_item(CLAUDE_KEYCHAIN_SERVICE, Some(&account))?.ok_or_else(|| {
+                    "Claude Keychain credentials disappeared during refresh.".to_string()
+                })?;
             let mut credentials =
                 parse_claude_credentials_data(&raw, ClaudeCredentialSource::Keychain)?;
             credentials.keychain_account = Some(account);
@@ -4207,11 +4204,8 @@ fn validate_claude_keychain_target(
         credentials,
         || Ok(claude_keychain_account()),
         |captured_account| {
-            load_claude_credentials_from_keychain_item(
-                CLAUDE_KEYCHAIN_SERVICE,
-                Some(captured_account),
-            )
-            .map_err(|_| ())
+            load_claude_credentials_from_keychain_item(CLAUDE_KEYCHAIN_SERVICE, Some(captured_account))
+                .map_err(|_| ())
         },
     )
     .map(|_| ())
@@ -4240,11 +4234,8 @@ fn save_claude_credentials_to_keychain(
         credentials,
         || Ok(claude_keychain_account()),
         |captured_account| {
-            load_claude_credentials_from_keychain_item(
-                CLAUDE_KEYCHAIN_SERVICE,
-                Some(captured_account),
-            )
-            .map_err(|_| ())
+            load_claude_credentials_from_keychain_item(CLAUDE_KEYCHAIN_SERVICE, Some(captured_account))
+                .map_err(|_| ())
         },
     )?;
 
@@ -5509,7 +5500,10 @@ mod tests {
                     peak.set(peak.get().max(live.get()));
                     // Later entries finish FIRST, so input order and completion
                     // order disagree for every pair.
-                    tokio::time::sleep(Duration::from_millis(((total - index) * 10) as u64)).await;
+                    tokio::time::sleep(Duration::from_millis(
+                        ((total - index) * 10) as u64,
+                    ))
+                    .await;
                     live.set(live.get() - 1);
                     index
                 }));
@@ -5986,21 +5980,16 @@ mod tests {
 
         assert_eq!(
             payload.quota_curve_series(),
-            [
-                "session.v1",
-                "weekly.v1",
-                "sonnet.weekly.v1",
-                "weekly_scoped.fable.v1"
-            ]
-            .map(|window_key| (
-                None,
-                SeriesKey::new(
-                    "claude",
-                    &HistoryScope::for_test(trusted.as_str()),
-                    window_key
-                )
-            ))
-            .to_vec()
+            ["session.v1", "weekly.v1", "sonnet.weekly.v1", "weekly_scoped.fable.v1"]
+                .map(|window_key| (
+                    None,
+                    SeriesKey::new(
+                        "claude",
+                        &HistoryScope::for_test(trusted.as_str()),
+                        window_key
+                    )
+                ))
+                .to_vec()
         );
         scope.cleanup();
     }
@@ -6399,24 +6388,15 @@ mod tests {
             },
             Err(failure) => ProviderFetchOutcome::Failure(failure),
         };
-        let snapshot = apply_provider_outcome_with(
-            &cache,
-            "copilot",
-            None,
-            "oauth",
-            response_at,
-            outcome,
-            |_| {},
-        )
-        .unwrap();
+        let snapshot =
+            apply_provider_outcome_with(&cache, "copilot", None, "oauth", response_at, outcome, |_| {})
+                .unwrap();
 
         assert!(snapshot.error.is_none());
         assert_eq!(snapshot.windows.len(), 1);
         assert!((snapshot.windows[0].remaining_percent - 60.0).abs() < 0.01);
         assert!(snapshot.windows[0].resets_at.is_none());
-        let cached = lock_last_good(&cache).entries[&account_slot("copilot", None)]
-            .snapshot
-            .clone();
+        let cached = lock_last_good(&cache).entries[&account_slot("copilot", None)].snapshot.clone();
         assert_eq!(cached.updated_at, snapshot.updated_at);
         assert_eq!(cached.windows.len(), 1);
         assert!(cached.error.is_none());
@@ -6619,9 +6599,7 @@ mod tests {
             )
             .unwrap();
             assert!(result.windows.is_empty());
-            assert!(!lock_last_good(&cache)
-                .entries
-                .contains_key(&account_slot("codex", None)));
+            assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("codex", None)));
         }
 
         let cache = Mutex::new(ProviderLastGoodCache::default());
@@ -6647,9 +6625,7 @@ mod tests {
             |_| panic!("absent must not enrich"),
         )
         .is_none());
-        assert!(!lock_last_good(&cache)
-            .entries
-            .contains_key(&account_slot("codex", None)));
+        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("codex", None)));
         scope.cleanup();
     }
 
@@ -6693,9 +6669,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(anonymous.windows.len(), 1);
-        assert!(!lock_last_good(&cache)
-            .entries
-            .contains_key(&account_slot("antigravity", None)));
+        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("antigravity", None)));
 
         apply_provider_outcome_with(
             &cache,
@@ -6725,9 +6699,7 @@ mod tests {
         )
         .unwrap();
         assert!(live_empty.windows.is_empty());
-        assert!(!lock_last_good(&cache)
-            .entries
-            .contains_key(&account_slot("antigravity", None)));
+        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("antigravity", None)));
 
         apply_provider_outcome_with(
             &cache,
@@ -6761,9 +6733,7 @@ mod tests {
         .unwrap();
         assert!(invalid.windows.is_empty());
         assert_eq!(enrich_calls.get(), 0);
-        assert!(!lock_last_good(&cache)
-            .entries
-            .contains_key(&account_slot("antigravity", None)));
+        assert!(!lock_last_good(&cache).entries.contains_key(&account_slot("antigravity", None)));
         scope.cleanup();
     }
 
@@ -9147,7 +9117,8 @@ mod tests {
     }
 
     use crate::agent_account_scope::test_support::{
-        assert_refresh_crash_boundaries, assert_transient_used_lock_reloaded_binding, checkpoint_at,
+        assert_concurrent_target_untouched, assert_refresh_crash_boundaries,
+        assert_transient_used_lock_reloaded_binding, checkpoint_at,
     };
 
     async fn codex_test_response(
@@ -9240,12 +9211,15 @@ mod tests {
         .await
         .unwrap_err();
 
-        assert!(matches!(failure, ProviderFetchFailure::Terminal { .. }));
+        assert_concurrent_target_untouched(
+            &failure,
+            &scope,
+            &metadata_before,
+            &path,
+            Some(B_BYTES),
+            "codex-new",
+        );
         assert!(recording.transfers().is_empty());
-        assert_eq!(scope.metadata_bytes(), metadata_before);
-        let stored_bytes = fs::read(&path).unwrap();
-        assert_eq!(stored_bytes, B_BYTES);
-        assert!(!String::from_utf8_lossy(&stored_bytes).contains("codex-new"));
         let stored = load_codex_credentials_from(&path).unwrap();
         assert_eq!(stored.access_token, "account-b-access");
         assert_eq!(stored.refresh_token.as_deref(), Some("account-b-refresh"));
@@ -9343,13 +9317,16 @@ mod tests {
         .await
         .unwrap_err();
 
-        assert!(matches!(failure, ProviderFetchFailure::Terminal { .. }));
+        assert_concurrent_target_untouched(
+            &failure,
+            &scope,
+            &metadata_before,
+            &path,
+            Some(LOGGED_OUT_BYTES),
+            "codex-new",
+        );
         assert!(recording.transfers().is_empty());
-        assert_eq!(scope.metadata_bytes(), metadata_before);
-        let stored_bytes = fs::read(&path).unwrap();
-        assert_eq!(stored_bytes, LOGGED_OUT_BYTES);
-        assert!(!String::from_utf8_lossy(&stored_bytes).contains("codex-new"));
-        let stored: Value = serde_json::from_slice(&stored_bytes).unwrap();
+        let stored: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
         assert!(stored.get("tokens").is_none());
         scope.cleanup();
     }
@@ -11660,14 +11637,10 @@ mod tests {
         // Clearing one account must not evict the other.
         lock_last_good(&cache).clear(&second);
         assert!(
-            lock_last_good(&cache)
-                .clean_for(&primary, &binding)
-                .is_some(),
+            lock_last_good(&cache).clean_for(&primary, &binding).is_some(),
             "clearing the second account evicted the primary"
         );
-        assert!(lock_last_good(&cache)
-            .clean_for(&second, &binding)
-            .is_none());
+        assert!(lock_last_good(&cache).clean_for(&second, &binding).is_none());
         scope.cleanup();
     }
 
@@ -11789,9 +11762,7 @@ mod tests {
             .as_array()
             .unwrap()
             .iter()
-            .filter(|entry| {
-                entry["providerId"] == "claude" && entry["accountScope"] == account_scope
-            })
+            .filter(|entry| entry["providerId"] == "claude" && entry["accountScope"] == account_scope)
             .cloned()
             .collect()
     }
@@ -11811,17 +11782,15 @@ mod tests {
             scope.resolve_history(provider, authoritative)
         };
 
-        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary =
+            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let extra = claude_account_identity_with(
             Some(G_TEST_CONFIG_DIR),
             &claude_config_dir_test_credentials(G_TEST_CONFIG_DIR),
             resolve,
         );
 
-        assert_eq!(
-            primary.account_key, None,
-            "the primary publishes no accountKey"
-        );
+        assert_eq!(primary.account_key, None, "the primary publishes no accountKey");
         assert_eq!(extra.account_key.as_deref(), Some(G_TEST_CONFIG_DIR));
 
         let primary_scope = primary
@@ -11862,7 +11831,8 @@ mod tests {
             .resolve_current("fixture", "g3-account", b"g3-marker")
             .unwrap();
 
-        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary =
+            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let extra = claude_account_identity_with(
             Some(G_TEST_CONFIG_DIR),
             &claude_config_dir_test_credentials(G_TEST_CONFIG_DIR),
@@ -11882,8 +11852,7 @@ mod tests {
                 &history_path,
             )
         });
-        let after_primary: Value =
-            serde_json::from_slice(&fs::read(&history_path).unwrap()).unwrap();
+        let after_primary: Value = serde_json::from_slice(&fs::read(&history_path).unwrap()).unwrap();
         let primary_series_before = claude_series_for(&after_primary, &primary_scope);
         assert_eq!(
             primary_series_before.len(),
@@ -11893,18 +11862,14 @@ mod tests {
 
         let mut extra_snapshot =
             claude_identity_test_snapshot(&extra, account_scope.clone(), 77.0, now + 600);
-        enrich_snapshot_with(
-            &mut extra_snapshot,
-            now + 600,
-            |active, observations, at| {
-                crate::agent_quota_history::record_observations_at_path_and_evaluate(
-                    active,
-                    observations,
-                    at,
-                    &history_path,
-                )
-            },
-        );
+        enrich_snapshot_with(&mut extra_snapshot, now + 600, |active, observations, at| {
+            crate::agent_quota_history::record_observations_at_path_and_evaluate(
+                active,
+                observations,
+                at,
+                &history_path,
+            )
+        });
         let after_extra: Value = serde_json::from_slice(&fs::read(&history_path).unwrap()).unwrap();
 
         assert_eq!(
@@ -11950,7 +11915,8 @@ mod tests {
             .unwrap();
 
         let now = 1_800_000_000_i64;
-        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary =
+            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let mut primary_snapshot =
             claude_identity_test_snapshot(&primary, account_scope.clone(), 20.0, now);
         enrich_snapshot_with(&mut primary_snapshot, now, |active, observations, at| {
@@ -11981,19 +11947,15 @@ mod tests {
         let writes = std::cell::Cell::new(0);
         let mut extra_snapshot =
             claude_identity_test_snapshot(&extra, account_scope, 77.0, now + 600);
-        enrich_snapshot_with(
-            &mut extra_snapshot,
-            now + 600,
-            |active, observations, at| {
-                writes.set(writes.get() + 1);
-                crate::agent_quota_history::record_observations_at_path_and_evaluate(
-                    active,
-                    observations,
-                    at,
-                    &history_path,
-                )
-            },
-        );
+        enrich_snapshot_with(&mut extra_snapshot, now + 600, |active, observations, at| {
+            writes.set(writes.get() + 1);
+            crate::agent_quota_history::record_observations_at_path_and_evaluate(
+                active,
+                observations,
+                at,
+                &history_path,
+            )
+        });
         assert_eq!(writes.get(), 0, "it opened a history transaction anyway");
         assert_eq!(
             fs::read(&history_path).unwrap(),
@@ -12029,7 +11991,8 @@ mod tests {
             .unwrap();
 
         let now = 1_800_000_000_i64;
-        let primary = claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
+        let primary =
+            claude_account_identity_with(None, &claude_test_login_credentials(), resolve);
         let mut primary_snapshot =
             claude_identity_test_snapshot(&primary, account_scope.clone(), 20.0, now);
         enrich_snapshot_with(&mut primary_snapshot, now, |active, observations, at| {
@@ -12078,11 +12041,7 @@ mod tests {
                     &history_path,
                 )
             });
-            assert_eq!(
-                writes.get(),
-                0,
-                "{semantic_source} opened a history transaction"
-            );
+            assert_eq!(writes.get(), 0, "{semantic_source} opened a history transaction");
         }
 
         assert_eq!(
@@ -12116,22 +12075,11 @@ mod tests {
         let reads = std::cell::Cell::new(0);
         let loaded = load_claude_config_dir_credentials_with(G_TEST_CONFIG_DIR, |dir| {
             reads.set(reads.get() + 1);
-            assert_eq!(
-                dir,
-                Some(G_TEST_CONFIG_DIR),
-                "it read another account's item"
-            );
+            assert_eq!(dir, Some(G_TEST_CONFIG_DIR), "it read another account's item");
             Ok(None)
         });
-        assert!(
-            loaded.is_err(),
-            "a missing item must not fall back to the primary's credential"
-        );
-        assert_eq!(
-            reads.get(),
-            1,
-            "one configured account costs exactly one read"
-        );
+        assert!(loaded.is_err(), "a missing item must not fall back to the primary's credential");
+        assert_eq!(reads.get(), 1, "one configured account costs exactly one read");
         // ...and there are no configured directories until the setter is called.
         assert!(crate::claude_config_dirs::snapshot().is_empty());
 
@@ -12248,18 +12196,14 @@ mod tests {
             recovered.account_key, None,
             "the recovered card is not the primary's"
         );
-        assert!(
-            recovered.error.is_some(),
-            "a failed round must still report the failure"
-        );
+        assert!(recovered.error.is_some(), "a failed round must still report the failure");
 
         // The extra account kept its own entry through all three rounds.
-        assert!(lock_last_good(&cache)
-            .clean_for(
-                &account_slot("claude", Some(G_TEST_CONFIG_DIR)),
-                &extra_binding
-            )
-            .is_some());
+        assert!(
+            lock_last_good(&cache)
+                .clean_for(&account_slot("claude", Some(G_TEST_CONFIG_DIR)), &extra_binding)
+                .is_some()
+        );
         scope.cleanup();
     }
 

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -9510,8 +9510,8 @@ mod tests {
                 load_codex_credentials_from(path)
                     .unwrap()
                     .refresh_token
-                    .as_deref()
-                    == Some("codex-new-refresh")
+                    .unwrap_or_default()
+                    .into_bytes()
             },
             |boundary| {
                 matches!(
@@ -10555,7 +10555,11 @@ mod tests {
                         .map(|_| ())
                 })
             },
-            |path| stored_claude_refresh_token(path).as_deref() == Some("claude-new-refresh"),
+            |path| {
+                stored_claude_refresh_token(path)
+                    .unwrap_or_default()
+                    .into_bytes()
+            },
             |boundary| boundary == RefreshCheckpoint::CredentialsPersisted,
             |boundary| {
                 matches!(


### PR DESCRIPTION
Refs #166.

Shares the four-provider refresh checkpoint-crash matrix (Codex, Claude, Antigravity, Grok) through `agent_account_scope::test_support`. Production refresh functions are byte-identical to `main`. Claude/Grok concurrent-target matrices that already landed on 08-16 are left alone.

This does **not** meet the issue's 40% combined reduction. Current `main` had already absorbed most of the 1.9K duplication the issue estimated; the crate is net +53 after the shared harness. Issue stays open.

| Check | Result |
|---|---|
| Diff surface | `agent_account_scope.rs`, `agent_antigravity.rs`, `agent_grok.rs`, `agent_usage.rs` — all `#[cfg(test)]` |
| Production refresh | `refresh_*` bodies identical to `origin/main` |
| `cargo test -p tb_core_ffi` | 402 passed, 0 failed, 3 ignored |
| Four crash tests | all pass through the shared harness |
| Mutation | shared `assert_injected_crash` string → four tests fail, restored, pass |