### PR TITLE
fix(quota): divide the equivalence by the distance the readings travelled

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -1352,7 +1352,7 @@ private struct DashboardSnapshot {
                         // `collected` keeps the full list for the lifetime
                         // summaries below.
                         let admitted = QuotaHistoryFold.considered(window.cycles).filter {
-                            $0.usedPercent >= WindowEquivalence.minimumDelta
+                            WindowEquivalence.deltaQualifies($0.usedPercent, runs: $0.risingRuns)
                                 && $0.observedFraction >= WindowEquivalence.minimumObservedFraction
                         }
                         guard admitted.count >= WindowEquivalence.minimumCycles else { return nil }
@@ -1458,7 +1458,8 @@ private struct DashboardSnapshot {
                 cycles: zip(cycles, spans).map { cycle, span in
                     WindowEquivalence.Cycle(
                         deltaPercent: cycle.usedPercent, spanTokens: span.tokens,
-                        spanCost: span.cost, observedFraction: cycle.observedFraction)
+                        spanCost: span.cost, observedFraction: cycle.observedFraction,
+                        risingRuns: cycle.risingRuns)
                 })
         }
         quotaEquivalences = built

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -12230,9 +12230,42 @@ enum SelfTest {
                        + "numerator's two windows meet a denominator that counted both")
             expect(distError == 1,
                    "QH-DIST and the quoted error follows the same denominator — "
-                       + "0.5/93, not the 6% that 0.5/8 printed on the card")
+                       + "two rises at 0.5 each over 93, not the 6% that 0.5/8 printed")
         } else {
             expect(false, "QH-DIST the crossing fixture still produces a ratio row")
+        }
+
+        // QH-RUNS. Each rise `consumed` sums was quantised on its own, so a
+        // group that crossed a reset carries the uncertainty of every rise, not
+        // of one. [0,3,0,3] is two 3-point rises: 6 consumed, but neither rise
+        // clears the single-rise bar and their summed error is ±1 on 6, about
+        // 17% — over tolerance. It must come back insufficient, not as a ratio
+        // quoted at ±8%.
+        expect(QuotaHistoryFold.risingRuns([0, 3, 0, 3]) == 2,
+               "QH-RUNS one decline separates two rises")
+        expect(QuotaHistoryFold.risingRuns([1, 12, 30]) == 1
+                   && QuotaHistoryFold.risingRuns([7]) == 1
+                   && QuotaHistoryFold.risingRuns([]) == 0,
+               "QH-RUNS a monotonic run is one rise; a lone reading is one; nothing is none")
+        let runsSamples = [0.0, 3, 0, 3].enumerated().map {
+            QuotaSample(atMs: Int64($0.offset + 1) * 1_000_000, usedPercent: $0.element)
+        }
+        let runsMessages = try! JSONDecoder().decode(
+            [WindowMessage].self,
+            from: Data("""
+            [{"timestamp":1500000,"client":"c","providerId":"p",
+              "modelId":"m","input":60,"output":0,"cacheRead":0,"cacheWrite":0,
+              "reasoning":0,"cost":0.6,"isTurnStart":true}]
+            """.utf8))
+        if case let .insufficient(runsDelta, runsError) =
+            WindowEquivalence.row(samples: runsSamples, messages: runsMessages)
+        {
+            expect(abs(runsDelta - 6) < 1e-9,
+                   "QH-RUNS the consumption is still the full 6 — the gate scales, the sum does not")
+            expect(runsError == 17,
+                   "QH-RUNS and the error is 0.5 × 2 rises over 6, not 0.5 over 6")
+        } else {
+            expect(false, "QH-RUNS two sub-threshold rises must not be admitted as one measurement")
         }
         // The pooled site, same readings, same answer.
         let distCycles = QuotaHistoryFold.cycles(points: distResetReadings.enumerated().map {

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -12244,9 +12244,9 @@ enum SelfTest {
         expect(QuotaHistoryFold.risingRuns([0, 3, 0, 3]) == 2,
                "QH-RUNS one decline separates two rises")
         expect(QuotaHistoryFold.risingRuns([1, 12, 30]) == 1
-                   && QuotaHistoryFold.risingRuns([7]) == 1
+                   && QuotaHistoryFold.risingRuns([7]) == 0
                    && QuotaHistoryFold.risingRuns([]) == 0,
-               "QH-RUNS a monotonic run is one rise; a lone reading is one; nothing is none")
+               "QH-RUNS a monotonic run is one rise; a lone reading has none; nothing is none")
         let runsSamples = [0.0, 3, 0, 3].enumerated().map {
             QuotaSample(atMs: Int64($0.offset + 1) * 1_000_000, usedPercent: $0.element)
         }
@@ -12266,6 +12266,82 @@ enum SelfTest {
                    "QH-RUNS and the error is 0.5 × 2 rises over 6, not 0.5 over 6")
         } else {
             expect(false, "QH-RUNS two sub-threshold rises must not be admitted as one measurement")
+        }
+
+        // QH-RUNS-A1. The run count under one rule: a positive delta starts a
+        // run iff no earlier delta was positive or the most recent non-zero
+        // delta was negative; zero deltas are transparent. The first cut
+        // counted declines and charged [0,9,0]'s trailing decline as a rise.
+        for (readings, want) in [([0.0, 9, 0], 1), ([0, 3, 0, 3], 2), ([0, 5, 5, 9], 1),
+                                 ([0, 9, 8, 9], 2), ([1, 12, 30, 55], 1), ([7], 0),
+                                 ([], 0), ([5, 5, 5], 0)] as [([Double], Int)] {
+            expect(QuotaHistoryFold.risingRuns(readings) == want,
+                   "QH-RUNS-A1 risingRuns(\(readings)) == \(want)")
+        }
+        // QH-RUNS-A2. The one statement of the admission rule. `delta > 0`
+        // is what keeps `runs == 0` from turning the threshold into zero.
+        expect(!WindowEquivalence.deltaQualifies(6, runs: 2)
+                   && WindowEquivalence.deltaQualifies(9, runs: 1)
+                   && !WindowEquivalence.deltaQualifies(0, runs: 0)
+                   && WindowEquivalence.deltaQualifies(93, runs: 2)
+                   && !WindowEquivalence.deltaQualifies(4.9, runs: 1),
+               "QH-RUNS-A2 deltaQualifies clears the bar once per rise and never at zero")
+        // QH-RUNS-A3. A trailing decline is not a rise: [0,9,0] is one
+        // 9-point measurement, admitted at threshold 5 with error 0.5/9.
+        let trailSamples = [0.0, 9, 0].enumerated().map {
+            QuotaSample(atMs: Int64($0.offset + 1) * 1_000_000, usedPercent: $0.element)
+        }
+        let trailMessages = try! JSONDecoder().decode(
+            [WindowMessage].self,
+            from: Data("""
+            [{"timestamp":1500000,"client":"c","providerId":"p",
+              "modelId":"m","input":90,"output":0,"cacheRead":0,"cacheWrite":0,
+              "reasoning":0,"cost":0.9,"isTurnStart":true}]
+            """.utf8))
+        if case let .ratio(trailTokens, _, trailError) =
+            WindowEquivalence.row(samples: trailSamples, messages: trailMessages)
+        {
+            expect(trailTokens == 100, "QH-RUNS-A3 90 tokens over one 9-point rise is 100 per tenth")
+            expect(trailError == 6, "QH-RUNS-A3 and its error is 0.5 over 9, one rise not two")
+        } else {
+            expect(false, "QH-RUNS-A3 a single rise followed by a decline is still admitted")
+        }
+        // QH-RUNS-A4. The same rule at the pooled site. A merged [0,3,0,3]
+        // cycle carries delta 6 over 2 rises; beside two clean qualifying
+        // cycles it must NOT be admitted, so the pool sees two, not three.
+        let mergedCycle = QuotaHistoryFold.cycles(points: [0.0, 3, 0, 3].enumerated().map {
+            heatPoint(1_767_600_000 + Int64($0.offset) * 3_600, $0.element, reset: monReset)
+        }).first!
+        expect(abs(mergedCycle.usedPercent - 6) < 1e-9 && mergedCycle.risingRuns == 2,
+               "QH-RUNS-A4 the merged cycle carries both its consumption and its run count")
+        let poolRow = WindowEquivalence.aggregate(cycles: [
+            WindowEquivalence.Cycle(deltaPercent: 50, spanTokens: 5_000, spanCost: 5,
+                                    observedFraction: 1, risingRuns: 1),
+            WindowEquivalence.Cycle(deltaPercent: 40, spanTokens: 4_000, spanCost: 4,
+                                    observedFraction: 1, risingRuns: 1),
+            WindowEquivalence.Cycle(deltaPercent: mergedCycle.usedPercent, spanTokens: 600,
+                                    spanCost: 0.6, observedFraction: 1,
+                                    risingRuns: mergedCycle.risingRuns),
+        ])
+        if case let .tooFewCycles(poolCount, poolNeeded) = poolRow {
+            expect(poolCount == 2 && poolNeeded == 3,
+                   "QH-RUNS-A4 the pool admits the two clean cycles and rejects the merged one")
+        } else {
+            expect(false, "QH-RUNS-A4 the merged cycle must not make a third admitted cycle")
+        }
+        // QH-RUNS-A9. The insufficient row's error sums half-steps over every
+        // rise in every cycle offered — not over admitted cycles, which are
+        // empty by construction in that branch, and not per cycle.
+        if case let .insufficient(insDelta, insError) = WindowEquivalence.aggregate(cycles: [
+            WindowEquivalence.Cycle(deltaPercent: 2, spanTokens: 100, spanCost: 0.1,
+                                    observedFraction: 1, risingRuns: 1),
+            WindowEquivalence.Cycle(deltaPercent: 3, spanTokens: 100, spanCost: 0.1,
+                                    observedFraction: 1, risingRuns: 2),
+        ]) {
+            expect(abs(insDelta - 5) < 1e-9 && insError == 30,
+                   "QH-RUNS-A9 three rises at 0.5 over 5 points is 30%, not 20% per-cycle nor 0% over admitted")
+        } else {
+            expect(false, "QH-RUNS-A9 two sub-threshold cycles produce the insufficient row")
         }
         // The pooled site, same readings, same answer.
         let distCycles = QuotaHistoryFold.cycles(points: distResetReadings.enumerated().map {
@@ -14200,6 +14276,74 @@ enum SelfTest {
                 + "data silently overwriting the other's under a shared "
                 + "\"clientId|cardId\" key")
 
+
+        // QH-RUNS-A5. The dashboard's qualifying-window filter applies the same
+        // rule as the pooled aggregate and the live row. Three completed
+        // cycles, the third a merged [0,3,0,3]: it carries 6 points over two
+        // rises, which clears a single-rise bar and fails a two-rise one. With
+        // it rejected the window has two admitted cycles, not three, and
+        // `rebuildQuotaEquivalences` builds no row for it at all — not a
+        // `.tooFewCycles` row, no key. Drop the run factor from
+        // `deltaQualifies` and the key appears.
+        func runsCurve(cycles: [[Double]]) -> QuotaCurve {
+            var points: [String] = []
+            var oldest = Int64.max, newest = Int64.min
+            for (index, readings) in cycles.enumerated() {
+                let reset = m3fNow - Int64(cycles.count - index) * 18_000
+                // Spread from 17,000s before reset towards 1,000s before, so
+                // every cycle's observed fraction is about 16,000 / 18,000.
+                // Integer division means a 4-reading cycle ends a second or two
+                // short of -1,000, so coverage is derived from the points
+                // actually emitted — the decoder rejects a coverage block that
+                // does not match them.
+                let step = readings.count > 1 ? 16_000 / (readings.count - 1) : 0
+                for (slot, pct) in readings.enumerated() {
+                    let at = reset - 17_000 + Int64(slot * step)
+                    oldest = min(oldest, at); newest = max(newest, at)
+                    points.append("""
+                        {"sampledAt":\(at),"usedPercent":\(pct),
+                         "resetAt":\(reset),"durationSeconds":18000,
+                         "durationSource":"provider","origin":"liveV3",
+                         "isActiveGroup":false}
+                        """)
+                }
+            }
+            let json = """
+                {"points":[\(points.joined(separator: ","))],
+                 "coverage":{"oldestSampledAt":\(oldest),
+                             "newestSampledAt":\(newest),
+                             "sampleCount":\(points.count)},
+                 "activeResetAt":null,"generation":11}
+                """
+            return try! JSONDecoder().decode(QuotaCurve.self, from: Data(json.utf8))
+        }
+        let runsA5Keys: [String]? = awaitMainActorValue {
+            let src = WindowScanCountingSource(payload: m3fPayload)
+            src.curveByAccount = [
+                nil: runsCurve(cycles: [[0, 40], [0, 45], [0, 3, 0, 3]]),
+                m3ExtraKey: runsCurve(cycles: [[0, 20], [0, 25], [0, 30]]),
+            ]
+            let m = DashboardModel(source: src, initialYear: nil)
+            m.windowCardClients = ["claude"]
+            let poll = Task { await m.pollAgentUsage() }
+            var spins = 0
+            while !m.agentUsageAttempted, spins < 2_000 {
+                try? await Task.sleep(nanoseconds: 1_000_000)
+                spins += 1
+            }
+            poll.cancel()
+            _ = await poll.value
+            m.windowUsageClient = nil
+            m.quotaLensAllAgents = true
+            await m.refreshWindowUsage()
+            return Array(m.quotaEquivalences.keys).sorted()
+        }
+        expect(runsA5Keys?.contains("claude|session.v1") == false,
+               "QH-RUNS-A5 a window whose third cycle is a merged two-rise 6 does not "
+                   + "qualify at the dashboard filter, so no equivalence row is built for it")
+        expect(runsA5Keys?.contains("claude|\(m3ExtraKey)|session.v1") == true,
+               "QH-RUNS-A5 and the control window with three clean cycles does qualify, "
+                   + "so the absence above is the filter and not a broken fixture")
 
         // M3-q. The defect issue #258 reports, at the layer this side owns:
         // every account's equivalence row folding one shared scan.

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -12197,6 +12197,70 @@ enum SelfTest {
             expect(false, "QH-CACHE-LIVE the live fixture produces a ratio row")
         }
 
+        // QH-DIST. A reset inside a group makes the two old denominators
+        // disagree with each other and with the truth: the readings return to
+        // zero, so the displacement collapses while the range saturates at the
+        // highest reading. Both call sites now measure the distance travelled.
+        //
+        // Worked from the group behind a card that read 4.2B per 10% where the
+        // volume implied 0.35B: first 0%, last 8%, peak 85%, 93 points actually
+        // consumed. Dividing by 8 rather than 93 is the whole 11.6x.
+        let distResetReadings: [Double] = [0, 40, 85, 0, 3, 8]
+        expect(abs(QuotaHistoryFold.consumed(distResetReadings) - 93) < 1e-9,
+               "QH-DIST a run crossing one reset consumed 93, not the 8 it ended on "
+                   + "nor the 85 it reached")
+        let distSamples = distResetReadings.enumerated().map {
+            QuotaSample(atMs: Int64($0.offset + 1) * 1_000_000, usedPercent: $0.element)
+        }
+        let distMessages = try! JSONDecoder().decode(
+            [WindowMessage].self,
+            from: Data("""
+            [{"timestamp":1500000,"client":"c","providerId":"p",
+              "modelId":"m","input":930,"output":0,"cacheRead":0,"cacheWrite":0,
+              "reasoning":0,"cost":9.3,"isTurnStart":true}]
+            """.utf8))
+        // 930 tokens over 93 points is 10 per point, so per-tenth is 100. The
+        // same fixture under the old displacement of 8 divides by 11.6x less
+        // and reports 11.6x more, which is the defect's whole size.
+        if case let .ratio(distTokens, _, distError) =
+            WindowEquivalence.row(samples: distSamples, messages: distMessages)
+        {
+            expect(distTokens == 100,
+                   "QH-DIST the live path divides by the distance travelled, so the "
+                       + "numerator's two windows meet a denominator that counted both")
+            expect(distError == 1,
+                   "QH-DIST and the quoted error follows the same denominator — "
+                       + "0.5/93, not the 6% that 0.5/8 printed on the card")
+        } else {
+            expect(false, "QH-DIST the crossing fixture still produces a ratio row")
+        }
+        // The pooled site, same readings, same answer.
+        let distCycles = QuotaHistoryFold.cycles(points: distResetReadings.enumerated().map {
+            heatPoint(1_767_600_000 + Int64($0.offset) * 3_600, $0.element, reset: monReset)
+        })
+        expect(distCycles.first.map { abs($0.usedPercent - 93) < 1e-9 } == true,
+               "QH-DIST the pooled site agrees with the live one, which is the point "
+                   + "of stating the rule once")
+        expect(distCycles.first.map { abs($0.peakUsedPercent - 85) < 1e-9 } == true,
+               "QH-DIST and the peak is untouched — still the highest reading")
+        // Two resets accumulate rather than saturating. Asserting past 100 is
+        // the deliberate outcome: a group holding three windows consumed three
+        // windows' worth of one allowance.
+        expect(abs(QuotaHistoryFold.consumed([0, 60, 99, 0, 50, 99, 0, 20]) - 218) < 1e-9,
+               "QH-DIST consumption accumulates across every reset in the group and "
+                   + "may exceed 100, where the range would have saturated at 99")
+        // The no-op that guards the regression. Compared against the old
+        // expressions computed here rather than against literals, so what is
+        // asserted is the equality itself.
+        let distRising: [Double] = [1, 12, 30, 55, 88, 99]
+        expect(abs(QuotaHistoryFold.consumed(distRising)
+                   - ((distRising.max() ?? 0) - (distRising.min() ?? 0))) < 1e-9,
+               "QH-DIST on readings that only rise the distance equals the old range")
+        expect(abs(QuotaHistoryFold.consumed(distRising)
+                   - ((distRising.last ?? 0) - (distRising.first ?? 0))) < 1e-9,
+               "QH-DIST and equals the old displacement, so every clean cycle is "
+                   + "left exactly where it was")
+
         // QH-B. Exhaustion is an absolute reading, not the observed span. A
         // cycle first seen at 40% and last at 100% consumed 60 points as far as
         // this machine can tell, and reached the ceiling; deriving the ceiling

--- a/Sources/TokenBar/Views/QuotaHistoryCard.swift
+++ b/Sources/TokenBar/Views/QuotaHistoryCard.swift
@@ -345,7 +345,8 @@ struct QuotaHistoryCard: View {
                         WindowEquivalence.Cycle(
                             deltaPercent: $0.cycle.usedPercent,
                             spanTokens: $0.spanTokens, spanCost: $0.spanCost,
-                            observedFraction: $0.cycle.observedFraction)
+                            observedFraction: $0.cycle.observedFraction,
+                            risingRuns: $0.cycle.risingRuns)
                     }),
                 tokens: Format.compactTokens, money: Format.usdOrBelowCent))
                 .font(.caption2)

