### PR TITLE
fix(models): flag implausible self-reported costs, and fix the list's hover tooltip

### DIFF
--- a/Sources/TokenBar/Format.swift
+++ b/Sources/TokenBar/Format.swift
@@ -34,6 +34,17 @@ enum Format {
         String(format: "$%.2f", amount)
     }
 
+    /// A "this many times over" multiple, for the implausible-cost warning.
+    ///
+    /// Whole numbers only. The value exists to say a cost is wrong by orders
+    /// of magnitude, and a decimal place would imply a precision the estimate
+    /// behind it does not have: the pricing lookup can land on a near-miss key
+    /// or a row missing cache rates, either of which moves the ratio by
+    /// single-digit multiples without changing what it is telling you.
+    static func compactRatio(_ ratio: Double) -> String {
+        String(format: "%.0f", ratio)
+    }
+
     /// `usd`, except that a real amount too small to show is said to be small
     /// rather than rendered as nothing.
     ///

--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -122,6 +122,7 @@
 "Show more" = "顯示更多";
 "Prices updated %@" = "價格更新於 %@";
 "LiteLLM pricing data; refreshes automatically about once an hour" = "LiteLLM 價格資料，大約每小時自動更新一次";
+"Cost reported by the client, about %@x the local price estimate" = "費用由用戶端自行回報，約為本機價格估算的 %@ 倍";
 "Timeline" = "時間軸";
 "Profile" = "分布";
 "peak %02lld:00 · %@" = "尖峰 %1$02lld:00 · %2$@";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -1214,6 +1214,12 @@ enum SelfTest {
                 .costEstimate == nil,
             "one unpriceable component makes the merged estimate a partial denominator, "
                 + "which would overstate the ratio — the merged row reports no estimate instead")
+        expect(
+            CostPlausibility.warningText(308.4).contains("308")
+                && !CostPlausibility.warningText(308.4).contains("308.4"),
+            "the warning names the multiple as a whole number — one wording shared by the "
+                + "tooltip line and the icon's accessibility label, which is the only channel "
+                + "a VoiceOver user has because the tooltip is pointer-only")
 
         // Usage attribution: declarations are explicit, provider-level by
         // default, and model overrides are more specific. Suggestions never

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -1141,6 +1141,80 @@ enum SelfTest {
             modelLevelEntries.first { $0.model == "shared-model" }?.msPer1kTokens == nil,
             "provider-split model fold omits unrecomputable throughput")
 
+        // Implausible self-reported cost. A client that records its own cost
+        // (OpenCode, MiMo Code) has it taken verbatim by tokscale-core and
+        // never priced, so this comparison against the local estimate is the
+        // only thing between a unit error upstream and the number on screen.
+        func costEntry(_ cost: Double, _ estimate: Double?, provider: String = "p") -> String {
+            """
+            {"client":"c","model":"m","provider":"\(provider)",
+             "input":1,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0,
+             "total":1,"messageCount":1,"cost":\(cost),"msPer1kTokens":null,
+             "costEstimate":\(estimate.map { "\($0)" } ?? "null")}
+            """
+        }
+        func costReport(_ entries: [String]) -> ModelReport {
+            let json = """
+            {"entries":[\(entries.joined(separator: ","))],
+             "totalInput":1,"totalOutput":0,"totalCacheRead":0,"totalCacheWrite":0,
+             "totalMessages":\(entries.count),"totalCost":0.0}
+            """
+            return try! JSONDecoder().decode(ModelReport.self, from: Data(json.utf8))
+        }
+        func onlyRow(_ entries: [String]) -> ModelReportEntry {
+            costReport(entries).modelLevelEntries[0]
+        }
+
+        expect(
+            onlyRow([costEntry(1000, 1)]).implausibleCostRatio == 1000,
+            "a cost 1000x the local estimate is flagged, with that multiple — the shape of "
+                + "the user report where a per-1K rate was billed per-token")
+        expect(
+            onlyRow([costEntry(CostPlausibility.threshold, 1)]).implausibleCostRatio == nil
+                && onlyRow([costEntry(CostPlausibility.threshold + 0.5, 1)])
+                    .implausibleCostRatio != nil,
+            "the threshold is pinned from both sides, so a comparison flipped to >= or < "
+                + "cannot pass this pair")
+        expect(
+            onlyRow([costEntry(0.3, 1)]).implausibleCostRatio == nil,
+            "a row costing LESS than the estimate is never flagged — every healthy row "
+                + "measured on real data sits at 0.1-0.3x, so a two-sided check would flag "
+                + "all of them forever")
+        expect(
+            onlyRow([costEntry(0, 1)]).implausibleCostRatio == nil,
+            "a genuinely free model reports 0.0 against a positive estimate and must stay quiet")
+        expect(
+            onlyRow([costEntry(99_999, nil)]).implausibleCostRatio == nil,
+            "no estimate means the table cannot price these tokens at all, which is not "
+                + "evidence about the reported cost — and must not divide by nil")
+        expect(
+            onlyRow([costEntry(99_999, 0)]).implausibleCostRatio == nil,
+            "a zero estimate is not a usable denominator")
+
+        // The fold is where a pre-fold ratio would go wrong (PR #264 review):
+        // one broken component merged with a larger healthy row is NOT the
+        // component's multiple. 100/1 + 1000/1000 = 1100/1001 = 1.1x.
+        let mergedMostlyHealthy = onlyRow([
+            costEntry(100, 1, provider: "a"), costEntry(1000, 1000, provider: "b"),
+        ])
+        expect(
+            mergedMostlyHealthy.cost == 1100 && mergedMostlyHealthy.costEstimate == 1001,
+            "the fold sums cost and estimate together, so the ratio describes the merged row")
+        expect(
+            mergedMostlyHealthy.implausibleCostRatio == nil,
+            "a merged row at 1.1x is not flagged, even though one component alone was 100x — "
+                + "carrying the component's ratio onto the aggregate would be materially false")
+        expect(
+            onlyRow([costEntry(100_000, 1, provider: "a"), costEntry(1000, 1000, provider: "b")])
+                .implausibleCostRatio != nil,
+            "a component broken badly enough to distort the merged total still flags after "
+                + "the fold — the warning is not lost by summing")
+        expect(
+            onlyRow([costEntry(100_000, nil, provider: "a"), costEntry(1, 1, provider: "b")])
+                .costEstimate == nil,
+            "one unpriceable component makes the merged estimate a partial denominator, "
+                + "which would overstate the ratio — the merged row reports no estimate instead")
+
         // Usage attribution: declarations are explicit, provider-level by
         // default, and model overrides are more specific. Suggestions never
         // participate in effective-state resolution.

