### PR TITLE
fix(badge): paginate the install-count so older releases are included

### DIFF
--- a/.github/workflows/update-install-count.yml
+++ b/.github/workflows/update-install-count.yml
@@ -27,8 +27,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COUNT=$(gh api repos/Nanako0129/TokenBar/releases \
-            --jq '[.[].assets[] | select(.name | test("\\.(tar\\.gz|dmg|zip|pkg)$")) | .download_count] | add // 0')
+          # Paginate: GitHub's default page is 30 releases. Sum outside jq so a
+          # per-page `--jq` cannot emit multiple numbers into the badge JSON.
+          COUNT=$(gh api --paginate repos/Nanako0129/TokenBar/releases \
+            --jq '[.[].assets[] | select(.name | test("\\.(tar\\.gz|dmg|zip|pkg)$")) | .download_count] | add // 0' \
+            | awk '{s+=$1} END {print s+0}')
           JSON="{\"schemaVersion\":1,\"label\":\"installs\",\"message\":\"${COUNT}\",\"color\":\"brightgreen\"}"
 
           # Build the orphan branch in an isolated repo so the workspace tree is

--- a/.github/workflows/update-install-count.yml
+++ b/.github/workflows/update-install-count.yml
@@ -24,6 +24,9 @@ jobs:
       # from scratch and force-pushed every run, so it always holds exactly one
       # commit. Shields reads it via the raw URL for the `badges` ref.
       - name: Compute and publish download count
+        # Explicit bash: ubuntu-latest's default is `bash -e` without pipefail,
+        # which would let awk publish 0 or a partial total after `gh api` fails.
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/knowledge/release.md
+++ b/docs/knowledge/release.md
@@ -4,7 +4,7 @@ id: kb-release
 kind: canonical
 scope: repository
 read_when: changing release scripts, code signing, appcast, Sparkle, Homebrew, Pages, or post-release notes
-last_verified: 2026-08-09
+last_verified: 2026-08-28
 sources: [".github/workflows/release.yml", ".github/workflows/ci.yml", ".github/workflows/pages.yml", ".github/workflows/update-install-count.yml", "scripts/bundle.sh", "scripts/build-sparkle.sh", "appcast.xml", "Makefile", "docs/knowledge/plans/provider-quota-pace.md", "public release history"]
 ---
 
@@ -101,7 +101,7 @@ The bridge population is shrinking and the beta cask is not the normal installat
 
 The current tap name is intentionally retained until a second app justifies a tap migration. A future migration must move all casks, delete their old copies in the same old-tap commit, retain the old public repository, and provide an app-level migration path because users who rely on Sparkle may not run Homebrew often enough to see a tap warning.
 
-The install-count workflow writes a single JSON file to an orphan branch rather than adding a noisy commit to `main`. Its count filters release assets by installable archive extensions and intentionally excludes update metadata downloads.
+The install-count workflow writes a single JSON file to an orphan branch rather than adding a noisy commit to `main`. Its count paginates the GitHub Releases API (default page size is 30), filters assets by installable archive extensions, and intentionally excludes update metadata downloads.
 
 ## Landing deployment
 


### PR DESCRIPTION
## Why

The README `installs` badge is produced by `.github/workflows/update-install-count.yml`. It summed GitHub release asset `download_count` for installable archives (`.tar.gz` / `.dmg` / `.zip` / `.pkg`) and published that total on the orphan `badges` branch.

`gh api repos/Nanako0129/TokenBar/releases` without `--paginate` follows GitHub's default page size of 30. The repository now has 38 releases, so the badge was missing the older eight.

Live check on 2026-08-28:

| Total | Value | What it includes |
|---|---|---|
| Published badge | 3,678 | First 30 releases, installable archives only (a few downloads behind the daily cron) |
| First-page filtered | 3,684 | Same filter, current API |
| Full filtered | **4,023** | All 38 releases, same filter — the number this PR publishes |
| All assets | 6,344 | Includes `latest.json` updater metadata (2,321). Still excluded on purpose |

The filter is unchanged. This PR only restores the pages the API already returned.

## Change

- `gh api --paginate` so every release page is included.
- Sum page totals with `awk` so a per-page `--jq` cannot write multiple numbers into the badge JSON. Empty output still becomes `0`.
- `docs/knowledge/release.md` records the pagination requirement next to the existing filter contract.

## Verification

Ran the replacement snippet against the live Releases API: `COUNT=4023`, JSON parses.

The published badge will move from 3,678 to the current filtered total the next time this workflow runs (release dispatch, daily cron at 03:17 UTC, or `workflow_dispatch`). It does not update on merge by itself.

## Out of scope

Other surfaces that sum every asset, including updater metadata, are a different definition and are not changed here.