--- a/Sources/TokenBar/WindowProbe.swift
+++ b/Sources/TokenBar/WindowProbe.swift
@@ -176,7 +176,7 @@ enum WindowProbe {
                     let confirmed = UsageAttribution.confirmed().records
                     func estimate(_ set: [QuotaCycle]) -> WindowEquivalence.Row {
                         let admitted = set.filter {
-                            $0.usedPercent >= WindowEquivalence.minimumDelta
+                            WindowEquivalence.deltaQualifies($0.usedPercent, runs: $0.risingRuns)
                                 && $0.observedFraction >= WindowEquivalence.minimumObservedFraction
                         }
                         let spans = QuotaHistoryFold.spans(
@@ -193,7 +193,8 @@ enum WindowProbe {
                                 WindowEquivalence.Cycle(
                                     deltaPercent: cycle.usedPercent,
                                     spanTokens: span.tokens, spanCost: span.cost,
-                                    observedFraction: cycle.observedFraction)
+                                    observedFraction: cycle.observedFraction,
+                                    risingRuns: cycle.risingRuns)
                             })
                     }
                     // The sweep that set `consideredCycles`. Re-run it before

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -15,19 +15,33 @@ public struct QuotaCycle: Equatable, Sendable {
     /// its samples by exactly this value.
     public let resetAtMs: Int64
     public let startMs: Int64
-    /// How much of the allowance this cycle consumed: the span between the
-    /// lowest and highest reading in it, NOT the highest reading alone.
+    /// How much of the allowance this cycle consumed: the distance the readings
+    /// travelled, summed over their rises, NOT the highest reading alone and
+    /// NOT the range between the lowest and the highest.
     ///
-    /// The distinction is not cosmetic. Sampling starts whenever the app
-    /// happens to be running, so a cycle first observed at 40% used would
-    /// report 40% as its consumption when the app only witnessed the last few
-    /// points of it. The span is what this app can honestly claim to have seen.
+    /// Counting only rises is not cosmetic. Sampling starts whenever the app
+    /// happens to be running, so a cycle first observed at 40% used would report
+    /// 40% as its consumption when the app only witnessed the last few points of
+    /// it. What travelled between readings is what this app can honestly claim
+    /// to have seen.
+    ///
+    /// The range was the earlier answer and agrees with this one on every cycle
+    /// whose readings only rise. It stops agreeing when a reset falls inside the
+    /// group: the readings return to zero and the range then saturates at the
+    /// highest reading while the consumption keeps going. See
+    /// `QuotaHistoryFold.consumed`, which states the rule once for both this and
+    /// the live single-window path.
     ///
     /// Note the floor this leaves: `QuotaCurvePoint` rejects `usedPercent == 0`
-    /// at decode, so a cycle's first reading is always above zero and the span
-    /// necessarily omits whatever was consumed before it. That understates, and
-    /// understating is the right direction — the alternative assumes the app
-    /// witnessed a window it may have joined late.
+    /// at decode, so a cycle's first reading is always above zero and the
+    /// distance necessarily omits whatever was consumed before it. That
+    /// understates, and understating is the right direction — the alternative
+    /// assumes the app witnessed a window it may have joined late.
+    ///
+    /// May exceed 100 when a group holds more than one window's worth of
+    /// consumption, which is the deliberate outcome of keeping a window keyed by
+    /// its reset time rather than splitting it at a reset the provider never
+    /// reported.
     public let usedPercent: Double
     /// The highest absolute reading seen in this cycle.
     ///
@@ -235,7 +249,7 @@ public enum QuotaHistoryFold {
             return QuotaCycle(
                 resetAtMs: resetAt * 1000,
                 startMs: start * 1000,
-                usedPercent: (used.max() ?? 0) - (used.min() ?? 0),
+                usedPercent: consumed(used),
                 sampleCount: sorted.count,
                 observedFraction: min(1, max(0, Double(last.sampledAt - first.sampledAt)
                     / Double(last.durationSeconds))),
@@ -443,6 +457,31 @@ public enum QuotaHistoryFold {
         return spanTotals(
             cycles: cycles, sorted: sorted, stamps: sorted.map(\.timestamp),
             subscription: subscription, confirmed: confirmed)
+    }
+
+    /// How much allowance a run of readings records consuming: the distance
+    /// they travelled, summed over the rises between consecutive readings.
+    ///
+    /// Neither the range nor the displacement, though on a cycle whose readings
+    /// only rise all three are the same number. They stop agreeing the moment a
+    /// reset falls inside the group: the readings return to zero, so the
+    /// displacement collapses toward nothing while the range saturates at
+    /// whatever the highest reading happened to be. Measured on a real merged
+    /// group — 8 by displacement, 85 by range, 93 actually travelled. The
+    /// numerator keeps every message from both sides of that reset whichever
+    /// denominator is used, so one that does not accumulate makes the ratio
+    /// report a multiple of the truth: 11.6x on that group, which is where a
+    /// card reading `$2974.92` came from.
+    ///
+    /// Only rises count, which keeps the property the range was chosen for.
+    /// Sampling starts whenever the app happens to be running, so a cycle first
+    /// seen at 40% must not claim the 40% nobody watched.
+    ///
+    /// Order-dependent where the range was not. Every caller passes readings
+    /// already sorted by sample time; one that did not used to get the right
+    /// answer by accident and now gets a wrong one.
+    public static func consumed(_ readings: [Double]) -> Double {
+        zip(readings, readings.dropFirst()).reduce(0.0) { $0 + max(0, $1.1 - $1.0) }
     }
 
     /// The messages a scoped window may count. One statement of the rule, so

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -498,6 +498,20 @@ public enum QuotaHistoryFold {
     /// 2 to 100 points and bounce-backs 2 to 22, fully overlapping; real resets
     /// land anywhere from 0% to 21%, with bounce-backs landing at 0% as well.
     ///
+    /// The numerator has the twin of this, and it is left in place for the
+    /// same reason. A declining interval contributes nothing here while every
+    /// message inside it still counts above the line, so whatever was consumed
+    /// between the last reading before a reset and the reset itself is divided
+    /// by the rises around it. Excluding those messages is right when the
+    /// decline was a reset and wrong twice over when it was a correction —
+    /// numerator down, denominator already up — and the paragraph above is the
+    /// measurement saying the two cannot be told apart. Bound, from the same
+    /// store: 2 of 128 groups contain any decline at all, declining intervals
+    /// hold 0.17% of all observed time, 4.08% in the worst single group and
+    /// 0.92% in the merged group this whole change was written for. Time, not
+    /// messages — the message share is not measured, and a gap denser than
+    /// average carries proportionally more.
+    ///
     /// It is kept because the bound is small and the alternative costs more.
     /// Over 121 groups in that store, this and the range agreed on 119 — every
     /// cycle whose readings only rise — and differed by at most 3.5% on the
@@ -509,8 +523,9 @@ public enum QuotaHistoryFold {
         zip(readings, readings.dropFirst()).reduce(0.0) { $0 + max(0, $1.1 - $1.0) }
     }
 
-    /// How many separately measured rises `consumed` summed: one, plus one
-    /// more for every decline between consecutive readings.
+    /// How many separately measured rises `consumed` summed: the number of
+    /// times the readings started going up after not going up. Zero on
+    /// readings that never rose.
     ///
     /// The provider reports whole percents, so each rise carries the same
     /// ±0.5 quantisation whether it spans 3 points or 90. Summing two rises

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -480,6 +480,23 @@ public enum QuotaHistoryFold {
     /// Order-dependent where the range was not. Every caller passes readings
     /// already sorted by sample time; one that did not used to get the right
     /// answer by accident and now gets a wrong one.
+    ///
+    /// Every rise counts, including one that only undoes a provider's downward
+    /// correction: `[0, 40, 35, 40]` returns 45 where 40 was consumed. That is
+    /// a known overstatement and it is not fixable from the readings — a
+    /// decline does not say whether the quota was refilled or the earlier
+    /// number was wrong, and neither its size nor where it lands separates the
+    /// two. Measured across every series in a real store: persistent drops run
+    /// 2 to 100 points and bounce-backs 2 to 22, fully overlapping; real resets
+    /// land anywhere from 0% to 21%, with bounce-backs landing at 0% as well.
+    ///
+    /// It is kept because the bound is small and the alternative costs more.
+    /// Over 121 groups in that store, this and the range agreed on 119 — every
+    /// cycle whose readings only rise — and differed by at most 3.5% on the
+    /// two that had been refilled, where the range prices the window at its
+    /// widest excursion rather than at what it consumed. The residual also
+    /// leans the safe way: overstating the denominator understates the ratio,
+    /// so a quota reads as worth less rather than more.
     public static func consumed(_ readings: [Double]) -> Double {
         zip(readings, readings.dropFirst()).reduce(0.0) { $0 + max(0, $1.1 - $1.0) }
     }

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -501,6 +501,22 @@ public enum QuotaHistoryFold {
         zip(readings, readings.dropFirst()).reduce(0.0) { $0 + max(0, $1.1 - $1.0) }
     }
 
+    /// How many separately measured rises `consumed` summed: one, plus one
+    /// more for every decline between consecutive readings.
+    ///
+    /// The provider reports whole percents, so each rise carries the same
+    /// ±0.5 quantisation whether it spans 3 points or 90. Summing two rises
+    /// sums their uncertainty as well, and a ratio built on `[0, 3, 0, 3]`
+    /// is not a 6-point measurement at ±0.5 — it is two 3-point measurements
+    /// at ±0.5 each, neither of which clears the bar on its own. Callers that
+    /// quote an error or gate on a minimum delta scale both by this count, so
+    /// a group that crossed a reset does not come out looking more precise
+    /// than a group that did not.
+    public static func risingRuns(_ readings: [Double]) -> Int {
+        guard readings.count >= 2 else { return readings.isEmpty ? 0 : 1 }
+        return 1 + zip(readings, readings.dropFirst()).filter { $0.1 < $0.0 }.count
+    }
+
     /// The messages a scoped window may count. One statement of the rule, so
     /// the three surfaces of a window cannot apply it differently.
     public static func inScope(_ messages: [WindowMessage], _ scope: String?) -> [WindowMessage] {

--- a/Sources/TokenBarCore/QuotaHistory.swift
+++ b/Sources/TokenBarCore/QuotaHistory.swift
@@ -43,6 +43,11 @@ public struct QuotaCycle: Equatable, Sendable {
     /// its reset time rather than splitting it at a reset the provider never
     /// reported.
     public let usedPercent: Double
+    /// How many separately measured rises `usedPercent` sums. One on a cycle
+    /// whose readings only rose; more when a reset fell inside the group. The
+    /// admission bar and the quoted error scale by it, because each rise was
+    /// quantised on its own. See `QuotaHistoryFold.risingRuns`.
+    public let risingRuns: Int
     /// The highest absolute reading seen in this cycle.
     ///
     /// Separate from `usedPercent`, which is the observed SPAN. The two answer
@@ -87,9 +92,11 @@ public struct QuotaCycle: Equatable, Sendable {
         resetAtMs: Int64, startMs: Int64, usedPercent: Double,
         sampleCount: Int, observedFraction: Double,
         firstSampleMs: Int64 = 0, lastSampleMs: Int64 = 0,
-        peakUsedPercent: Double? = nil
+        peakUsedPercent: Double? = nil,
+        risingRuns: Int = 1
     ) {
         self.peakUsedPercent = peakUsedPercent ?? usedPercent
+        self.risingRuns = risingRuns
         self.resetAtMs = resetAtMs
         self.startMs = startMs
         self.usedPercent = usedPercent
@@ -255,7 +262,8 @@ public enum QuotaHistoryFold {
                     / Double(last.durationSeconds))),
                 firstSampleMs: first.sampledAt * 1000,
                 lastSampleMs: last.sampledAt * 1000,
-                peakUsedPercent: used.max() ?? 0)
+                peakUsedPercent: used.max() ?? 0,
+                risingRuns: risingRuns(used))
         }
         .sorted { $0.resetAtMs > $1.resetAtMs }
     }
@@ -513,8 +521,23 @@ public enum QuotaHistoryFold {
     /// a group that crossed a reset does not come out looking more precise
     /// than a group that did not.
     public static func risingRuns(_ readings: [Double]) -> Int {
-        guard readings.count >= 2 else { return readings.isEmpty ? 0 : 1 }
-        return 1 + zip(readings, readings.dropFirst()).filter { $0.1 < $0.0 }.count
+        // A positive delta starts a run iff no earlier delta was positive, or
+        // the most recent non-zero delta before it was negative. A zero delta
+        // is transparent: a plateau inside a rise is still one measurement
+        // span under the ±0.5-per-reading model, so it neither starts nor ends
+        // a run. Counting declines instead — the first cut here — charged a
+        // trailing decline as a run that contributed no rise.
+        var runs = 0
+        var lastNonZeroWasNegative = true
+        for (before, after) in zip(readings, readings.dropFirst()) {
+            if after > before {
+                if lastNonZeroWasNegative { runs += 1 }
+                lastNonZeroWasNegative = false
+            } else if after < before {
+                lastNonZeroWasNegative = true
+            }
+        }
+        return runs
     }
 
     /// The messages a scoped window may count. One statement of the rule, so

--- a/Sources/TokenBarCore/QuotaOverview.swift
+++ b/Sources/TokenBarCore/QuotaOverview.swift
@@ -98,8 +98,10 @@ public enum QuotaOverviewFold {
             let consumption = ordered.map(\.usedPercent)
             let peaks = ordered.map(\.peakUsedPercent)
             // Consumption for the strip, absolute reading for the ceiling.
-            // `usedPercent` is a span, so a cycle first observed at 40% and
-            // last at 100% has a span of 60 and would have been called quiet.
+            // `usedPercent` is the distance travelled, so a cycle first observed
+            // at 40% and last at 100% consumed 60 and would have been called
+            // quiet. It can also exceed 100 where a group holds more than one
+            // window, which the strip's bars clamp and its sentence does not.
             let peak = window.cycles.map(\.peakUsedPercent).max() ?? 0
             return QuotaWindowSummary(
                 clientId: window.clientId, accountKey: window.accountKey,

--- a/Sources/TokenBarCore/WindowEquivalence.swift
+++ b/Sources/TokenBarCore/WindowEquivalence.swift
@@ -37,6 +37,28 @@ public enum WindowEquivalence {
     /// Derived, not chosen: ±0.5/Δ ≤ tolerance ⇒ Δ ≥ 5.
     public static var minimumDelta: Double { quantisationHalfStep / tolerance }
 
+    /// The one statement of whether a measured consumption is large enough to
+    /// divide by. `minimumDelta` is the single-rise delta at which the ±0.5
+    /// quantisation reaches `tolerance`; a delta summed over several rises
+    /// carries that uncertainty once per rise, so it has to clear the bar once
+    /// per rise to make the same claim.
+    ///
+    /// Four sites admit cycles — the live row, the pooled aggregate, the
+    /// dashboard's qualifying-window filter and the probe — and this rule used
+    /// to be written out at each of them. Scaling it at one and not the others
+    /// is how `[0, 3, 0, 3]` came to be rejected by the live row as two
+    /// sub-threshold rises and admitted by the pooled path as one 6-point
+    /// cycle in the same build. It lives here so that cannot recur.
+    ///
+    /// `delta > 0` is load-bearing, not defensive: `consumed` returns a
+    /// positive value only when at least one rise exists, so a positive delta
+    /// implies `runs >= 1` and the product below cannot be zero. Without the
+    /// guard, `runs == 0` would make the threshold zero and admit a cycle that
+    /// never moved.
+    public static func deltaQualifies(_ delta: Double, runs: Int) -> Bool {
+        delta > 0 && delta >= minimumDelta * Double(runs)
+    }
+
     public enum Row: Equatable, Sendable {
         /// Tokens and cost equivalent to one tenth of the window's quota.
         case ratio(tokensPerTenth: Int64, costPerTenth: Double, errorPercent: Int)
@@ -187,7 +209,7 @@ public enum WindowEquivalence {
         // once per rise to make the same claim. Without this, `[0, 3, 0, 3]`
         // read as a 6-point measurement at ±8% — two rises of 3 that each
         // fell short, presented as one that did not.
-        let runs = Double(QuotaHistoryFold.risingRuns(readings))
+        let runs = QuotaHistoryFold.risingRuns(readings)
 
         // Numerator and denominator must cover the same interval or the ratio
         // means nothing — hence the span between samples, not the whole window.
@@ -196,14 +218,14 @@ public enum WindowEquivalence {
         }
         let tokens = inSpan.reduce(Int64(0)) { $0.saturatingAdding(ratioTokens($1)) }
         let cost = inSpan.reduce(0.0) { $0 + $1.cost }
-        let error = Int((quantisationHalfStep * runs / delta * 100).rounded())
+        let error = Int((quantisationHalfStep * Double(runs) / delta * 100).rounded())
 
         // "Recorded" means either kind of evidence. A provider row can carry a
         // cost with no token components, and the pooled path already admits
         // one; requiring tokens here made the single-window footer say "none of
         // it recorded on this machine" about usage sitting in the same scan.
         guard tokens > 0 || cost > 0 else { return .unaccounted(deltaPercent: delta) }
-        guard delta >= minimumDelta * runs else {
+        guard deltaQualifies(delta, runs: runs) else {
             return .insufficient(deltaPercent: delta, errorPercent: error)
         }
         // Clamping, not truncating: a saturated token count over a small delta
@@ -233,15 +255,19 @@ public enum WindowEquivalence {
         public let spanTokens: Int64
         public let spanCost: Double
         public let observedFraction: Double
+        /// How many separately measured rises `deltaPercent` sums; the
+        /// admission bar scales by it. See `deltaQualifies`.
+        public let risingRuns: Int
 
         public init(
             deltaPercent: Double, spanTokens: Int64, spanCost: Double,
-            observedFraction: Double
+            observedFraction: Double, risingRuns: Int = 1
         ) {
             self.deltaPercent = deltaPercent
             self.spanTokens = spanTokens
             self.spanCost = spanCost
             self.observedFraction = observedFraction
+            self.risingRuns = risingRuns
         }
     }
 
@@ -293,7 +319,7 @@ public enum WindowEquivalence {
         // as "none of it recorded on this machine", which is false about the
         // one thing it could see.
         let admitted = cycles.filter {
-            $0.deltaPercent >= minimumDelta
+            deltaQualifies($0.deltaPercent, runs: $0.risingRuns)
                 && $0.observedFraction >= minimumObservedFraction
                 && ($0.spanCost > 0 || $0.spanTokens > 0)
         }
@@ -313,7 +339,13 @@ public enum WindowEquivalence {
             }
             return .insufficient(
                 deltaPercent: anyMovement,
-                errorPercent: Int((quantisationHalfStep * Double(cycles.count)
+                // One half-step per RISE, summed over every cycle offered —
+                // not per cycle. A merged cycle carries several quantised
+                // rises and its error is that many half-steps wide. Over
+                // `cycles`, not `admitted`: inside this branch `admitted` is
+                // empty by construction, and a sum over it would quote ±0%.
+                errorPercent: Int((quantisationHalfStep
+                    * Double(cycles.reduce(0) { $0 + $1.risingRuns })
                     / anyMovement * 100).rounded()))
         }
         // Count, not size: these cycles each cleared `minimumDelta` on their

--- a/Sources/TokenBarCore/WindowEquivalence.swift
+++ b/Sources/TokenBarCore/WindowEquivalence.swift
@@ -171,7 +171,13 @@ public enum WindowEquivalence {
               samples.count >= 2
         else { return .unavailable }
 
-        let delta = last.usedPercent - first.usedPercent
+        // The distance the readings travelled, not `last - first`. A reset
+        // inside the span returns them to zero, and the displacement then
+        // collapses while the numerator below keeps every message from both
+        // sides of it — which is how a window that consumed 93 points came to
+        // divide by 8 and report eleven times the true rate. One statement of
+        // the rule, shared with the pooled path.
+        let delta = QuotaHistoryFold.consumed(samples.map(\.usedPercent))
         guard delta > 0 else { return .notMoved }
 
         // Numerator and denominator must cover the same interval or the ratio

--- a/Sources/TokenBarCore/WindowEquivalence.swift
+++ b/Sources/TokenBarCore/WindowEquivalence.swift
@@ -177,8 +177,17 @@ public enum WindowEquivalence {
         // sides of it — which is how a window that consumed 93 points came to
         // divide by 8 and report eleven times the true rate. One statement of
         // the rule, shared with the pooled path.
-        let delta = QuotaHistoryFold.consumed(samples.map(\.usedPercent))
+        let readings = samples.map(\.usedPercent)
+        let delta = QuotaHistoryFold.consumed(readings)
         guard delta > 0 else { return .notMoved }
+        // Every rise `consumed` summed was quantised on its own, so both the
+        // error quoted below and the admission bar scale with how many there
+        // were. `minimumDelta` is the single-rise delta at which the error
+        // reaches `tolerance`; a group that crossed a reset has to clear it
+        // once per rise to make the same claim. Without this, `[0, 3, 0, 3]`
+        // read as a 6-point measurement at ±8% — two rises of 3 that each
+        // fell short, presented as one that did not.
+        let runs = Double(QuotaHistoryFold.risingRuns(readings))
 
         // Numerator and denominator must cover the same interval or the ratio
         // means nothing — hence the span between samples, not the whole window.
@@ -187,14 +196,14 @@ public enum WindowEquivalence {
         }
         let tokens = inSpan.reduce(Int64(0)) { $0.saturatingAdding(ratioTokens($1)) }
         let cost = inSpan.reduce(0.0) { $0 + $1.cost }
-        let error = Int((quantisationHalfStep / delta * 100).rounded())
+        let error = Int((quantisationHalfStep * runs / delta * 100).rounded())
 
         // "Recorded" means either kind of evidence. A provider row can carry a
         // cost with no token components, and the pooled path already admits
         // one; requiring tokens here made the single-window footer say "none of
         // it recorded on this machine" about usage sitting in the same scan.
         guard tokens > 0 || cost > 0 else { return .unaccounted(deltaPercent: delta) }
-        guard delta >= minimumDelta else {
+        guard delta >= minimumDelta * runs else {
             return .insufficient(deltaPercent: delta, errorPercent: error)
         }
         // Clamping, not truncating: a saturated token count over a small delta

--- a/Sources/TokenBarCore/WindowEquivalence.swift
+++ b/Sources/TokenBarCore/WindowEquivalence.swift
@@ -213,6 +213,14 @@ public enum WindowEquivalence {
 
         // Numerator and denominator must cover the same interval or the ratio
         // means nothing — hence the span between samples, not the whole window.
+        //
+        // Held exactly at the ends and approximately in the middle: a
+        // declining interval inside the span contributes to the numerator and
+        // not to `consumed`. See `QuotaHistoryFold.consumed` for why that is
+        // not fixed here — briefly, dropping those messages is right for a
+        // reset and wrong for a correction, and the readings do not say which
+        // — and for the measured size of it, which is 0.9% of the span on the
+        // group that produced the defect this function was rewritten for.
         let inSpan = messages.filter {
             $0.timestamp > first.atMs && $0.timestamp <= last.atMs
         }


### PR DESCRIPTION
Fixes the denominator behind a card that read `額度 10% ≈ 4.2B token · $2974.92` where the transcript volume behind the same cycles implied 0.35B.

## The defect

`WindowEquivalence.row` divided by the readings' **net displacement**:

```swift
let delta = last.usedPercent - first.usedPercent
let inSpan = messages.filter { $0.timestamp > first.atMs && $0.timestamp <= last.atMs }
```

The numerator sums every message across the span. When a reset falls inside it the readings return to zero, so the displacement collapses while the numerator keeps the work from both sides.

| | |
|---|---|
| first sample | 0% |
| last sample | 8% |
| `last − first` | **8 pp** |
| distance actually travelled | **93 pp** |
| span tokens, deduped and attributed | 3.37B |
| `3.37B / 8 * 10` | **4.21B per 10%** |
| displayed | **4.2B per 10%** |

0.2% apart. Inflation 93/8 = **11.6x**.

> A second confirmation was printed on the card the whole time. `error = quantisationHalfStep / delta * 100` is `0.5 / 8 * 100 = 6`, and the card read **±6%**. The wrong denominator was on screen and nobody read it.

`QuotaHistory.cycles` had the same defect through a different expression — `max − min`, the range. Range does not collapse, it saturates, so it understates by only 1.1x on the same group, and contributes nothing today because `cycles()` filters active groups and only active groups merge. It matters once windows stop merging.

## The fix

One quantity, stated once for both paths:

```swift
public static func consumed(_ readings: [Double]) -> Double {
    zip(readings, readings.dropFirst()).reduce(0.0) { $0 + max(0, $1.1 - $1.0) }
}
```

Only rises count, which preserves the property the range was chosen for: sampling starts whenever the app happens to be running, so a cycle first observed at 40% must not claim the 40% nobody watched. **On readings that only rise, distance, range and displacement are the same number** — every clean cycle is left exactly where it was.

The helper is order-dependent where `max − min` was not. Both call sites pass readings already sorted by sample time, but a caller that did not would previously have got the right answer by accident.

## What changes on screen

A window's consumption may exceed 100%, which is the deliberate outcome of keeping a window keyed by its reset time rather than splitting it at a reset the provider never reported. Two surfaces print it: the history card's per-cycle label, and the overview strip's `Consumed %@%% of the allowance`. Both bars are clamped at `min(1, value / 100)`; the two sentences are not, and a group holding three cycles will read 218%.

Accepted rather than special-cased. Splitting the quantity so one card keeps the range would put two definitions of "consumed" on two cards, which is what stating the rule once exists to prevent.

More cycles may clear `DashboardModel`'s `>= minimumDelta` admission, since distance is never below range. Correct — those cycles did consume more.

## Verification

`make selftest` green at **1238 checks**. Eight new `QH-DIST` assertions, each run against the mutation named for it:

| mutation | assertions killed |
|---|---|
| restore `last − first` at `row:174` | 2 — the live ratio and the quoted error |
| restore `max − min` at `cycles:238` | 1 — the pooled site |
| drop `max(0, ...)` from the helper | 5, including accumulate-past-100, which degenerates to the displacement without it |

Two assertions are deliberately killed by nothing. The monotonic cases compare the new helper against both old expressions **computed inline rather than written as literals**, so what they assert is the equality itself; they guard the regression while the mutations guard the fix.

Not touched: `peakUsedPercent`, `observedFraction`, the numerator's bounds, `Fixtures/CrossCheck/provider-quota-pace-v3.json`. The cross-check oracle never reaches either site — `WindowEquivalence`, `QuotaHistory`, `QuotaCycle`, `WindowMessage` and `ratioTokens` appear in no file under `Sources/CrossCheckHarness/`, whose lanes call `Format.*`, `UsagePace.compute`, `QuotaResolver.*` and `graph.trayTotals`. **The Windows oracle pin does not need to advance for this.**

**Not observed: the corrected figure on screen.** Every check here is a fixture.

## Notes

`M3-o3`, a multi-account poller assertion unrelated to this change, failed once and passed on a re-run of the identical build. Flaky, standing beside this work rather than caused by it, and left alone.

Not stacked on #258, which is implemented in another session and not yet pushed. The two touch disjoint files and can land in either order; this PR's base can be retargeted if a stack is wanted.

Refs #259