--- a/Sources/TokenBar/Views/ModelBreakdownCard.swift
+++ b/Sources/TokenBar/Views/ModelBreakdownCard.swift
@@ -271,14 +271,26 @@ struct ModelUsageTooltip: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 5) {
+            HStack(alignment: .top, spacing: 5) {
                 Circle()
                     .fill(Color(hex: color))
                     .frame(width: 6, height: 6)
+                    // Keeps the dot on the first line's optical centre once
+                    // the name below wraps to a second one.
+                    .padding(.top, 3)
+                // Wraps instead of truncating: the rows themselves have to
+                // middle-truncate (a fixed-width column), so this is the only
+                // place a long identifier can be read in full —
+                // `deepseek/deepseek-v4-flash-vision-exp` and other provider-
+                // prefixed OpenRouter names exceed the 210pt panel on one
+                // line. Three lines is roughly 90 characters, past any real
+                // model id, with middle truncation still the last resort so
+                // corrupt input cannot grow the panel without bound.
                 Text(model)
                     .font(.caption.weight(.semibold))
-                    .lineLimit(1)
+                    .lineLimit(3)
                     .truncationMode(.middle)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             Text([context, provider].compactMap { $0 }.joined(separator: " · "))
                 .font(.caption2)

--- a/Sources/TokenBar/Views/ModelBreakdownCard.swift
+++ b/Sources/TokenBar/Views/ModelBreakdownCard.swift
@@ -171,9 +171,15 @@ struct ModelBreakdownCard: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(Format.compactTokens(entry.total))
                     .font(.caption.monospacedDigit())
-                Text(Format.usd(entry.cost))
-                    .font(.caption2.monospacedDigit())
-                    .foregroundStyle(Color(hex: "#22c55e"))
+                HStack(spacing: 3) {
+                    if entry.costRatio != nil {
+                        Image(systemName: CostPlausibility.symbol)
+                            .foregroundStyle(Color(hex: CostPlausibility.warningColor))
+                    }
+                    Text(Format.usd(entry.cost))
+                        .foregroundStyle(Color(hex: "#22c55e"))
+                }
+                .font(.caption2.monospacedDigit())
             }
         }
         // Float the rich tooltip near the cursor anywhere on the row — the
@@ -233,6 +239,7 @@ struct ModelBreakdownCard: View {
             reasoning: entry.reasoning,
             total: entry.total,
             cost: entry.cost,
+            costRatio: entry.costRatio,
             measuredSize: $tooltipSize)
     }
 }
