### PR TITLE
refactor(quota): make the admission threshold unreachable outside its rule

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -13201,8 +13201,15 @@ enum SelfTest {
         expect(Set(LimitsLayout.allCases.map(\.rawValue)) == ["full", "classic", "chart"],
                "LL2 three layouts are offered, and Settings enumerates allCases")
 
+        // Stated in behaviour rather than by reading the constant, because the
+        // constant is no longer reachable from this target: `minimumDelta` is
+        // internal to `TokenBarCore` so the admission comparison cannot be
+        // written outside `deltaQualifies`. Bracketing the boundary is also a
+        // stronger claim than the equality it replaces — it says where the bar
+        // is AND that it admits at it, which an `== 5` on the constant did not.
         expect(
-            WindowEquivalence.minimumDelta == 5,
+            !WindowEquivalence.deltaQualifies(4.999, runs: 1)
+                && WindowEquivalence.deltaQualifies(5, runs: 1),
             "V15 the threshold follows from the tolerance, not from a chosen number")
 
         // Every row string is rendered, not just constructed. A literal `%` in

--- a/Sources/TokenBarCore/WindowEquivalence.swift
+++ b/Sources/TokenBarCore/WindowEquivalence.swift
@@ -35,7 +35,17 @@ public enum WindowEquivalence {
     /// How much relative error the displayed ratio may carry.
     static let tolerance = 0.10
     /// Derived, not chosen: ±0.5/Δ ≤ tolerance ⇒ Δ ≥ 5.
-    public static var minimumDelta: Double { quantisationHalfStep / tolerance }
+    ///
+    /// Internal on purpose. `deltaQualifies` below is the whole admission rule
+    /// and this is only its single-rise half; a caller holding the bare number
+    /// can write `delta >= minimumDelta` and silently drop the run scaling,
+    /// which is exactly what happened at two sites in the `TokenBar` target and
+    /// took a review round to find. Keeping it inside this module makes that
+    /// comparison fail to compile out there rather than fail review. The
+    /// previous guard was a `git grep` showing one comparison, which is a
+    /// statement about the text at the moment it ran and not about the
+    /// repository — an edit relocates around it without touching it.
+    static var minimumDelta: Double { quantisationHalfStep / tolerance }
 
     /// The one statement of whether a measured consumption is large enough to
     /// divide by. `minimumDelta` is the single-rise delta at which the ±0.5


### PR DESCRIPTION
`WindowEquivalence.minimumDelta` drops from `public` to internal. Nothing else changes — `deltaQualifies` was already the only comparison against it and stays public, so every current call site compiles unaltered.

## What stops compiling

`minimumDelta` is only the single-rise half of the admission rule. A caller holding the bare number can write `delta >= minimumDelta` and silently drop the run scaling. That is what #260 found at two sites in the `TokenBar` target, where `[0, 3, 0, 3]` was rejected by the live row as two sub-threshold rises and admitted by the pooled path as one 6-point cycle in the same build. Those sites are in `TokenBar`; the constant is now inside `TokenBarCore`, so the comparison cannot be spelled out there at all.

## Why a probe rather than a grep

#260 offered `git grep minimumDelta Sources` as its evidence that one comparison remained. A grep states what the text looked like at the moment it ran; an edit relocates around it without touching it, and this repository has had three successive scans escaped that way.

Restoring the bare comparison at `DashboardModel.swift:1355` — one of the two sites that actually drifted — and building:

```
DashboardModel.swift:1355:65: error: 'minimumDelta' is inaccessible due to 'internal' protection level
1355 |                             $0.usedPercent >= WindowEquivalence.minimumDelta
     |                                                                 `- error: 'minimumDelta' is inaccessible due to 'internal' protection level
WindowEquivalence.swift:48:16: note: 'minimumDelta' declared here
```

Observed, then reverted.

**Limit, stated rather than implied:** this closes the cross-module hole only. Inside `WindowEquivalence.swift` a bare comparison is still writable — but that is the one file that owns the rule, which is a different risk from four sites in two targets drifting apart.

## The one test that had to change

V15 read `WindowEquivalence.minimumDelta == 5` and can no longer see the constant. It is restated in behaviour and is stronger for it:

```swift
!WindowEquivalence.deltaQualifies(4.999, runs: 1)
    && WindowEquivalence.deltaQualifies(5, runs: 1)
```

That brackets the boundary — where the bar sits *and* that it admits at it — where an equality on the constant said neither. Name and claim unchanged.

## Credit and the rejected alternative

The shape came from the TokenBar-Windows session, which reached it from the other end: its port made an omitted argument a compile error and verified that with a probe against the old signature rather than with a diff.

Its own suggestion here was to wrap `consumed`'s return type so no bare `Double` exists. Measured against these callers, that would not have closed it — the two drifting sites read the stored `QuotaCycle.usedPercent` rather than calling `consumed`, and `usedPercent` is read in 17 files across both targets. Removing the other operand costs two lines instead.

## Verification

`make selftest` green. No mutation is offered: the guarantee here is a compile error, and the probe above is the observation of it.

Refs #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUnrY2FKMkYRsMGiaTucA7