@@ -251,6 +258,9 @@ struct ModelUsageTooltip: View {
     let reasoning: Int64
     let total: Int64
     let cost: Double
+    /// See `ModelReportEntry.costRatio`. Defaults to nil so the day/month
+    /// slice callers, which have no pricing comparison, need not pass it.
+    var costRatio: Double? = nil
     @Binding var measuredSize: CGSize
 
     private var kinds: [(label: String, color: String, value: Int64)] {
@@ -280,6 +290,16 @@ struct ModelUsageTooltip: View {
             }
             .font(.caption2)
             .foregroundStyle(.secondary)
+            if let costRatio {
+                // Named in multiples rather than "wrong": the app cannot know
+                // the client's real rate, only that this is far off any price
+                // the local table can justify.
+                Text("Cost reported by the client, about %@x the local price estimate"
+                    .localized(Format.compactRatio(costRatio)))
+                    .font(.caption2)
+                    .foregroundStyle(Color(hex: CostPlausibility.warningColor))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             ForEach(kinds, id: \.label) { kind in
                 HStack(spacing: 4) {
                     RoundedRectangle(cornerRadius: 1.5)
@@ -305,4 +325,16 @@ struct ModelUsageTooltip: View {
 extension ModelReportEntry {
     /// Stable row identity across re-sorts (client+model+provider triple).
     var rowID: String { "\(client)|\(model)|\(provider)" }
+}
+
+/// Presentation for a cost the local pricing table cannot justify. The
+/// decision itself is made in Rust (`implausible_cost_ratio`); this only says
+/// how it looks.
+enum CostPlausibility {
+    /// Amber, not red: the row is untrustworthy, not broken — the tokens are
+    /// still real and the client may yet be right about its own rate.
+    static let warningColor = "#f59e0b"
+
+    /// Shown beside the cost on a flagged row.
+    static let symbol = "exclamationmark.triangle.fill"
 }

--- a/Sources/TokenBar/Views/ModelBreakdownCard.swift
+++ b/Sources/TokenBar/Views/ModelBreakdownCard.swift
@@ -172,7 +172,7 @@ struct ModelBreakdownCard: View {
                 Text(Format.compactTokens(entry.total))
                     .font(.caption.monospacedDigit())
                 HStack(spacing: 3) {
-                    if entry.costRatio != nil {
+                    if entry.implausibleCostRatio != nil {
                         Image(systemName: CostPlausibility.symbol)
                             .foregroundStyle(Color(hex: CostPlausibility.warningColor))
                     }
@@ -239,7 +239,7 @@ struct ModelBreakdownCard: View {
             reasoning: entry.reasoning,
             total: entry.total,
             cost: entry.cost,
-            costRatio: entry.costRatio,
+            costRatio: entry.implausibleCostRatio,
             measuredSize: $tooltipSize)
     }
 }
@@ -258,7 +258,7 @@ struct ModelUsageTooltip: View {
     let reasoning: Int64
     let total: Int64
     let cost: Double
-    /// See `ModelReportEntry.costRatio`. Defaults to nil so the day/month
+    /// See `ModelReportEntry.implausibleCostRatio`. Defaults to nil so the day/month
     /// slice callers, which have no pricing comparison, need not pass it.
     var costRatio: Double? = nil
     @Binding var measuredSize: CGSize
@@ -327,14 +327,3 @@ extension ModelReportEntry {
     var rowID: String { "\(client)|\(model)|\(provider)" }
 }
 
-/// Presentation for a cost the local pricing table cannot justify. The
-/// decision itself is made in Rust (`implausible_cost_ratio`); this only says
-/// how it looks.
-enum CostPlausibility {
-    /// Amber, not red: the row is untrustworthy, not broken — the tokens are
-    /// still real and the client may yet be right about its own rate.
-    static let warningColor = "#f59e0b"
-
-    /// Shown beside the cost on a flagged row.
-    static let symbol = "exclamationmark.triangle.fill"
-}

--- a/Sources/TokenBar/Views/ModelBreakdownCard.swift
+++ b/Sources/TokenBar/Views/ModelBreakdownCard.swift
@@ -172,9 +172,14 @@ struct ModelBreakdownCard: View {
                 Text(Format.compactTokens(entry.total))
                     .font(.caption.monospacedDigit())
                 HStack(spacing: 3) {
-                    if entry.implausibleCostRatio != nil {
+                    if let ratio = entry.implausibleCostRatio {
                         Image(systemName: CostPlausibility.symbol)
                             .foregroundStyle(Color(hex: CostPlausibility.warningColor))
+                            // See ModelsView: the tooltip carrying this
+                            // explanation is pointer-only, so the icon needs
+                            // to say it itself.
+                            .accessibilityLabel(
+                                CostPlausibility.warningText(ratio))
                     }
                     Text(Format.usd(entry.cost))
                         .foregroundStyle(Color(hex: "#22c55e"))
@@ -280,15 +285,28 @@ struct ModelUsageTooltip: View {
                     .padding(.top, 3)
                 // Wraps instead of truncating: the rows themselves have to
                 // middle-truncate (a fixed-width column), so this is the only
-                // place a long identifier can be read in full —
-                // `deepseek/deepseek-v4-flash-vision-exp` and other provider-
-                // prefixed OpenRouter names exceed the 210pt panel on one
-                // line. Three lines is roughly 90 characters, past any real
-                // model id, with middle truncation still the last resort so
-                // corrupt input cannot grow the panel without bound.
+                // place a long identifier can be read in full.
+                //
+                // Measured, not estimated — caption1 is 10pt and the text has
+                // 183pt after the panel's padding, the dot and the spacing,
+                // giving a 12pt line height:
+                //
+                //     deepseek/deepseek-v4-flash-vision-exp   37 chars, 2 lines
+                //     nousresearch/hermes-3-llama-3.1-405b-…  45 chars, 2 lines
+                //     4-line capacity                         76 chars worst
+                //                                             case (all 'm'),
+                //                                             102 for a mixed
+                //                                             model-id alphabet
+                //
+                // The longest identifiers in circulation are around 45
+                // characters, so four lines clears them by more than half
+                // again. The cap stays because middle truncation is the last
+                // resort against corrupt input growing the panel without
+                // bound; `lineLimit` costs nothing on the ordinary one- and
+                // two-line names.
                 Text(model)
                     .font(.caption.weight(.semibold))
-                    .lineLimit(3)
+                    .lineLimit(4)
                     .truncationMode(.middle)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -306,8 +324,7 @@ struct ModelUsageTooltip: View {
                 // Named in multiples rather than "wrong": the app cannot know
                 // the client's real rate, only that this is far off any price
                 // the local table can justify.
-                Text("Cost reported by the client, about %@x the local price estimate"
-                    .localized(Format.compactRatio(costRatio)))
+                Text(CostPlausibility.warningText(costRatio))
                     .font(.caption2)
                     .foregroundStyle(Color(hex: CostPlausibility.warningColor))
                     .fixedSize(horizontal: false, vertical: true)
@@ -337,5 +354,19 @@ struct ModelUsageTooltip: View {
 extension ModelReportEntry {
     /// Stable row identity across re-sorts (client+model+provider triple).
     var rowID: String { "\(client)|\(model)|\(provider)" }
+}
+
+extension CostPlausibility {
+    /// The one wording for a flagged cost, used by the tooltip line and by the
+    /// icon's accessibility label. Both have to say the same thing, and the
+    /// icon is the only channel a VoiceOver or keyboard user has — the tooltip
+    /// that carries this text is summoned by a pointer and nothing else.
+    ///
+    /// Lives here rather than beside the threshold in TokenBarCore because it
+    /// needs `Format` and `.localized`, which are TokenBar-side.
+    static func warningText(_ ratio: Double) -> String {
+        "Cost reported by the client, about %@x the local price estimate"
+            .localized(Format.compactRatio(ratio))
+    }
 }
 

--- a/Sources/TokenBar/Views/ModelsView.swift
+++ b/Sources/TokenBar/Views/ModelsView.swift
@@ -139,9 +139,15 @@ struct ModelsView: View {
                 Text(Format.compactTokens(entry.total))
                     .font(.caption.monospacedDigit())
                 HStack(spacing: 3) {
-                    if entry.implausibleCostRatio != nil {
+                    if let ratio = entry.implausibleCostRatio {
                         Image(systemName: CostPlausibility.symbol)
                             .foregroundStyle(Color(hex: CostPlausibility.warningColor))
+                            // The explanation otherwise lives only in the
+                            // hover tooltip, which a pointer is the only way
+                            // to summon — so without this the icon is the
+                            // whole message and it says nothing.
+                            .accessibilityLabel(
+                                CostPlausibility.warningText(ratio))
                     }
                     Text(Format.usd(entry.cost))
                         .foregroundStyle(Color(hex: "#22c55e"))

--- a/Sources/TokenBar/Views/ModelsView.swift
+++ b/Sources/TokenBar/Views/ModelsView.swift
@@ -14,6 +14,18 @@ struct ModelsView: View {
     /// fetch is not the same as a completed fetch that found nothing.
     var loading = false
 
+    @State private var hover: HoverState?
+    @State private var tooltipSize: CGSize = .zero
+    @Environment(\.popoverScrollViewport) private var popoverScrollViewport
+
+    private struct HoverState {
+        let entry: ModelReportEntry
+        /// Cursor location in the rows container's coordinate space.
+        let point: CGPoint
+    }
+
+    private static let rowsSpace = "models-rows"
+
     private static let kinds: [(label: String, pick: (ModelReportEntry) -> Int64)] = [
         ("In", { $0.input }),
         ("Out", { $0.output }),
@@ -63,23 +75,52 @@ struct ModelsView: View {
                         row(entry, totalCost: totalCost)
                     }
                 }
+                .coordinateSpace(name: Self.rowsSpace)
+                .overlay(alignment: .topLeading) {
+                    if let hover {
+                        GeometryReader { geo in
+                            let measuredSize = tooltipSize == .zero
+                                ? CGSize(width: ModelUsageTooltip.width, height: 120)
+                                : tooltipSize
+                            let offset = PopoverTooltipPlacement.offset(
+                                anchor: hover.point,
+                                tooltipSize: measuredSize,
+                                containerFrame: geo.frame(in: .global),
+                                viewport: popoverScrollViewport)
+                            tooltip(hover.entry)
+                                .offset(offset ?? .zero)
+                        }
+                        // GeometryReader fills the rows; keep hits on the rows
+                        // so continuous hover does not end while the tooltip
+                        // is up.
+                        .allowsHitTesting(false)
+                    }
+                }
             }
         }
     }
 
     private func row(_ entry: ModelReportEntry, totalCost: Double) -> some View {
         let share = totalCost > 0 ? entry.cost / totalCost * 100 : 0
+        let isHovered = hover?.entry.rowID == entry.rowID
         return HStack(spacing: 8) {
             Circle()
                 .fill(Color(hex: colors.color(entry.provider, entry.model)))
                 .frame(width: 8, height: 8)
+                .overlay {
+                    Circle().stroke(
+                        Color.primary.opacity(isHovered ? 0.85 : 0),
+                        lineWidth: 1)
+                }
+                .shadow(
+                    color: Color.primary.opacity(isHovered ? 0.65 : 0),
+                    radius: isHovered ? 3 : 0)
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(entry.model)
                         .font(.caption)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                        .help("\(entry.model) · \(ClientRegistry.style(entry.client).displayName)")
                     Text(String(format: "%.1f%%", share))
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.tertiary)
@@ -102,5 +143,39 @@ struct ModelsView: View {
                     .foregroundStyle(Color(hex: "#22c55e"))
             }
         }
+        // Whole-row hit area and a hand-drawn tooltip, matching
+        // ModelBreakdownCard/DailyView. The old `.help` only covered the model
+        // name's glyph rect and carried AppKit's tooltip delay.
+        .contentShape(Rectangle())
+        .onContinuousHover(coordinateSpace: .named(Self.rowsSpace)) { phase in
+            switch phase {
+            case let .active(point):
+                hover = HoverState(entry: entry, point: point)
+            case .ended:
+                // Guard on identity: this list scrolls, so an `.ended` from a
+                // row the cursor already left must not clear the current one.
+                if hover?.entry.rowID == entry.rowID {
+                    hover = nil
+                }
+            }
+        }
+    }
+
+    // MARK: - Hover tooltip
+
+    private func tooltip(_ entry: ModelReportEntry) -> some View {
+        ModelUsageTooltip(
+            model: entry.model,
+            provider: entry.provider,
+            context: ClientRegistry.style(entry.client).displayName,
+            color: colors.color(entry.provider, entry.model),
+            input: entry.input,
+            output: entry.output,
+            cacheRead: entry.cacheRead,
+            cacheWrite: entry.cacheWrite,
+            reasoning: entry.reasoning,
+            total: entry.total,
+            cost: entry.cost,
+            measuredSize: $tooltipSize)
     }
 }

--- a/Sources/TokenBar/Views/ModelsView.swift
+++ b/Sources/TokenBar/Views/ModelsView.swift
@@ -138,9 +138,15 @@ struct ModelsView: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(Format.compactTokens(entry.total))
                     .font(.caption.monospacedDigit())
-                Text(Format.usd(entry.cost))
-                    .font(.caption2.monospacedDigit())
-                    .foregroundStyle(Color(hex: "#22c55e"))
+                HStack(spacing: 3) {
+                    if entry.costRatio != nil {
+                        Image(systemName: CostPlausibility.symbol)
+                            .foregroundStyle(Color(hex: CostPlausibility.warningColor))
+                    }
+                    Text(Format.usd(entry.cost))
+                        .foregroundStyle(Color(hex: "#22c55e"))
+                }
+                .font(.caption2.monospacedDigit())
             }
         }
         // Whole-row hit area and a hand-drawn tooltip, matching
@@ -176,6 +182,7 @@ struct ModelsView: View {
             reasoning: entry.reasoning,
             total: entry.total,
             cost: entry.cost,
+            costRatio: entry.costRatio,
             measuredSize: $tooltipSize)
     }
 }

--- a/Sources/TokenBar/Views/ModelsView.swift
+++ b/Sources/TokenBar/Views/ModelsView.swift
@@ -139,7 +139,7 @@ struct ModelsView: View {
                 Text(Format.compactTokens(entry.total))
                     .font(.caption.monospacedDigit())
                 HStack(spacing: 3) {
-                    if entry.costRatio != nil {
+                    if entry.implausibleCostRatio != nil {
                         Image(systemName: CostPlausibility.symbol)
                             .foregroundStyle(Color(hex: CostPlausibility.warningColor))
                     }
@@ -182,7 +182,7 @@ struct ModelsView: View {
             reasoning: entry.reasoning,
             total: entry.total,
             cost: entry.cost,
-            costRatio: entry.costRatio,
+            costRatio: entry.implausibleCostRatio,
             measuredSize: $tooltipSize)
     }
 }

--- a/Sources/TokenBarCore/ModelReport.swift
+++ b/Sources/TokenBarCore/ModelReport.swift
@@ -17,6 +17,17 @@ public struct ModelReportEntry: Decodable, Sendable {
     public let messageCount: Int
     public let cost: Double
     public let msPer1kTokens: Double?
+    /// Set only when `cost` exceeds the local pricing estimate by an
+    /// implausible multiple — a client that reports its own cost (OpenCode,
+    /// MiMo Code) has that figure taken verbatim, so a unit error upstream
+    /// reaches this row unchallenged. The value is that multiple. `nil` is the
+    /// normal case and also covers rows the check could not evaluate (no
+    /// cached pricing table, or a model the table cannot price at all). See
+    /// `implausible_cost_ratio` in crates/tb_core_ffi/src/model_report.rs.
+    ///
+    /// Optional so a report serialized before this field existed still
+    /// decodes.
+    public let costRatio: Double?
 }
 
 public struct ModelReport: Decodable, Sendable {
@@ -73,7 +84,14 @@ public extension ModelReport {
                     ? Int.max
                     : messageCount.partialValue,
                 cost: current.cost + entry.cost,
-                msPer1kTokens: nil
+                msPer1kTokens: nil,
+                // The merged cost is a sum across providers, so no single
+                // ratio describes it any more. Keep the largest of the
+                // contributing rows: the flag has to survive the fold (one
+                // broken provider still makes the merged total wrong), and the
+                // worst multiple is the honest thing to name when the row is
+                // pointed at.
+                costRatio: [current.costRatio, entry.costRatio].compactMap { $0 }.max()
             )
         }
         return folded

--- a/Sources/TokenBarCore/ModelReport.swift
+++ b/Sources/TokenBarCore/ModelReport.swift
@@ -17,17 +17,69 @@ public struct ModelReportEntry: Decodable, Sendable {
     public let messageCount: Int
     public let cost: Double
     public let msPer1kTokens: Double?
-    /// Set only when `cost` exceeds the local pricing estimate by an
-    /// implausible multiple — a client that reports its own cost (OpenCode,
-    /// MiMo Code) has that figure taken verbatim, so a unit error upstream
-    /// reaches this row unchallenged. The value is that multiple. `nil` is the
-    /// normal case and also covers rows the check could not evaluate (no
-    /// cached pricing table, or a model the table cannot price at all). See
-    /// `implausible_cost_ratio` in crates/tb_core_ffi/src/model_report.rs.
+    /// What the local pricing table would charge for this row's tokens; `nil`
+    /// when it cannot price them (no cached dataset, or a model it does not
+    /// carry). See `local_cost_estimate` in
+    /// crates/tb_core_ffi/src/model_report.rs.
     ///
     /// Optional so a report serialized before this field existed still
     /// decodes.
-    public let costRatio: Double?
+    public let costEstimate: Double?
+}
+
+public extension ModelReportEntry {
+    /// How many times `cost` exceeds what the local pricing table would
+    /// charge, when that multiple is large enough to call the cost broken;
+    /// `nil` otherwise.
+    ///
+    /// A client that reports its own per-message cost (OpenCode, MiMo Code)
+    /// has that figure taken verbatim by tokscale-core — it never meets a
+    /// pricing table — so a unit error upstream reaches the row unchallenged.
+    /// This is the only thing standing between that and the number on screen.
+    ///
+    /// Computed here rather than in Rust because it must be evaluated AFTER
+    /// `modelLevelEntries` folds the provider-split rows together: one
+    /// component at 100x merged with a larger healthy row is a merged 1.1x,
+    /// and describing the merged cost with the component's ratio would be
+    /// materially false.
+    ///
+    /// One-directional. Rows measured on real data run 0.1-0.3x of the
+    /// estimate (the table prices dearer than OpenCode actually bills), and a
+    /// genuinely free model reports 0.0 against a positive estimate; a
+    /// two-sided check would flag both forever.
+    var implausibleCostRatio: Double? {
+        guard let costEstimate, costEstimate > 0, cost.isFinite, cost > 0 else { return nil }
+        let ratio = cost / costEstimate
+        return ratio > CostPlausibility.threshold ? ratio : nil
+    }
+}
+
+/// Where a self-reported cost stops being expensive and starts being broken.
+public enum CostPlausibility {
+    /// Measured against real local data, LiteLLM estimate vs OpenCode's own
+    /// figure:
+    ///
+    ///     deepseek-v4-flash (default)          0.7139 /    2.5719 =   0.3x
+    ///     deepseek-v4-flash (low)              0.2943 /    1.0470 =   0.3x
+    ///     deepseek-v4-pro                      3.9039 /   26.4468 =   0.1x
+    ///     deepseek-v4-flash @ exptech (user) 5495.30  /   17.84   = 308x
+    ///     deepseek-v4-flash-free    (user)   3174.69  /    9.79   = 324x
+    ///
+    /// Healthy rows top out near 0.3x, so the threshold is nowhere near 1.0.
+    /// 50x leaves two orders of magnitude of headroom above every healthy row
+    /// while still catching the reporter's, which matters because the estimate
+    /// is only approximate: the lookup can match a near-miss key
+    /// (`deepseek-v4-flash-free` resolves to the paid `deepseek-v4-flash`
+    /// entry) or a row missing cache rates, each skewing it by single-digit
+    /// multiples. Nothing short of a unit-scale error clears 50x.
+    public static let threshold: Double = 50
+
+    /// Amber, not red: the row is untrustworthy, not broken — the tokens are
+    /// real and the client may yet be right about its own rate.
+    public static let warningColor = "#f59e0b"
+
+    /// Shown beside the cost on a flagged row.
+    public static let symbol = "exclamationmark.triangle.fill"
 }
 
 public struct ModelReport: Decodable, Sendable {
@@ -85,13 +137,15 @@ public extension ModelReport {
                     : messageCount.partialValue,
                 cost: current.cost + entry.cost,
                 msPer1kTokens: nil,
-                // The merged cost is a sum across providers, so no single
-                // ratio describes it any more. Keep the largest of the
-                // contributing rows: the flag has to survive the fold (one
-                // broken provider still makes the merged total wrong), and the
-                // worst multiple is the honest thing to name when the row is
-                // pointed at.
-                costRatio: [current.costRatio, entry.costRatio].compactMap { $0 }.max()
+                // Sum the estimates alongside the costs, so the ratio taken
+                // from the merged row describes the merged cost. All-or-
+                // nothing: if any contributing provider could not be priced,
+                // the sum is a partial denominator that would overstate the
+                // ratio for the whole row, so the merged row reports no
+                // estimate rather than a misleading one.
+                costEstimate: current.costEstimate.flatMap { c in
+                    entry.costEstimate.map { c + $0 }
+                }
             )
         }
         return folded

--- a/crates/tb_core_ffi/src/model_report.rs
+++ b/crates/tb_core_ffi/src/model_report.rs
@@ -28,13 +28,16 @@ struct ModelEntry {
     /// Milliseconds per 1K tokens, when tokscale could time the model. `None`
     /// when no message in the rollup carried a usable duration.
     ms_per_1k_tokens: Option<f64>,
-    /// How many times larger this row's cost is than what the local pricing
-    /// table would charge for the same tokens — set ONLY when that multiple
-    /// clears `IMPLAUSIBLE_COST_RATIO`, so a value here means "this number is
-    /// not trustworthy", not "here is a ratio". `None` is the normal case and
-    /// also covers every row the check could not evaluate. See
-    /// `implausible_cost_ratio`.
-    cost_ratio: Option<f64>,
+    /// What the local pricing table would charge for this row's tokens, or
+    /// `None` when it cannot price them at all.
+    ///
+    /// Reported rather than judged here on purpose. The frontend folds these
+    /// provider-split rows together by client+model, and a ratio computed
+    /// before that fold cannot describe the merged cost — one component at
+    /// 100x combined with a larger healthy one is a merged 1.1x, not 100x. So
+    /// this ships the estimate and the comparison happens after the fold, in
+    /// `ModelReportEntry.implausibleCostRatio`.
+    cost_estimate: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -91,51 +94,28 @@ pub(crate) fn run(context: &crate::LocalSourceContext, year: &str) -> Result<Val
     serde_json::to_value(data).map_err(|e| format!("serialize model report: {}", e))
 }
 
-/// A provider-reported cost this many times the local pricing table's estimate
-/// is treated as broken rather than expensive.
+/// What the local pricing table would charge for this row's tokens, or `None`
+/// when it cannot price them.
 ///
-/// Clients that record their own per-message cost (OpenCode, MiMo Code) have
-/// it taken verbatim: tokscale-core's `apply_pricing_if_available` returns
-/// early on `has_authoritative_cost()`, so no pricing table ever sees those
-/// rows. That is the right default — the client knows its own contract — but
-/// it also means a unit error upstream (a per-1K rate applied per-token, a
-/// non-USD figure) reaches the UI with nothing in between.
+/// This exists because clients that record their own per-message cost
+/// (OpenCode, MiMo Code) have it taken verbatim: tokscale-core's
+/// `apply_pricing_if_available` returns early on `has_authoritative_cost()`,
+/// so no pricing table ever sees those rows. That default is right — the
+/// client knows its own billing contract — but it also means a unit error
+/// upstream (a per-1K rate applied per-token, a non-USD figure, a mispriced
+/// custom provider) reaches the UI with nothing in between. Shipping the
+/// estimate alongside the cost gives the frontend something to compare
+/// against; what counts as implausible is decided there, after the
+/// provider-split rows have been folded together.
 ///
-/// Measured on real local data, LiteLLM estimate vs OpenCode's own figure:
-///
-/// | row                              | reported | estimate | ratio  |
-/// |----------------------------------|----------|----------|--------|
-/// | deepseek-v4-flash (default)      |   0.7139 |   2.5719 |   0.3x |
-/// | deepseek-v4-flash (low)          |   0.2943 |   1.0470 |   0.3x |
-/// | deepseek-v4-pro                  |   3.9039 |  26.4468 |   0.1x |
-/// | deepseek-v4-flash (user report)  | 8647.24  |  27.8316 | 310.7x |
-///
-/// Healthy rows sit at 0.1-0.3x (the table runs a few times dearer than what
-/// OpenCode actually bills), so the floor is not near 1.0 and the threshold
-/// must not be either. 50x leaves two orders of magnitude of headroom above
-/// every healthy row while still catching the 310x case, which matters
-/// because the estimate itself is only approximate: the lookup can match a
-/// near-miss key (`deepseek-v4-flash-free` resolves to `deepseek-v4-flash`)
-/// or a row missing cache rates, and either skews it by single-digit
-/// multiples. Nothing short of a unit-scale error clears 50x.
-const IMPLAUSIBLE_COST_RATIO: f64 = 50.0;
-
-/// The multiple by which `cost` exceeds the local pricing estimate, when that
-/// is high enough to call the cost broken; `None` otherwise.
-///
-/// Deliberately one-directional. A row costing *less* than the estimate is the
-/// normal case above, and a genuinely free model (`deepseek-v4-flash-free`
-/// reports 0.0 against a 0.0384 estimate) would be flagged forever by a
-/// two-sided check. An absent or zero estimate means the table cannot price
-/// these tokens at all, which is not evidence about the reported cost.
-fn implausible_cost_ratio(
+/// A zero or non-finite estimate is reported as `None`: the table cannot
+/// price these tokens at all, which is not evidence about the reported cost
+/// and must not become a division by zero downstream.
+fn local_cost_estimate(
     pricing: Option<&tokscale_core::pricing::PricingService>,
     entry: &tokscale_core::ModelUsage,
 ) -> Option<f64> {
     let pricing = pricing?;
-    if !entry.cost.is_finite() || entry.cost <= 0.0 {
-        return None;
-    }
     let usage = tokscale_core::TokenBreakdown {
         input: entry.input,
         output: entry.output,
@@ -144,11 +124,7 @@ fn implausible_cost_ratio(
         reasoning: entry.reasoning,
     };
     let estimate = pricing.calculate_cost_with_provider(&entry.model, Some(&entry.provider), &usage);
-    if !estimate.is_finite() || estimate <= 0.0 {
-        return None;
-    }
-    let ratio = entry.cost / estimate;
-    (ratio > IMPLAUSIBLE_COST_RATIO).then_some(ratio)
+    (estimate.is_finite() && estimate > 0.0).then_some(estimate)
 }
 
 fn normalize_year(year: &str) -> Result<Option<String>, String> {
@@ -172,7 +148,7 @@ fn map_report(
             .entries
             .into_iter()
             .map(|e| {
-                let cost_ratio = implausible_cost_ratio(pricing, &e);
+                let cost_estimate = local_cost_estimate(pricing, &e);
                 // saturating_add so #766's i64::MAX-clamped buckets (corrupt
                 // Antigravity DB) can't overflow this FFI-exposed total in
                 // debug/release (see agents_report.rs's map_report for the
@@ -196,7 +172,7 @@ fn map_report(
                     message_count: e.message_count,
                     cost: e.cost,
                     ms_per_1k_tokens: e.performance.ms_per_1k_tokens,
-                    cost_ratio,
+                    cost_estimate,
                 }
             })
             .collect(),
@@ -634,8 +610,8 @@ mod tests {
         tokscale_core::pricing::PricingService::new(litellm, std::collections::HashMap::new())
     }
 
-    /// 1M input tokens against the table above estimates to exactly $1.00, so
-    /// `cost` doubles as the ratio and each case below states its own multiple.
+    /// 1M input tokens, which the table above prices at exactly $1.00 — so
+    /// every expected estimate below is a round number this test states.
     fn priced_entry(model: &str, cost: f64) -> tokscale_core::ModelUsage {
         let mut e = entry(1_000_000, 0, 0, 0, 0);
         e.model = model.to_string();
@@ -645,80 +621,58 @@ mod tests {
     }
 
     #[test]
-    fn implausible_cost_is_flagged_with_its_ratio() {
+    fn priced_model_reports_the_table_estimate() {
         let service = priced_service("m");
-        // The shape of the user report: a per-1K rate billed per-token.
-        let ratio = implausible_cost_ratio(Some(&service), &priced_entry("m", 1000.0));
-        assert_eq!(ratio, Some(1000.0));
-    }
-
-    #[test]
-    fn plausible_cost_is_not_flagged() {
-        let service = priced_service("m");
-        // Every healthy row measured on real data sat at or below 1.0x; even a
-        // client billing 10x the table's rate stays quiet.
-        for cost in [0.1, 1.0, 10.0, IMPLAUSIBLE_COST_RATIO] {
+        // Independent of `cost`: the estimate describes the tokens, and the
+        // comparison against cost happens downstream, after the fold.
+        for cost in [0.0, 1.0, 1000.0, f64::NAN] {
             assert_eq!(
-                implausible_cost_ratio(Some(&service), &priced_entry("m", cost)),
-                None,
-                "{cost} should not be flagged"
+                local_cost_estimate(Some(&service), &priced_entry("m", cost)),
+                Some(1.0),
+                "cost {cost} must not change the estimate"
             );
         }
-        // Just past the threshold it is. Pins the boundary from both sides, so
-        // a comparison flipped to `>=`/`<` cannot pass this pair.
-        assert!(
-            implausible_cost_ratio(
-                Some(&service),
-                &priced_entry("m", IMPLAUSIBLE_COST_RATIO + 0.5)
-            )
-            .is_some(),
-            "just above the threshold should be flagged"
-        );
     }
 
     #[test]
-    fn unpriced_model_is_never_flagged() {
+    fn estimate_scales_with_the_tokens() {
+        // Pins that the tokens actually reach the pricing call: a version that
+        // priced a fixed or empty breakdown would return Some(1.0) here too.
         let service = priced_service("m");
-        // The table cannot price this model at all, so an enormous cost is not
-        // evidence of anything. Without the estimate > 0 guard the division
-        // would be by zero and every unpriced row would be flagged.
-        assert_eq!(
-            implausible_cost_ratio(Some(&service), &priced_entry("other", 99_999.0)),
-            None
-        );
+        let mut e = priced_entry("m", 1.0);
+        e.input = 3_000_000;
+        assert_eq!(local_cost_estimate(Some(&service), &e), Some(3.0));
     }
 
     #[test]
-    fn free_and_absent_costs_are_never_flagged() {
+    fn unpriceable_rows_report_no_estimate() {
         let service = priced_service("m");
-        // A genuinely free model reports 0.0 against a positive estimate; a
-        // two-sided check would flag it on every refresh forever.
+        // A model the table does not carry. Reported as None rather than 0.0
+        // so the frontend cannot divide by it.
         assert_eq!(
-            implausible_cost_ratio(Some(&service), &priced_entry("m", 0.0)),
+            local_cost_estimate(Some(&service), &priced_entry("other", 99_999.0)),
             None
         );
-        assert_eq!(
-            implausible_cost_ratio(Some(&service), &priced_entry("m", f64::NAN)),
-            None
-        );
-        // No cached table (first run, offline): the check disables itself
-        // rather than reporting against a table that isn't there.
-        assert_eq!(implausible_cost_ratio(None, &priced_entry("m", 1000.0)), None);
+        // No cached table at all (first run, offline).
+        assert_eq!(local_cost_estimate(None, &priced_entry("m", 1000.0)), None);
+        // Zero tokens price to 0.0, which is not a usable denominator either.
+        let mut empty = priced_entry("m", 1000.0);
+        empty.input = 0;
+        assert_eq!(local_cost_estimate(Some(&service), &empty), None);
     }
 
     #[test]
-    fn flagged_ratio_reaches_the_serialized_entry() {
-        // The three cases above test the predicate directly; this one proves
-        // map_report actually carries it onto the wire shape the UI decodes,
-        // under the key Swift reads.
+    fn estimate_reaches_the_serialized_entry() {
+        // The cases above test the function directly; this one proves
+        // map_report carries it onto the wire shape, under the key Swift reads.
         let service = priced_service("m");
-        let report = wrap(vec![priced_entry("m", 1000.0), priced_entry("m", 1.0)]);
+        let report = wrap(vec![priced_entry("m", 1000.0), priced_entry("other", 1.0)]);
         let mapped = map_report(report, Some(&service));
-        assert_eq!(mapped.entries[0].cost_ratio, Some(1000.0));
-        assert_eq!(mapped.entries[1].cost_ratio, None);
+        assert_eq!(mapped.entries[0].cost_estimate, Some(1.0));
+        assert_eq!(mapped.entries[1].cost_estimate, None);
 
         let json = serde_json::to_value(&mapped).unwrap();
-        assert_eq!(json["entries"][0]["costRatio"], serde_json::json!(1000.0));
-        assert!(json["entries"][1]["costRatio"].is_null());
+        assert_eq!(json["entries"][0]["costEstimate"], serde_json::json!(1.0));
+        assert!(json["entries"][1]["costEstimate"].is_null());
     }
 }

--- a/crates/tb_core_ffi/src/model_report.rs
+++ b/crates/tb_core_ffi/src/model_report.rs
@@ -28,6 +28,13 @@ struct ModelEntry {
     /// Milliseconds per 1K tokens, when tokscale could time the model. `None`
     /// when no message in the rollup carried a usable duration.
     ms_per_1k_tokens: Option<f64>,
+    /// How many times larger this row's cost is than what the local pricing
+    /// table would charge for the same tokens — set ONLY when that multiple
+    /// clears `IMPLAUSIBLE_COST_RATIO`, so a value here means "this number is
+    /// not trustworthy", not "here is a ratio". `None` is the normal case and
+    /// also covers every row the check could not evaluate. See
+    /// `implausible_cost_ratio`.
+    cost_ratio: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -74,8 +81,74 @@ pub(crate) fn run(context: &crate::LocalSourceContext, year: &str) -> Result<Val
         .map_err(|e| format!("build runtime: {}", e))?;
     let report = runtime.block_on(tokscale_core::get_model_report(options))?;
 
-    let data = map_report(report);
+    // Read-only, no network: `get_model_report` has already refreshed and
+    // written this cache on its own path, and a cold cache (first ever run,
+    // offline) simply yields None, which disables the check rather than
+    // reporting on a table that isn't there.
+    let pricing = tokscale_core::pricing::PricingService::load_cached_any_age();
+
+    let data = map_report(report, pricing.as_ref());
     serde_json::to_value(data).map_err(|e| format!("serialize model report: {}", e))
+}
+
+/// A provider-reported cost this many times the local pricing table's estimate
+/// is treated as broken rather than expensive.
+///
+/// Clients that record their own per-message cost (OpenCode, MiMo Code) have
+/// it taken verbatim: tokscale-core's `apply_pricing_if_available` returns
+/// early on `has_authoritative_cost()`, so no pricing table ever sees those
+/// rows. That is the right default — the client knows its own contract — but
+/// it also means a unit error upstream (a per-1K rate applied per-token, a
+/// non-USD figure) reaches the UI with nothing in between.
+///
+/// Measured on real local data, LiteLLM estimate vs OpenCode's own figure:
+///
+/// | row                              | reported | estimate | ratio  |
+/// |----------------------------------|----------|----------|--------|
+/// | deepseek-v4-flash (default)      |   0.7139 |   2.5719 |   0.3x |
+/// | deepseek-v4-flash (low)          |   0.2943 |   1.0470 |   0.3x |
+/// | deepseek-v4-pro                  |   3.9039 |  26.4468 |   0.1x |
+/// | deepseek-v4-flash (user report)  | 8647.24  |  27.8316 | 310.7x |
+///
+/// Healthy rows sit at 0.1-0.3x (the table runs a few times dearer than what
+/// OpenCode actually bills), so the floor is not near 1.0 and the threshold
+/// must not be either. 50x leaves two orders of magnitude of headroom above
+/// every healthy row while still catching the 310x case, which matters
+/// because the estimate itself is only approximate: the lookup can match a
+/// near-miss key (`deepseek-v4-flash-free` resolves to `deepseek-v4-flash`)
+/// or a row missing cache rates, and either skews it by single-digit
+/// multiples. Nothing short of a unit-scale error clears 50x.
+const IMPLAUSIBLE_COST_RATIO: f64 = 50.0;
+
+/// The multiple by which `cost` exceeds the local pricing estimate, when that
+/// is high enough to call the cost broken; `None` otherwise.
+///
+/// Deliberately one-directional. A row costing *less* than the estimate is the
+/// normal case above, and a genuinely free model (`deepseek-v4-flash-free`
+/// reports 0.0 against a 0.0384 estimate) would be flagged forever by a
+/// two-sided check. An absent or zero estimate means the table cannot price
+/// these tokens at all, which is not evidence about the reported cost.
+fn implausible_cost_ratio(
+    pricing: Option<&tokscale_core::pricing::PricingService>,
+    entry: &tokscale_core::ModelUsage,
+) -> Option<f64> {
+    let pricing = pricing?;
+    if !entry.cost.is_finite() || entry.cost <= 0.0 {
+        return None;
+    }
+    let usage = tokscale_core::TokenBreakdown {
+        input: entry.input,
+        output: entry.output,
+        cache_read: entry.cache_read,
+        cache_write: entry.cache_write,
+        reasoning: entry.reasoning,
+    };
+    let estimate = pricing.calculate_cost_with_provider(&entry.model, Some(&entry.provider), &usage);
+    if !estimate.is_finite() || estimate <= 0.0 {
+        return None;
+    }
+    let ratio = entry.cost / estimate;
+    (ratio > IMPLAUSIBLE_COST_RATIO).then_some(ratio)
 }
 
 fn normalize_year(year: &str) -> Result<Option<String>, String> {
@@ -90,12 +163,16 @@ fn normalize_year(year: &str) -> Result<Option<String>, String> {
     }
 }
 
-fn map_report(report: tokscale_core::ModelReport) -> ModelReportData {
+fn map_report(
+    report: tokscale_core::ModelReport,
+    pricing: Option<&tokscale_core::pricing::PricingService>,
+) -> ModelReportData {
     ModelReportData {
         entries: report
             .entries
             .into_iter()
             .map(|e| {
+                let cost_ratio = implausible_cost_ratio(pricing, &e);
                 // saturating_add so #766's i64::MAX-clamped buckets (corrupt
                 // Antigravity DB) can't overflow this FFI-exposed total in
                 // debug/release (see agents_report.rs's map_report for the
@@ -119,6 +196,7 @@ fn map_report(report: tokscale_core::ModelReport) -> ModelReportData {
                     message_count: e.message_count,
                     cost: e.cost,
                     ms_per_1k_tokens: e.performance.ms_per_1k_tokens,
+                    cost_ratio,
                 }
             })
             .collect(),
@@ -513,7 +591,7 @@ mod tests {
     #[test]
     fn total_saturates_on_overlarge_buckets() {
         let report = wrap(vec![entry(i64::MAX, i64::MAX, 0, 0, 0)]);
-        let mapped = map_report(report);
+        let mapped = map_report(report, None);
         assert_eq!(mapped.entries[0].total, i64::MAX);
     }
 
@@ -524,7 +602,7 @@ mod tests {
     #[test]
     fn total_saturates_when_cache_write_is_overlarge() {
         let report = wrap(vec![entry(10, 20, i64::MAX, i64::MAX, 5)]);
-        let mapped = map_report(report);
+        let mapped = map_report(report, None);
         assert_eq!(mapped.entries[0].total, i64::MAX);
     }
 
@@ -534,7 +612,113 @@ mod tests {
     #[test]
     fn total_includes_every_token_field() {
         let report = wrap(vec![entry(1, 2, 4, 8, 16)]);
-        let mapped = map_report(report);
+        let mapped = map_report(report, None);
         assert_eq!(mapped.entries[0].total, 31);
+    }
+
+    // MARK: - Implausible-cost guard
+
+    /// A hermetic stand-in for the LiteLLM table: one priced model at
+    /// $1.00 per 1M input tokens and nothing else, so every estimate below is
+    /// a number this test states rather than one the shipping dataset supplies
+    /// (which would drift with upstream and make the assertions meaningless).
+    fn priced_service(model: &str) -> tokscale_core::pricing::PricingService {
+        let mut litellm = std::collections::HashMap::new();
+        litellm.insert(
+            model.to_string(),
+            tokscale_core::pricing::litellm::ModelPricing {
+                input_cost_per_token: Some(1e-6),
+                ..Default::default()
+            },
+        );
+        tokscale_core::pricing::PricingService::new(litellm, std::collections::HashMap::new())
+    }
+
+    /// 1M input tokens against the table above estimates to exactly $1.00, so
+    /// `cost` doubles as the ratio and each case below states its own multiple.
+    fn priced_entry(model: &str, cost: f64) -> tokscale_core::ModelUsage {
+        let mut e = entry(1_000_000, 0, 0, 0, 0);
+        e.model = model.to_string();
+        e.provider = "deepseek".to_string();
+        e.cost = cost;
+        e
+    }
+
+    #[test]
+    fn implausible_cost_is_flagged_with_its_ratio() {
+        let service = priced_service("m");
+        // The shape of the user report: a per-1K rate billed per-token.
+        let ratio = implausible_cost_ratio(Some(&service), &priced_entry("m", 1000.0));
+        assert_eq!(ratio, Some(1000.0));
+    }
+
+    #[test]
+    fn plausible_cost_is_not_flagged() {
+        let service = priced_service("m");
+        // Every healthy row measured on real data sat at or below 1.0x; even a
+        // client billing 10x the table's rate stays quiet.
+        for cost in [0.1, 1.0, 10.0, IMPLAUSIBLE_COST_RATIO] {
+            assert_eq!(
+                implausible_cost_ratio(Some(&service), &priced_entry("m", cost)),
+                None,
+                "{cost} should not be flagged"
+            );
+        }
+        // Just past the threshold it is. Pins the boundary from both sides, so
+        // a comparison flipped to `>=`/`<` cannot pass this pair.
+        assert!(
+            implausible_cost_ratio(
+                Some(&service),
+                &priced_entry("m", IMPLAUSIBLE_COST_RATIO + 0.5)
+            )
+            .is_some(),
+            "just above the threshold should be flagged"
+        );
+    }
+
+    #[test]
+    fn unpriced_model_is_never_flagged() {
+        let service = priced_service("m");
+        // The table cannot price this model at all, so an enormous cost is not
+        // evidence of anything. Without the estimate > 0 guard the division
+        // would be by zero and every unpriced row would be flagged.
+        assert_eq!(
+            implausible_cost_ratio(Some(&service), &priced_entry("other", 99_999.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn free_and_absent_costs_are_never_flagged() {
+        let service = priced_service("m");
+        // A genuinely free model reports 0.0 against a positive estimate; a
+        // two-sided check would flag it on every refresh forever.
+        assert_eq!(
+            implausible_cost_ratio(Some(&service), &priced_entry("m", 0.0)),
+            None
+        );
+        assert_eq!(
+            implausible_cost_ratio(Some(&service), &priced_entry("m", f64::NAN)),
+            None
+        );
+        // No cached table (first run, offline): the check disables itself
+        // rather than reporting against a table that isn't there.
+        assert_eq!(implausible_cost_ratio(None, &priced_entry("m", 1000.0)), None);
+    }
+
+    #[test]
+    fn flagged_ratio_reaches_the_serialized_entry() {
+        // The three cases above test the predicate directly; this one proves
+        // map_report actually carries it onto the wire shape the UI decodes,
+        // under the key Swift reads.
+        let service = priced_service("m");
+        let report = wrap(vec![priced_entry("m", 1000.0), priced_entry("m", 1.0)]);
+        let mapped = map_report(report, Some(&service));
+        assert_eq!(mapped.entries[0].cost_ratio, Some(1000.0));
+        assert_eq!(mapped.entries[1].cost_ratio, None);
+
+        let json = serde_json::to_value(&mapped).unwrap();
+        assert_eq!(json["entries"][0]["costRatio"], serde_json::json!(1000.0));
+        assert!(json["entries"][1]["costRatio"].is_null());
     }
 }


### PR DESCRIPTION
Two independent fixes to the Models surface, one commit each.

## 1. A reported cost the pricing table cannot justify now says so

A user's Models list showed `deepseek-v4-flash` at **$8647.24** for 74.3M tokens.

The number is not ours. OpenCode records a per-message cost of its own, and tokscale-core's `apply_pricing_if_available` returns early on `has_authoritative_cost()` — so those rows never meet a pricing table at all. `sessions/opencode.rs:196-209` takes any positive embedded cost verbatim, checking only that it is finite and non-negative:

```rust
/// OpenCode computes per-message cost at request time from its own pricing
/// data, so a positive embedded cost is authoritative.
fn mark_opencode_cost_source(unified: &mut UnifiedMessage) {
    if unified.cost > 0.0 {
        unified.mark_provider_reported_cost();
```

That default is right — the client knows its own billing contract — but it means a unit error upstream reaches the UI with nothing in between and nothing to say so.

Confirmed against the reporter's own database. Their OpenCode rows already hold these figures, under providerID `exptech` rather than `deepseek`:

```
{"id":"deepseek-v4-flash","providerID":"exptech","variant":"max"}       | 5495.303222 | 40555976
{"id":"deepseek-v4-flash-free","providerID":"opencode","variant":"max"} | 3174.69345  | 22243866
```

So the figure originates upstream, in whatever pricing that third-party gateway is configured with. This PR does not try to correct it.

### What it does instead

Compare each row's cost against what the local pricing table would charge for the same tokens; when the multiple is implausible, carry it to the UI as a warning.

| Decision | Why |
|---|---|
| Nothing is recalculated | `cost` ships exactly as reported. The app cannot know the client's real rate, only that this is far off any price it can justify. The row is annotated, not corrected. |
| Lives in `tb_core_ffi`, not `vendor/tokscale-core` | It needs no `cost_source`: a locally-priced row equals the estimate by construction and can never trip the threshold, so only self-reported rows can. The vendored submodule stays untouched. |
| One-directional | Healthy rows measured on real data run **0.1-0.3x** of the estimate (LiteLLM prices dearer than OpenCode actually bills), and a genuinely free model reports 0.0 against a positive estimate. A two-sided check would flag both forever. |
| Fails open | No cached pricing dataset (first run, offline), or a model the table cannot price, yields no flag rather than a false one. The read is `load_cached_any_age` — no network; `get_model_report` has already refreshed that cache on its own path. |

Threshold is **50x**, with the measurements behind it recorded at the constant:

| row | reported | estimate | ratio |
|---|---|---|---|
| deepseek-v4-flash (local, default) | 0.7139 | 2.5719 | 0.3x |
| deepseek-v4-flash (local, low) | 0.2943 | 1.0470 | 0.3x |
| deepseek-v4-pro (local) | 3.9039 | 26.4468 | 0.1x |
| deepseek-v4-flash @ exptech (reporter) | 5495.30 | 17.84 | **308x** |
| deepseek-v4-flash-free @ opencode (reporter) | 3174.69 | 9.79 | **324x** |

Two orders of magnitude sit between the healthy ceiling and the broken rows. The slack is needed rather than decorative: the lookup can match a near-miss key (`deepseek-v4-flash-free` resolves to the paid `deepseek-v4-flash` entry) or a row missing cache rates, each skewing the estimate by single-digit multiples. Nothing short of a unit-scale error clears 50x.

### Plumbing

`ModelEntry.cost_ratio: Option<f64>` (wire key `costRatio`; `Some` only when flagged, so its presence is the signal and its value the multiple) through to `ModelReportEntry.costRatio`, declared optional so a report serialized before this field still decodes. `modelLevelEntries` folds provider-split rows by taking the largest contributing ratio — the flag has to survive the fold, since one broken provider still makes the merged total wrong.

UI is an amber warning triangle beside the cost in both `ModelsView` and `ModelBreakdownCard`, plus a line in the shared `ModelUsageTooltip` naming the multiple. Amber rather than red: the tokens are real and the client may yet be right about its own rate. `ModelUsageTooltip.costRatio` defaults to nil, so the DailyView and MonthlyView slice callers are unchanged.

## 2. The Models list gets the same hover tooltip as every other card

Reported alongside the above: the tooltip in the Models list is hard to trigger. It was the only per-row tooltip in the app still served by SwiftUI `.help`, and two properties made it awkward.

> The modifier sat on the model-name `Text` alone, so the hit area was that string's glyph rect — caption-height, and only as wide as the name. The share percentage, the token line, the right-hand columns, the provider dot and all the interior whitespace did nothing.

> `.help` maps to an AppKit tooltip, which carries a built-in appearance delay with no public API to shorten it. The sibling cards' tooltips are hand-drawn and appear on entry, so the two behaved visibly differently on the same data.

Replaced with the mechanism `ModelBreakdownCard`, `DailyView` and `MonthlyView` already share — whole-row `.contentShape(Rectangle())` + `.onContinuousHover`, positioned by the existing `PopoverTooltipPlacement.offset` (already covered by eight SelfTest cases), rendering `ModelUsageTooltip` verbatim. Nothing new is computed; the content also gains the full token breakdown in place of the old one-line string.

Two deliberate departures from `ModelBreakdownCard`: the coordinate space is named `models-rows` (the two views are mutually exclusive so a shared name would not collide, but a distinct one keeps them from reading as the same space), and `.ended` clears the hover only when the leaving row's `rowID` still matches — the guard `DailyView` uses, needed here because this list has no row cap and scrolls.

The `.help` on the "Prices updated" line and those in AgentsView, AgentLimitsCard, DashboardTabs and SettingsPanel are untouched: static metadata, where the system tooltip is the right control.

## Verification

- Five hermetic unit tests over `implausible_cost_ratio` and `map_report`, using a hand-built one-model pricing table so no assertion depends on the shipping dataset. They cover the flagged case, the threshold boundary from both sides, an unpriced model, a free model, a NaN cost, an absent table, and the serialized `costRatio` key.
- Both halves of the predicate were mutation-tested: inverting the threshold comparison fails 3 tests, deleting the zero-estimate guard fails 1, and the suite is green again after restoring.
- The reporter's real rows were run through the shipping predicate with their actual `exptech` provider id: both flag, at 308x and 324x.
- `cargo test -p tb_core_ffi --lib` — 426 passed.
- `make build` and `make selftest` (with `-AppleLanguages "(en)"`) pass.
- Both changes were looked at in the running app and accepted. Seeing the warning required temporarily widening the predicate, since no row on that machine exceeds 50x (its ceiling is 0.3x); that patch was reverted before this branch was pushed, and `git status` was empty against the commit afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b6oYpz3XWF8kvs32jNy8e
