### PR TITLE
feat(i18n): add Simplified Chinese localization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,7 @@ let package = Package(
                 // root so direct `swift run` can stage them beside the
                 // executable for Bundle.main/SwiftUI lookup.
                 .copy("Resources/Localizations/en.lproj"),
+                .copy("Resources/Localizations/zh-Hans.lproj"),
                 .copy("Resources/Localizations/zh-Hant.lproj"),
             ],
             linkerSettings: rustLinkerSettings

--- a/Sources/TokenBar/Charts/ContributionGraph3D.swift
+++ b/Sources/TokenBar/Charts/ContributionGraph3D.swift
@@ -285,8 +285,9 @@ final class ContributionGraphView: SCNView {
                 m.emission.intensity = 0.35
             }
         }
+        let tokenLine = "%@ tokens".localized(Format.compactTokens(cell.tokens))
         tooltip.stringValue =
-            "\(Format.monthDay(cell.date))\n\(Format.compactTokens(cell.tokens)) tokens\n\(Format.usd(cell.cost))"
+            "\(Format.monthDay(cell.date))\n\(tokenLine)\n\(Format.usd(cell.cost))"
         tooltip.sizeToFit()
         tooltip.frame = tooltip.frame.insetBy(dx: -7, dy: -5)
         var origin = CGPoint(x: p.x + 12, y: p.y - tooltip.frame.height - 12)

--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -717,7 +717,7 @@ private struct DashboardSnapshot {
             // Keep showing stale data over an error screen when a previous
             // load succeeded — a transient failure must not blank the UI.
             if payload == nil {
-                phase = .failed("Failed to load usage: \(error)")
+                phase = .failed("Failed to load usage: %@".localized(String(describing: error)))
             }
         }
     }
@@ -870,7 +870,7 @@ private struct DashboardSnapshot {
             // "looking for clients". Once ready, keep the stale-data-over-error
             // behavior a manual refresh relies on.
             if case .loading = phase {
-                phase = .failed("Failed to load usage: \(error)")
+                phase = .failed("Failed to load usage: %@".localized(String(describing: error)))
             }
             return
         }

--- a/Sources/TokenBar/Localization.swift
+++ b/Sources/TokenBar/Localization.swift
@@ -35,6 +35,21 @@ enum AppLanguage: String, CaseIterable {
         currentRawValue != nextRawValue && Self(rawValue: nextRawValue) != nil
     }
 
+    /// Reads one locale explicitly from a bundle so selftest can prove that
+    /// each packaged localization copy exists without changing AppleLanguages.
+    static func localizedString(
+        _ key: String, locale: String, bundle: Bundle = .tokenBarResources
+    ) -> String? {
+        guard let url = bundle.url(
+            forResource: locale, withExtension: "lproj"),
+            let bundle = Bundle(url: url)
+        else { return nil }
+
+        let missing = "__TOKENBAR_MISSING_LOCALIZATION__"
+        let value = bundle.localizedString(forKey: key, value: missing, table: nil)
+        return value == missing ? nil : value
+    }
+
     /// Writes (or clears) the `AppleLanguages` override.
     func apply(to defaults: UserDefaults = .standard) {
         switch self {

--- a/Sources/TokenBar/Localization.swift
+++ b/Sources/TokenBar/Localization.swift
@@ -14,6 +14,7 @@ import TokenBarCore
 enum AppLanguage: String, CaseIterable {
     case system
     case english = "en"
+    case simplifiedChinese = "zh-Hans"
     case traditionalChinese = "zh-Hant"
 
     static let storageKey = "tokenbar.language"
@@ -23,6 +24,7 @@ enum AppLanguage: String, CaseIterable {
         switch self {
         case .system: return "System".localized
         case .english: return "English"
+        case .simplifiedChinese: return "简体中文"
         case .traditionalChinese: return "繁體中文"
         }
     }
@@ -57,7 +59,7 @@ enum AppLanguage: String, CaseIterable {
         else { return }
 
         let fileManager = FileManager.default
-        for locale in ["en", "zh-Hant"] {
+        for locale in ["en", "zh-Hans", "zh-Hant"] {
             let source = packageResourceURL.appendingPathComponent("\(locale).lproj")
             let destination = resourceURL.appendingPathComponent("\(locale).lproj")
             guard fileManager.fileExists(atPath: source.path) else { continue }

--- a/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "Refresh usage data (⌘R) — showing data from %@" = "刷新用量数据（⌘R）— 当前显示%@的数据";
 "Updating usage data" = "正在刷新用量数据";
 "Loading usage…" = "正在加载用量…";
+"Failed to load usage: %@" = "加载用量失败：%@";
 "Loading…" = "加载中…";
 "Settings" = "设置";
 "Quit" = "退出";
@@ -54,6 +55,7 @@
 "Token Usage" = "token 用量";
 "Streaks" = "连续天数";
 "Agent limits" = "Agent 额度";
+"OAuth quota" = "OAuth 额度";
 "Live session" = "实时会话";
 "Models by cost" = "模型费用排行";
 "Agents by cost" = "Agent 费用排行";
@@ -118,6 +120,7 @@
 "Price" = "费用";
 "Show less" = "收起";
 "Show %lld more" = "再显示 %lld 项";
+"Show %lld more · %lld of %lld" = "再显示 %1$lld 项 · 已显示 %2$lld／共 %3$lld 项";
 "Show more" = "显示更多";
 "Prices updated %@" = "价格更新于 %@";
 "LiteLLM pricing data; refreshes automatically about once an hour" = "LiteLLM 价格数据，约每小时自动刷新一次";
@@ -225,7 +228,7 @@
 "Not a subscription" = "不计入订阅";
 "Counts toward %@" = "计入 %@";
 "Suggested: counts toward %@" = "建议：计入 %@";
-"Suggested: not a subscription" = "建议：不是订阅";
+"Suggested: not a subscription" = "建议：不计入订阅";
 "Usage could not be loaded, so there is nothing to classify yet." = "无法加载用量，暂时没有可分类的内容。";
 "Usage breakdown is unavailable right now." = "暂时无法显示用量明细。";
 "Unspecified provider" = "未指定提供商";
@@ -365,7 +368,7 @@
 "Loading" = "加载中";
 "Waiting for quota…" = "正在等待额度…";
 "Waiting for quota" = "等待额度";
-"%@ window" = "%@ 窗口";
+"%@ window" = "%@窗口";
 "No quota history" = "没有额度历史";
 "This window has no recorded quota history, so there is no line to draw." = "此窗口没有额度历史记录，因此无法绘制曲线。";
 "Remaining" = "剩余";

--- a/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,553 @@
+/* TokenBar — 简体中文
+
+   Key 是源代码中的英文原文；缺少对应条目时会原样显示英文。
+
+   保留不翻译：TokenBar、产品名称（Claude、Codex、Copilot、Gemini…）、模型
+   名称、token、Agent、2D／3D，以及 In／Out／CR／CW 等图表缩写。
+
+   对经过 String(format:) 的条目（key 包含 %lld／%@），译文中的字面百分号
+   必须写成 %%；不经过格式化的纯文本可直接使用 %。
+*/
+
+/* ===== 标签页 ===== */
+"Overview" = "概览";
+"Models" = "模型";
+"Monthly" = "每月";
+"Daily" = "每日";
+"Hourly" = "每小时";
+"Stats" = "统计";
+"Agents" = "Agent";
+
+/* ===== 弹出窗口外框 ===== */
+"Year" = "年份";
+"All years" = "全部年份";
+"All" = "全部";
+"Filter usage by year" = "按年份筛选用量";
+"Refresh usage data (⌘R)" = "刷新用量数据（⌘R）";
+"Refresh usage data" = "刷新用量数据";
+"Refresh usage data (⌘R) — showing data from %@" = "刷新用量数据（⌘R）— 当前显示%@的数据";
+"Updating usage data" = "正在刷新用量数据";
+"Loading usage…" = "正在加载用量…";
+"Loading…" = "加载中…";
+"Settings" = "设置";
+"Quit" = "退出";
+"Dismiss" = "关闭";
+"Drag to resize the popover height" = "拖动以调整弹出窗口高度";
+"Update %@" = "更新 %@";
+"A new version is ready — click to install" = "新版本已就绪，点一下即可安装";
+"You're on the beta build" = "你目前使用的是 beta 版本";
+"Switch to the TokenBar 1.0 release — keeps your data" = "切换到 TokenBar 1.0 正式版，数据会保留";
+"Switch" = "切换";
+
+/* ===== 空状态 ===== */
+"No usage in this range" = "此范围内没有用量";
+"No model usage in this range" = "此范围内没有模型用量";
+"No agent activity in this range" = "此范围内没有 Agent 活动";
+"No activity in this window" = "此时间窗口内没有活动";
+"No data" = "暂无数据";
+"Checking…" = "正在检查…";
+"No clients with usage data yet." = "目前没有任何客户端有用量数据。";
+"No supported agents yet" = "尚无支持的 Agent";
+"Checking agent limits…" = "正在查询额度…";
+
+/* ===== 卡片标题 ===== */
+"Token Usage" = "token 用量";
+"Streaks" = "连续天数";
+"Agent limits" = "Agent 额度";
+"Live session" = "实时会话";
+"Models by cost" = "模型费用排行";
+"Agents by cost" = "Agent 费用排行";
+"Hourly rhythm" = "时段分布";
+"Hourly usage" = "每小时用量";
+"Full year" = "全年";
+"Stacked by model" = "按模型堆叠";
+"Stacked by agent" = "按 Agent 堆叠";
+"%@ limits" = "%@ 额度";
+"%@ models" = "%@ 模型";
+"Session / weekly / model limits" = "会话／每周／模型额度";
+"↔ Routes through opencode" = "↔ 经 opencode 路由";
+"opencode also taps: %@" = "opencode 还会使用：%@";
+"Subscriptions: %@" = "订阅：%@";
+
+/* ===== 统计数字 ===== */
+"Total" = "总计";
+"Tokens" = "token";
+"Best day" = "最高单日";
+"Total tokens" = "token 总数";
+"Total spend" = "总支出";
+"Active days" = "活跃天数";
+"Avg / day" = "日均";
+"Current streak" = "当前连续天数";
+"Longest streak" = "最长连续天数";
+"Favorite model" = "最常用模型";
+"Longest" = "最长";
+"Current" = "当前";
+"Your total spending is " = "你的总支出为";
+"%lld active days" = "%lld 个活跃日";
+"%@ tokens" = "%@ token";
+"%@ msgs" = "%@ 条消息";
+"%@ turns" = "%@ 轮";
+"Turns · %@ only" = "轮次 · 仅统计 %@";
+"Turns · %@ + %@ only" = "轮次 · 仅统计 %@ 和 %@";
+" days" = "天";
+
+/* ===== 数量摘要（英文分单复数，中文两者相同）===== */
+"%lld model · %@ · %@" = "%1$lld 个模型 · %2$@ · %3$@";
+"%lld models · %@ · %@" = "%1$lld 个模型 · %2$@ · %3$@";
+"%lld model · %@" = "%1$lld 个模型 · %2$@";
+"%lld models · %@" = "%1$lld 个模型 · %2$@";
+"%lld agent · %@" = "%1$lld 个 Agent · %2$@";
+"%lld agents · %@" = "%1$lld 个 Agent · %2$@";
+"%lld active day" = "%lld 天有用量";
+"%lld active month" = "%lld 个月有用量";
+"%lld active months" = "%lld 个月有用量";
+
+/* ===== 图表与明细 ===== */
+"Fit" = "自适应";
+"Reset" = "重置";
+"Input" = "输入";
+"Output" = "输出";
+"Cache read" = "缓存读取";
+"Cache write" = "缓存写入";
+"Reasoning" = "推理";
+"Model" = "模型";
+"Agent" = "Agent";
+"Bars" = "条形图";
+"Heatmap" = "热力图";
+"Window" = "时间窗口";
+"Price" = "费用";
+"Show less" = "收起";
+"Show %lld more" = "再显示 %lld 项";
+"Show more" = "显示更多";
+"Prices updated %@" = "价格更新于 %@";
+"LiteLLM pricing data; refreshes automatically about once an hour" = "LiteLLM 价格数据，约每小时自动刷新一次";
+"Cost reported by the client, about %@x the local price estimate" = "客户端报告的费用约为本地价格估算的 %@ 倍";
+"Timeline" = "时间轴";
+"Profile" = "分布图";
+"peak %02lld:00 · %@" = "峰值 %1$02lld:00 · %2$@";
+"%lld hrs · %@" = "%1$lld 小时 · %2$@";
+"last %lldm · %@/m total" = "最近 %1$lld 分钟 · 总计 %2$@/分钟";
+
+/* ===== 额度窗口 ===== */
+"Session" = "会话";
+"Weekly" = "每周";
+"Pro" = "Pro";
+"Flash" = "Flash";
+"Extra usage" = "额外用量";
+"%lld%% left" = "剩余 %lld%%";
+"%lld%% used" = "已用 %lld%%";
+"%@ used" = "已用 %@";
+"%@ less left" = "预计少剩 %@";
+"%@ more left" = "预计多剩 %@";
+"Expected %lld%% used by now" = "到当前时刻应已用 %lld%%";
+"Set up" = "待设置";
+"Error" = "错误";
+"Live" = "实时";
+"No quota" = "无额度";
+"Loading quotas…" = "正在加载额度…";
+"Menu bar tracks" = "菜单栏跟踪对象";
+"Auto (tightest window)" = "自动（剩余最少的窗口）";
+"Auto (tightest)" = "自动（剩余最少）";
+"Unavailable selection" = "所选项不可用";
+"Quota window" = "额度窗口";
+"Quota window %lld" = "额度窗口 %lld";
+"Hidden client tab; the item is suppressed." = "客户端标签页已隐藏，因此不会显示此项目。";
+"Quota unavailable." = "额度不可用。";
+"Using the last good quota window." = "正在使用上次成功获取的额度窗口。";
+"%@, %lld percent quota remaining" = "%1$@，剩余额度 %2$lld%%";
+"%@, quota unavailable" = "%@，额度无法使用";
+"Show %@ individual item" = "显示 %@ 的独立菜单栏项目";
+"Quota window for %@" = "%@ 的额度窗口";
+"%@ — %lld%% quota remaining" = "%1$@ — 剩余额度 %2$lld%%";
+"%@ — quota unavailable" = "%@ — 额度无法使用";
+"%@ — selected quota window unavailable" = "%@ — 所选的额度窗口不可用";
+"%@, selected quota window unavailable" = "%@，所选的额度窗口不可用";
+"%@ — %lld%% last known quota remaining" = "%1$@ — 上次已知剩余额度 %2$lld%%";
+"%@, %lld percent last known quota remaining" = "%1$@，上次已知剩余额度 %2$lld%%";
+"Copy command" = "复制命令";
+"Using a Claude `setup-token`? TokenBar auto-detects `CLAUDE_CODE_OAUTH_TOKEN` from your login shell. If limits don't appear, store the token in Keychain — run this, then paste the token at the prompt:" = "正在使用 Claude `setup-token`？TokenBar 会自动从登录 shell 中检测 `CLAUDE_CODE_OAUTH_TOKEN`。如果没有显示额度，请运行以下命令将 token 存入钥匙串，然后按提示粘贴 token：";
+
+/* ===== 时间格式 ===== */
+"Jan" = "1月";
+"Feb" = "2月";
+"Mar" = "3月";
+"Apr" = "4月";
+"May" = "5月";
+"Jun" = "6月";
+"Jul" = "7月";
+"Aug" = "8月";
+"Sep" = "9月";
+"Oct" = "10月";
+"Nov" = "11月";
+"Dec" = "12月";
+"format.monthDay" = "%1$@%2$lld日";
+"format.monthYear" = "%2$lld年%1$@";
+"just now" = "刚刚";
+"%lldm ago" = "%lld分钟前";
+"%lldh ago" = "%lld小时前";
+"%lldd ago" = "%lld天前";
+
+/* ===== 设置：分区标题 ===== */
+"Menubar title" = "菜单栏标题";
+"Startup" = "启动";
+"Menubar icon" = "菜单栏图标";
+"Quota source" = "额度来源";
+"Individual items" = "独立项目";
+"No eligible individual clients yet." = "尚无可显示为独立项目的客户端。";
+"Looking for eligible clients…" = "正在查找可用的客户端…";
+"View tabs" = "视图标签页";
+"Client tabs (top bar)" = "客户端标签页（顶部栏）";
+"Live trace" = "实时追踪";
+"Popover size" = "弹出窗口大小";
+"Data refresh" = "数据刷新";
+"Language" = "语言";
+"Discord" = "Discord";
+"About" = "关于";
+"Menu bar" = "菜单栏";
+"Dashboard" = "仪表盘";
+"General" = "常规";
+"Agent limits card" = "Agent 额度卡片";
+"Live session card" = "实时会话卡片";
+"Usage attribution" = "用量归属";
+"API-list-price equivalent" = "按 API 公开价估算";
+"Nothing is classified yet. Classify sources in Settings → Usage attribution." = "尚未设置任何归属。请在“设置”→“用量归属”中为来源分类。";
+"No attributed usage in this range." = "此范围内没有已归属用量。";
+"Classify each observed client/provider source against the subscription it should count toward. Nothing here is inferred as a billing event." = "将检测到的每个客户端／提供商来源归到应计入的订阅。此处分类不代表实际计费。";
+"Provider IDs are compared exactly as the source emitted them, so related-looking routes may appear as separate rows and be classified independently. Some clients merge them before reporting — Vertex AI arriving as Anthropic, Codex as OpenAI — and a row that arrived merged cannot be split here." = "提供商 ID 会与来源返回的值精确匹配，因此看似相关的路由仍可能分别显示和分类。部分客户端会在报告前合并提供商——例如将 Vertex AI 归为 Anthropic、将 Codex 归为 OpenAI——已经合并的行无法在此处拆分。";
+"A declaration is your classification, not a billing fact." = "此声明仅代表你的分类，不是计费事实。";
+"No provider-split usage in this range." = "此范围内没有按提供商拆分的用量。";
+"Accept all suggestions (%lld)" = "接受所有建议（%lld）";
+"Suggestions are proposals; they do not change your classification until accepted." = "建议不会自动更改分类，接受后才会应用。";
+"%@ · %@" = "%1$@ · %2$@";
+"Observed %@ tokens · %@" = "已观测 %@ token · %@";
+"Classification" = "分类";
+"Unassigned" = "未归属";
+"Not a subscription" = "不计入订阅";
+"Counts toward %@" = "计入 %@";
+"Suggested: counts toward %@" = "建议：计入 %@";
+"Suggested: not a subscription" = "建议：不是订阅";
+"Usage could not be loaded, so there is nothing to classify yet." = "无法加载用量，暂时没有可分类的内容。";
+"Usage breakdown is unavailable right now." = "暂时无法显示用量明细。";
+"Unspecified provider" = "未指定提供商";
+"Classification for %@" = "%@ 的分类";
+"Could not save this classification: existing attribution data is invalid or foreign." = "无法保存此分类：现有归属数据无效或来自其他格式。";
+"Could not save this classification: the attribution entry limit was reached." = "无法保存此分类：已达到归属条目上限。";
+"Could not save this classification: the new value is too large or unsupported." = "无法保存此分类：新值过大或不受支持。";
+"Claude accounts" = "Claude 账户";
+
+/* ===== 设置：选项 ===== */
+"Launch at login" = "登录时启动";
+"Animate based on token usage" = "根据 token 用量调整动画速度";
+"Show Agent limits card" = "显示 Agent 额度卡片";
+"Show as used" = "显示已用量";
+"Split by agent / model" = "按 Agent／模型拆分";
+"Height" = "高度";
+"Auto" = "自动";
+"Fit the height to the screen automatically" = "自动适应屏幕高度";
+"Version" = "版本";
+"Check for updates" = "检查更新";
+"Check Now" = "立即检查";
+"Receive beta updates" = "接收 Beta 更新";
+"Show today's usage on Discord" = "在 Discord 上显示今日用量";
+"Open Settings" = "打开设置";
+"Not now" = "暂不";
+"1.2M tokens today" = "今日 1.2M token";
+"Claude Code · $10-50" = "Claude Code · $10-50";
+"Your Discord profile can show what you have been building today. Pick exactly what appears — or nothing at all — in Settings." = "你的 Discord 个人资料可以显示今天的开发活动。显示哪些内容——或不显示任何内容——可在设置中选择。";
+"Off by default. Publishes what you pick below — today's tokens, a client name, a cost range or rounded figure — for whichever client you choose, and a link to TokenBar's source to your Discord profile. It updates while you work, so your active hours show too. Anyone who can see your profile can read and keep every update; switching this off stops new ones but cannot unshare what already went out. Hidden clients are never included, and a change here reaches your profile within about 15 seconds." = "默认关闭。它会根据你选择的客户端，将下方勾选的内容——今日 token 数、客户端名称、费用区间或取整金额——以及 TokenBar 源代码链接发布到 Discord 个人资料。工作期间会持续更新，因此也会暴露活跃时段。任何能查看你个人资料的人都可以读取并保存每次更新；关闭后只会停止新的发布，无法撤回已经发布的内容。隐藏的客户端绝不会包含在内；此处更改约在 15 秒内显示在个人资料中。";
+"Include today's tokens" = "包含今日 token 数";
+"Include the client name" = "包含客户端名称";
+"Include cost" = "包含费用";
+"Untick everything and nothing is published at all." = "取消全部勾选后不会发布任何内容。";
+"Show cost as a figure instead of a range" = "用具体金额而非区间显示费用";
+"A range keeps you among everyone else in that band. A figure is rounded to the dollar, never cents, but still says more about you — every day. With one client named above, it becomes that tool's daily spend." = "区间会将你和该范围内的其他人归为一组。具体金额会取整到美元，不显示美分，但仍会每天透露更多信息。若上方指定一个客户端，该金额就是该工具的每日费用。";
+"Whichever client you used most" = "用量最多的客户端";
+"Naming one client publishes only its usage, so the totals can differ from the menu bar, which counts every client including ones TokenBar does not recognise. The cost becomes that one tool's daily spend rather than the whole day's." = "指定一个客户端后只会发布该客户端的用量，因此总数可能与菜单栏不同；菜单栏会统计所有客户端，包括 TokenBar 尚未识别的客户端。费用也会变为该工具当日的费用，而不是全天总费用。";
+"Live preview — settings apply immediately." = "实时预览，设置立即生效。";
+"Takes effect the next time TokenBar starts." = "下次启动 TokenBar 时生效。";
+"Restart TokenBar?" = "重启 TokenBar？";
+"Restart TokenBar to apply the new language." = "重启 TokenBar 后应用新语言。";
+"Restart Now" = "立即重启";
+"Later" = "稍后";
+"Dark" = "深色";
+"Light" = "浅色";
+"System" = "跟随系统";
+"(quota card only)" = "（仅额度卡片）";
+"Drag to reorder" = "拖动以调整顺序";
+
+"Today's tokens (50M)" = "今日 token（50M）";
+"Today's cost ($5.20)" = "今日费用（$5.20）";
+"Total tokens (1.5B)" = "token 总量（1.5B）";
+"Total cost ($889)" = "总费用（$889）";
+"Tokens / min (12.4K/m)" = "每分钟 token（12.4K/m）";
+"Quota left (57%)" = "剩余额度（57%）";
+"Icon only" = "只显示图标";
+
+"Spinning cat" = "旋转猫";
+"Party parrot" = "派对鹦鹉";
+"Signal bars" = "信号条";
+"Ring gauge" = "环形仪表";
+"Melting popsicle" = "融化冰棒";
+"Color on warning only" = "仅警示时上色";
+"Always colored" = "始终显示颜色";
+"Never colored" = "始终不显示颜色";
+
+"Layout: Full" = "布局：完整";
+"Layout: Classic" = "布局：经典";
+"Pace: Historical" = "消耗节奏：历史";
+"Pace: Linear" = "消耗节奏：线性";
+"Pace: Off" = "消耗节奏：关闭";
+
+"Every hour" = "每小时";
+"Every %lld min" = "每 %lld 分钟";
+
+"Add config dir…" = "添加配置目录…";
+"Add" = "添加";
+"Not found on disk right now — kept in the list in case it's an unmounted drive or a typo you'll fix." = "当前磁盘上找不到。仍会保留在列表中，以便磁盘重新挂载或修正输入错误后继续使用。";
+
+/* ===== 设置：说明文字 ===== */
+"Spins faster as the live token rate climbs (idle 2 fps, 1M tokens/min tops out at 40 fps)." = "实时 token 速率越高，转得越快（空闲时 2 fps；达到每分钟 100 万 token 时，上限为 40 fps）。";
+"Gauge icons drain as the selected quota window empties. \"Color on warning only\" stays monochrome until under 25% left (amber) and 10% (red), like the battery icon." = "仪表图标会随所选额度窗口逐渐耗尽。“仅在警告时着色”会保持单色，直到剩余低于 25%（琥珀色）或 10%（红色），与电池图标一致。";
+"Feeds the gauge icons and the \"Quota left\" title. Auto follows whichever window is closest to running out." = "决定仪表图标和“剩余额度”标题的数据源。自动模式会跟踪最接近用完的窗口。";
+"Keep the main TokenBar item. Optional client items show each client's selected quota window; Auto chooses the tightest healthy window for that client." = "保留 TokenBar 主项目。可选的客户端独立项目会显示各自选定的额度窗口；自动模式会选择该客户端剩余最少且状态正常的窗口。";
+"Off hides the Agent-limits quota card everywhere — the Overview summary, every client's own tab, and this preview. Cost/token data is unaffected." = "关闭后会在所有位置隐藏 Agent 额度卡片，包括概览摘要、各客户端标签页和此预览。费用和 token 数据不受影响。";
+"On, bars count up as quota is used; off, they count down to what's left. The color always warns as quota runs low." = "开启时，条形图随已用额度增加；关闭时，条形图随剩余额度减少。额度较低时始终以颜色警告。";
+"The deficit/reserve marker. Historical learns each quota window's usage pattern; during learning, the Linear estimate is labeled; Linear uses the exact reset duration; Off hides the marker." = "显示超出或低于预期的标记。历史模式会学习每个额度窗口的用量模式；学习期间会标注“线性估算”；线性模式使用准确的重置周期；关闭后隐藏此标记。";
+"Hides only that client's quota card here and on its own tab — the tab and its cost/token data stay visible. Useful for accounts with no OAuth quota (e.g. Claude Console). Grayed out when the tab itself is hidden below, since a hidden tab always hides its quota card too." = "只会隐藏该客户端在此处及自身标签页中的额度卡片，标签页及其费用／token 数据仍然可见。适用于没有 OAuth 额度的账户（如 Claude Console）。如果下方已隐藏该标签页，此项会置灰，因为隐藏标签页也会隐藏其额度卡片。";
+"Off removes a tab from the popover's tab row. Cost/token data is unaffected." = "关闭后会从弹出窗口的标签栏移除该标签页。费用和 token 数据不受影响。";
+"Drag to set the order used by both the top tabs and the quota cards — or drag a tab directly in the top bar. The switch shows/hides a client's top tab (hiding also drops its quota card)." = "拖动可设置顶部标签页和额度卡片共用的顺序，也可直接在顶部栏拖动标签页。开关控制客户端顶部标签页的显示；隐藏标签页也会移除其额度卡片。";
+"Present clients have a switch to show/hide their top tab — hiding also removes that client's quota card. Quota-only clients (OAuth quota, no local sessions, e.g. Antigravity) have no tab, so they appear here only to order their quota card. Drag order applies to both top tabs and quota cards." = "检测到本地用量的客户端可以通过开关显示或隐藏顶部标签页；隐藏标签页也会移除该客户端的额度卡片。仅有额度的客户端（有 OAuth 额度但无本地会话，如 Antigravity）没有标签页，因此这里只用于调整其额度卡片顺序。拖动顺序同时应用于顶部标签页和额度卡片。";
+"Affects the live-session card only: on, each agent & model gets its own row; off, rows collapse to one per app." = "只影响实时会话卡片：开启后每个 Agent 和模型各占一行；关闭后按应用合并为一行。";
+"Or drag the handle at the bottom edge of the popover. Width is fixed; \"Auto\" fits about 60% of your screen height." = "也可拖动弹出窗口底边的控制柄。宽度固定；“自动”高度约为屏幕高度的 60%。";
+"How often the tray re-reads your logs. The dashboard refreshes when the popover opens; live tokens/min updates every few seconds regardless." = "决定菜单栏重新读取日志的频率。打开弹出窗口时会刷新仪表盘；实时 token/分钟无论此设置如何都会每隔几秒更新。";
+"TokenBar began as a fork of tokcat by handlecusion. Parsing & pricing come from tokscale by Junho Yeo; the menu-bar patterns reference CodexBar by Peter Steinberger; the running cat traces back to RunCat by Takuto Nakamura. MIT licensed." = "TokenBar 最初是 handlecusion 的 tokcat 分支。解析与计价来自 Junho Yeo 的 tokscale；菜单栏的做法参考 Peter Steinberger 的 CodexBar；跑动的猫则源自 Takuto Nakamura 的 RunCat。采用 MIT 授权。";
+"For a second Claude account, run it with CLAUDE_CONFIG_DIR pointed at an isolated folder, then add that folder here. Its usage is merged into the totals above everywhere in TokenBar — there is no separate per-account view." = "如需使用第二个 Claude 账户，请将 CLAUDE_CONFIG_DIR 指向独立目录后运行，再把该目录添加到这里。其用量会合并到上方总计中；TokenBar 不会按账户分别显示。";
+"%lld of %lld path(s) can't be read right now — this is retried automatically on the next scan." = "%2$lld 条路径中有 %1$lld 条当前无法读取；下次扫描会自动重试。";
+"%lld path(s) can't be used as a scan folder and were not added." = "%lld 条路径不能用作扫描目录，因此未添加。";
+
+/* ===== 消耗节奏（pace）=====
+   片段各自查表后以 " · " 串接，分隔符与语言无关，因此逐片段翻译是安全的。
+   英文原文同时是 SelfTest 与 cross-check 的断言对象，靠锁定 en 取得 fallback。
+*/
+"On pace" = "消耗节奏符合预期";
+"%lld%% in deficit" = "比预期多消耗 %lld%%";
+"%lld%% in reserve" = "比预期少消耗 %lld%%";
+"Lasts until reset" = "可用到重置";
+"Projected empty now" = "预计现在用完";
+"Projected empty in %@" = "预计 %@ 后用完";
+"≈ %lld%% run-out risk" = "≈ %lld%% 用完风险";
+
+"Learning history · Linear estimate" = "正在学习历史 · 采用线性估算";
+"Learning reset duration" = "正在学习重置周期";
+"Linear" = "线性";
+"Pace unavailable · legacy data" = "消耗节奏不可用 · 旧版数据";
+"Pace unavailable · unavailable reason" = "消耗节奏不可用 · 原因未知";
+"Pace unavailable · unknown quota window" = "消耗节奏不可用 · 未知额度窗口";
+"Pace unavailable · missing reset" = "消耗节奏不可用 · 缺少重置时间";
+"Pace unavailable · invalid quota data" = "消耗节奏不可用 · 额度数据无效";
+"Pace unavailable · account identity unavailable" = "消耗节奏不可用 · 无法识别账户";
+"Pace unavailable · history storage full" = "消耗节奏不可用 · 历史存储已满";
+"Pace unavailable · history unavailable" = "消耗节奏不可用 · 历史数据不可用";
+"Pace unavailable · non-recurring quota" = "消耗节奏不可用 · 非周期性额度";
+
+/* 紧凑时间长度，组合成「预计 3天2小时 后用尽」 */
+"duration.now" = "现在";
+"Resets now" = "立即重置";
+"Resets in %@" = "%@ 后重置";
+"%lldm" = "%lld分";
+"%lldh" = "%lld小时";
+"%lldh %lldm" = "%1$lld小时%2$lld分";
+"%lldd" = "%lld天";
+"%lldd %lldh" = "%1$lld天%2$lld小时";
+
+/* ===== 额度窗口卡片 ===== */
+"Session window" = "会话窗口";
+"Loading" = "加载中";
+"Waiting for quota…" = "正在等待额度…";
+"Waiting for quota" = "等待额度";
+"%@ window" = "%@ 窗口";
+"No quota history" = "没有额度历史";
+"This window has no recorded quota history, so there is no line to draw." = "此窗口没有额度历史记录，因此无法绘制曲线。";
+"Remaining" = "剩余";
+"Used" = "已用";
+"Placing the window…" = "正在定位窗口…";
+"Placing the window" = "正在定位窗口";
+"Inferred window · resets in %@" = "推算的窗口 · %@ 后重置";
+"No window running" = "当前没有运行中的窗口";
+"Window unavailable" = "窗口不可用";
+"The last window ended and nothing has been used since — no window is running." = "上一个窗口已结束，此后尚无用量——当前没有运行中的窗口。";
+"This subscription did not report a usable reset time, so the window cannot be placed." = "此订阅未提供有效的重置时间，因此无法定位该窗口。";
+"used" = "已用";
+"remaining" = "剩余";
+"No quota reading in this window" = "此窗口内没有额度读数";
+"Reading local usage…" = "正在读取本地用量…";
+"%@ readings" = "%@ 条读数";
+"Quota" = "额度";
+"Usage" = "用量";
+"No sample" = "无采样数据";
+"No usage in this interval" = "此区间无用量";
+"No quota reading in this interval" = "此区间无额度读数";
+"Quota %@%% %@" = "%2$@额度 %1$@%%";
+"%@%@%% this interval" = "此区间 %1$@%2$@%%";
+"10%% of quota ~ %@ · %@ API-equivalent, ±%@%%" = "10%% 额度 ≈ %@ token · 按 API 公开价估算为 %@（误差 ±%@%%）";
+"Quota moved only %@%% — too little to estimate (±%@%%)" = "额度仅变化 %@%%，不足以估算（误差 ±%@%%）";
+"Quota has not moved yet" = "额度尚无变化";
+"Quota moved %@%%, none of it recorded on this machine" = "额度变化 %@%%，但本机未记录到相应用量";
+"Not enough quota readings yet" = "额度读数不足";
+
+/* ===== 窗口 ===== */
+"TokenBar Settings" = "TokenBar 设置";
+"Sponsor" = "赞助";
+"The Agent limits card is turned off in Settings." = "Agent 额度卡片已在设置中关闭。";
+
+/* ===== 额度历史 ===== */
+"Window history" = "窗口历史";
+"%@ windows" = "%@ 个窗口";
+"No earlier windows recorded yet. They accumulate as TokenBar runs." = "尚无更早的窗口记录。TokenBar 运行期间会逐步积累。";
+"TokenBar observed %@%% of this window, so its usage figure is a floor." = "TokenBar 仅观测到此窗口的 %@%%，因此显示的用量只是下限。";
+"Nothing in this window was charged to this subscription." = "此窗口内没有用量计入该订阅。";
+"Other subscriptions in the same hours: %@ · %@" = "同一时段的其他订阅：%@ · %@";
+"Amounts are API list-price equivalents for usage you declared as %@ — not what the subscription charged." = "这些金额按你归为 %@ 的用量和 API 公开价估算，不代表订阅实际收费。";
+
+/* ===== 跨订阅摘要 ===== */
+"Tightest right now: " = "当前剩余最少：";
+" at %lld%% left" = "，剩余 %lld%%";
+"%lld other windows, all above %lld%%" = "另外 %1$lld 个窗口，剩余均高于 %2$lld%%";
+"%lld of %lld other windows are below %lld%%" = "另外 %2$lld 个窗口中，有 %1$lld 个低于 %3$lld%%";
+"No subscription is reporting a usage window right now." = "当前没有订阅报告正在使用的额度窗口。";
+"Burning fastest: " = "消耗最快：";
+" · %lld%% ahead of pace" = " · 比预期多消耗 %lld%%";
+"Today: %@ tokens · %@" = "今天：%@ token · %@";
+"Tightest" = "剩余最少";
+"Burning fastest" = "消耗最快";
+"Today" = "今天";
+"%lld%% ahead of pace" = "比预期多消耗 %lld%%";
+"Layout: Chart" = "布局：图表";
+"Full is the wide card with the pace bar; Classic is the original compact layout without pace; Chart draws each window's quota over time, with the pace estimate as a second line. Chart needs recorded quota history and falls back to a bar for windows that have none." = "“完整”是带消耗节奏条的宽卡片；“经典”是原始紧凑布局，不显示消耗节奏；“图表”会绘制各窗口的额度随时间变化，并将消耗节奏估算作为第二条线。图表需要已有额度历史；无历史的窗口会回退到条形图。";
+
+/* ===== 逐订阅用量 ===== */
+
+/* ===== 按订阅显示的每日趋势 ===== */
+"Daily by subscription" = "按订阅查看每日用量";
+"since %@" = "自 %@";
+"No usage recorded in this range." = "此范围内未记录用量。";
+"Reading daily usage…" = "正在读取每日用量…";
+"Unclassified" = "未分类";
+/* ===== 额度窗口趋势 ===== */
+"%lld%%" = "%lld%%";
+"Recent trend, projected %lld%% by reset" = "根据近期趋势，预计重置时已用 %lld%%";
+
+/* ===== 历史窗口 ===== */
+"Past windows" = "历史窗口";
+"never exhausted" = "从未用完";
+"No completed windows recorded yet. They accumulate as TokenBar runs." = "尚无已完成窗口的记录。TokenBar 运行期间会逐步积累。";
+"Reading quota history…" = "正在读取额度历史…";
+"Heaviest %@%% · never ran out" = "最多用到 %@%%，从未用完";
+"Heaviest %@%% · ran out at least once" = "最多用到 %@%%，至少用完过一次";
+"Pace" = "消耗节奏";
+"Every measured window is under its expected pace" = "所有可测窗口的消耗节奏均低于预期";
+"10%% of quota ~ %@-%@ · %@-%@ API-equivalent" = "10%% 额度 ≈ %@～%@ token · 按 API 公开价估算为 %@～%@";
+
+/* ===== 概览卡片组合 ===== */
+"Overview cards" = "概览卡片";
+"Quota summary" = "额度摘要";
+"Limits" = "Agent 额度";
+"Chart" = "用量图表";
+"Trace" = "实时追踪";
+"Which cards the Overview lens shows, in this order. The usage chart cannot be hidden — Overview is where every hidden lens falls back to, so it has to keep something. Cost and token data are unaffected." = "决定“概览”中显示哪些卡片，顺序如上。用量图表不可隐藏——所有隐藏视图都会回到“概览”，因此这里必须保留内容。费用和 token 数据不受影响。";
+"by reset %lld%%" = "重置时 %lld%%";
+"No usage this day" = "当天无用量";
+"Most recent window" = "最近的窗口";
+"%@ windows ago" = "%@ 个窗口前";
+"Consumed %@%% of the allowance" = "已消耗 %@%% 额度";
+"Ran out" = "已用完";
+"Consuming now · at this rate it runs out before reset (projected %lld%% used)" = "正在消耗 · 按当前速度会在重置前用完（预计已用 %lld%%）";
+"Consuming now · at this rate it reaches %lld%% used by reset" = "正在消耗 · 按当前速度重置时将用到 %lld%%";
+"Recent consumption" = "近期消耗";
+"At this rate it runs out before reset · projected %lld%% used" = "按当前速度会在重置前用完 · 预计已用 %lld%%";
+"At this rate it reaches %lld%% used by reset" = "按当前速度，重置时将用到 %lld%%";
+"The pace line beside it compares you with your usual pattern instead." = "旁边的消耗节奏线用于和你的惯常用量模式比较，两者含义不同。";
+
+/* ===== 额度热力图 ===== */
+"When the allowance goes" = "额度消耗时段";
+"%@ days observed" = "已观测 %@ 天";
+"No allowance movement recorded yet. It accumulates as TokenBar runs." = "尚未记录额度变化。TokenBar 运行期间会逐步积累。";
+"%@%% consumed between readings too far apart to place" = "有 %@%% 的消耗发生在间隔过长的两次读数之间，无法定位到具体时段";
+"No allowance consumed in this slot" = "此时段未消耗额度";
+"%@ allowance-points spent here" = "此时段消耗了 %@ 个额度百分点";
+"~ %@ API-equivalent, ±%@%%" = "≈ %@（按 API 公开价估算，误差 ±%@%%）";
+"Not enough history to convert this window to a figure" = "历史数据不足，无法将此窗口换算为金额";
+"Mon" = "一";
+"Tue" = "二";
+"Wed" = "三";
+"Thu" = "四";
+"Fri" = "五";
+"Sat" = "六";
+"Sun" = "日";
+"Classify your usage in Settings to see what this window is worth" = "在设置中为用量分类，才能估算此窗口的金额";
+"Nothing is classified yet. Settings › Usage attribution splits this by subscription." = "尚未为任何用量分类。“设置”›“用量归属”可以按订阅拆分此图。";
+"%@ of %@ windows recorded — the estimate needs that many" = "已记录 %@ 个窗口；至少需要 %@ 个才能估算";
+"runs out at this rate" = "按当前速度将会用完";
+"Peaked at %@%% · never ran out" = "峰值 %@%% · 从未用完";
+"Peaked at %@%% · ran out at least once" = "峰值 %@%% · 至少用完过一次";
+"Quota could not be loaded." = "无法加载额度。";
+"This agent reported no quota windows." = "此 Agent 未报告任何额度窗口。";
+"Not in the latest quota report." = "不在最新的额度报告中。";
+"Quota unavailable" = "额度不可用";
+"10%% of quota ~ %@, unpriced models, ±%@%%" = "10%% 额度 ≈ %@ token（部分模型没有定价，误差 ±%@%%）";
+"unpriced models, ±%@%%" = "部分模型没有定价，误差 ±%@%%";
+"10%% of quota ~ %@ API-equivalent, tokens unavailable, ±%@%%" = "10%% 额度 ≈ %@（按 API 公开价估算，无 token 明细，误差 ±%@%%）";
+"%@%% consumed, but every pair of readings was too far apart to place on the grid. It fills in as sampling gets denser." = "已消耗 %@%%，但每两次读数的间隔都太长，无法定位到热力图网格。随着采样变密，数据会逐步补全。";
+"Usage recorded, but none of it is priced." = "已记录用量，但均无价格。";
+"Usage recorded, but it carries no token counts." = "已记录用量，但不含 token 数。";
+"Other subscriptions in the same hours: %@" = "同一时段的其他订阅：%@";
+"Local usage could not be read." = "无法读取本地用量。";
+"tokens unavailable, ±%@%%" = "无 token 明细，误差 ±%@%%";
+"~ %@ – %@ API-equivalent" = "≈ %@–%@（按 API 公开价估算）";
+"The allowance did not move in this window" = "此窗口的额度没有变化";
+"The allowance moved too little to convert reliably" = "额度变化太小，无法可靠换算";
+"The allowance moved, but no usage was recorded on this machine" = "额度有变化，但本机未记录用量";
+"Historically: lasts until reset" = "根据历史：可用到重置";
+"On average: lasts until reset" = "按平均速度：可用到重置";
+"Recently: runs out" = "近期：将会用完";
+"%@ scanned rows have no usable timestamp, so no window can count them" = "扫描到 %@ 行缺少有效时间戳，因此无法计入任何窗口";
+"No local usage matched %@, though this subscription has other usage in this window" = "本地没有与“%@”匹配的用量，但此订阅在该窗口内还有其他用量";
+"Quota history could not be read. It will be retried." = "无法读取额度历史，稍后会重试。";
+"Other subscriptions in the same hours:" = "同一时段的其他订阅：";
+"Unclassified usage in the same hours:" = "同一时段的未分类用量：";
+"Other and unclassified usage in the same hours:" = "同一时段的其他与未分类用量：";
+"Excluded usage in the same hours:" = "同一时段的已排除用量：";
+"Other and excluded usage in the same hours:" = "同一时段的其他与已排除用量：";
+"%@ %@" = "%1$@%2$@";
+
+/* ===== 菜单栏文字外观 ===== */
+"Font color" = "文字颜色";
+"Automatic" = "自动";
+"Custom" = "自定义";
+"Custom color" = "自定义颜色";
+"Menu bar font color" = "菜单栏文字颜色";
+"Hex color" = "十六进制颜色";
+"Enter a 6-digit hex color, e.g. #000000." = "请输入 6 位十六进制颜色值，例如 #000000。";
+"Black" = "黑色";
+"Dark gray" = "深灰色";
+"Light gray" = "浅灰色";
+"White" = "白色";
+"Red" = "红色";
+"Orange" = "橙色";
+"Amber" = "琥珀色";
+"Yellow" = "黄色";
+"Lime" = "青柠绿";
+"Green" = "绿色";
+"Emerald" = "翠绿色";
+"Cyan" = "青色";
+"Blue" = "蓝色";
+"Indigo" = "靛蓝色";
+"Purple" = "紫色";
+"Pink" = "粉色";
+"Normal" = "正常";
+"Low" = "较低";
+"Very low" = "极低";
+"More than 25% remaining, other text, or unavailable quota" = "剩余超过 25%、其他文本或额度不可用";
+"More than 10% and up to 25% remaining" = "剩余超过 10% 且不超过 25%";
+"10% or less remaining" = "剩余 10% 或更低";
+"Custom colors follow each item's remaining quota: normal above 25%, low above 10% through 25%, and very low at 10% or below. Other text and unavailable quota use the normal color. Automatic keeps the original colors." = "自定义颜色根据每个项目的剩余额度应用：超过 25% 为正常；超过 10% 且不超过 25% 为较低；10% 或更低为极低。其他文本和额度不可用时使用正常颜色。自动模式保留原有配色。";

--- a/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -72,7 +72,7 @@
 /* ===== 统计数字 ===== */
 "Total" = "总计";
 "Tokens" = "token";
-"Best day" = "最高单日";
+"Best day" = "单日最高";
 "Total tokens" = "token 总数";
 "Total spend" = "总支出";
 "Active days" = "活跃天数";

--- a/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -307,7 +307,7 @@
 
 /* ===== 设置：说明文字 ===== */
 "Spins faster as the live token rate climbs (idle 2 fps, 1M tokens/min tops out at 40 fps)." = "实时 token 速率越高，转得越快（空闲时 2 fps；达到每分钟 100 万 token 时，上限为 40 fps）。";
-"Gauge icons drain as the selected quota window empties. \"Color on warning only\" stays monochrome until under 25% left (amber) and 10% (red), like the battery icon." = "仪表图标会随所选额度窗口逐渐耗尽。“仅在警告时着色”会保持单色，直到剩余低于 25%（琥珀色）或 10%（红色），与电池图标一致。";
+"Gauge icons drain as the selected quota window empties. \"Color on warning only\" stays monochrome until under 25% left (amber) and 10% (red), like the battery icon." = "仪表图标会随所选额度窗口逐渐耗尽。“仅警示时上色”会保持单色，直到剩余低于 25%（琥珀色）或 10%（红色），与电池图标一致。";
 "Feeds the gauge icons and the \"Quota left\" title. Auto follows whichever window is closest to running out." = "决定仪表图标和“剩余额度”标题的数据源。自动模式会跟踪最接近用完的窗口。";
 "Keep the main TokenBar item. Optional client items show each client's selected quota window; Auto chooses the tightest healthy window for that client." = "保留 TokenBar 主项目。可选的客户端独立项目会显示各自选定的额度窗口；自动模式会选择该客户端剩余最少且状态正常的窗口。";
 "Off hides the Agent-limits quota card everywhere — the Overview summary, every client's own tab, and this preview. Cost/token data is unaffected." = "关闭后会在所有位置隐藏 Agent 额度卡片，包括概览摘要、各客户端标签页和此预览。费用和 token 数据不受影响。";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -1077,6 +1077,53 @@ enum SelfTest {
             !AppLanguage.requiresRelaunch(from: "en", to: "unsupported"),
             "invalid language does not prompt for relaunch")
 
+        let zhHansBundles = [
+            (name: "main bundle", bundle: Bundle.main),
+            (name: "SwiftPM resource bundle", bundle: Bundle.tokenBarResources),
+        ]
+        for (bundleName, bundle) in zhHansBundles {
+            let zhHansWindow = AppLanguage.localizedString(
+                "Session", locale: "zh-Hans", bundle: bundle)
+            let zhHansWindowFormat = AppLanguage.localizedString(
+                "%@ window", locale: "zh-Hans", bundle: bundle)
+            expect(
+                zhHansWindow == "会话"
+                    && zhHansWindowFormat.map { String(format: $0, zhHansWindow ?? "") }
+                        == "会话窗口",
+                "Simplified Chinese window labels resolve from the \(bundleName)")
+
+            let zhHansMore = AppLanguage.localizedString(
+                "Show %lld more · %lld of %lld", locale: "zh-Hans", bundle: bundle)
+            expect(
+                zhHansMore.map { String(format: $0, Int64(7), Int64(20), Int64(27)) }
+                    == "再显示 7 项 · 已显示 20／共 27 项",
+                "Simplified Chinese pagination resolves from the \(bundleName)")
+            let zhHansError = AppLanguage.localizedString(
+                "Failed to load usage: %@", locale: "zh-Hans", bundle: bundle)
+            expect(
+                AppLanguage.localizedString(
+                    "OAuth quota", locale: "zh-Hans", bundle: bundle) == "OAuth 额度"
+                    && zhHansError.map { String(format: $0, "offline") }
+                        == "加载用量失败：offline",
+                "Simplified Chinese dynamic usage copy resolves from the \(bundleName)")
+            let zhHansDays = AppLanguage.localizedString(
+                "%lldd", locale: "zh-Hans", bundle: bundle)
+            let zhHansTokens = AppLanguage.localizedString(
+                "%@ tokens", locale: "zh-Hans", bundle: bundle)
+            expect(
+                zhHansDays.map { String(format: $0, Int64(3)) } == "3天"
+                    && zhHansTokens.map { String(format: $0, "5.2K") } == "5.2K token",
+                "Simplified Chinese streak and token formats resolve from the \(bundleName)")
+            expect(
+                AppLanguage.localizedString(
+                    "Not a subscription", locale: "zh-Hans", bundle: bundle)
+                    == "不计入订阅"
+                    && AppLanguage.localizedString(
+                        "Suggested: not a subscription", locale: "zh-Hans", bundle: bundle)
+                        == "建议：不计入订阅",
+                "Simplified Chinese attribution terms resolve from the \(bundleName)")
+        }
+
         let popoverResizeResult = MainActor.assumeIsolated { () -> (Bool, Bool) in
             let defaults = UserDefaults.standard
             let savedHeight = defaults.object(forKey: PopoverChrome.heightKey)

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -1071,6 +1071,9 @@ enum SelfTest {
             AppLanguage.requiresRelaunch(from: "en", to: "zh-Hant"),
             "language change prompts for relaunch")
         expect(
+            AppLanguage.requiresRelaunch(from: "en", to: "zh-Hans"),
+            "Simplified Chinese language change prompts for relaunch")
+        expect(
             !AppLanguage.requiresRelaunch(from: "en", to: "unsupported"),
             "invalid language does not prompt for relaunch")
 

--- a/Sources/TokenBar/Views/HourlyView.swift
+++ b/Sources/TokenBar/Views/HourlyView.swift
@@ -118,8 +118,10 @@ struct HourlyView: View {
                     }
                 }
                 if timeline.count > visible {
+                    let remaining = min(Self.timelineStep, timeline.count - visible)
                     Button(
-                        "Show \(min(Self.timelineStep, timeline.count - visible)) more · \(visible) of \(timeline.count)"
+                        "Show %lld more · %lld of %lld".localized(
+                            Int64(remaining), Int64(visible), Int64(timeline.count))
                     ) {
                         visible = min(visible + Self.timelineStep, timeline.count)
                     }

--- a/Sources/TokenBar/Views/QuotaSummaryLine.swift
+++ b/Sources/TokenBar/Views/QuotaSummaryLine.swift
@@ -65,8 +65,9 @@ struct QuotaSummaryLine: View {
                         // models sums to exactly zero, so "5.2K tokens · $0.00"
                         // — the case the first version of this comment claimed
                         // to have fixed — survived it untouched.
-                        Text(verbatim: "\(Format.compactTokens(today.tokens)) tokens · "
-                             + Format.money(tokens: today.tokens, cost: today.cost))
+                        Text(verbatim: "%@ tokens".localized(
+                            Format.compactTokens(today.tokens)) + " · "
+                            + Format.money(tokens: today.tokens, cost: today.cost))
                             .font(.caption)
                     }
                 }

--- a/Sources/TokenBar/Views/SettingsPanel.swift
+++ b/Sources/TokenBar/Views/SettingsPanel.swift
@@ -272,11 +272,14 @@ struct SettingsPanel: View {
                         ForEach(QuotaColorLevel.allCases, id: \.self) { level in
                             MenuBarTextColorControl(
                                 level: level, hex: textColorBinding(level), editingLevel: $editingTextColor)
+                                .popover(
+                                    isPresented: textColorEditorPresented(level), arrowEdge: .bottom
+                                ) {
+                                    MenuBarTextColorPopover(
+                                        hex: textColorBinding(level), level: level)
+                                        .id(level)
+                                }
                         }
-                    }
-                    .popover(item: $editingTextColor, arrowEdge: .bottom) { level in
-                        MenuBarTextColorPopover(hex: textColorBinding(level), level: level)
-                            .id(level)
                     }
                 }
             }
@@ -343,6 +346,16 @@ struct SettingsPanel: View {
         case .warning: $warningTextColorHex
         case .critical: $criticalTextColorHex
         }
+    }
+
+    private func textColorEditorPresented(_ level: QuotaColorLevel) -> Binding<Bool> {
+        Binding(
+            get: { editingTextColor == level },
+            set: { presented in
+                if !presented, editingTextColor == level {
+                    editingTextColor = nil
+                }
+            })
     }
 
     private func individualItemRow(_ row: ClientTray.SettingsRow) -> some View {

--- a/Sources/TokenBar/Views/StatsView.swift
+++ b/Sources/TokenBar/Views/StatsView.swift
@@ -54,8 +54,8 @@ struct StatsView: View {
                 ("Total spend", Format.usd(stats.totalCost), true),
                 ("Active days", String(stats.activeDays), false),
                 ("Avg / day", Format.usd(stats.averagePerDay), false),
-                ("Current streak", "\(stats.streaks.current)d", false),
-                ("Longest streak", "\(stats.streaks.longest)d", false),
+                ("Current streak", "%lldd".localized(stats.streaks.current), false),
+                ("Longest streak", "%lldd".localized(stats.streaks.longest), false),
             ]
             LazyVGrid(
                 columns: Array(repeating: GridItem(.flexible(), alignment: .leading), count: 3),

--- a/Sources/TokenBar/Views/WindowUsageCard.swift
+++ b/Sources/TokenBar/Views/WindowUsageCard.swift
@@ -17,7 +17,7 @@ struct WindowUsageCard: View {
     private var hoverMessages: [WindowMessage] { state.usageHalf?.mine ?? [] }
     private var hoverSubtitle: String {
         guard let q = state.quotaHalf else { return "" }
-        return "\(ClientRegistry.style(q.clientId).displayName) · \(q.windowLabel)"
+        return "\(ClientRegistry.style(q.clientId).displayName) · \(q.windowLabel.localized)"
     }
 
     @AppStorage("tokenbar.limits.asUsed") private var asUsed = false
@@ -72,7 +72,7 @@ struct WindowUsageCard: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         case let .noQuotaHistory(_, label, candidates, cardId):
-            DashCard("%@ window".localized(label), subtitle: "No quota history") {
+            DashCard("%@ window".localized(label.localized), subtitle: "No quota history") {
                 windowButtons(candidates: candidates, cardId: cardId)
                 Text("This window has no recorded quota history, so there is no line to draw.".localized)
                     .font(.caption)
@@ -93,7 +93,7 @@ struct WindowUsageCard: View {
     private func card(
         _ quota: WindowQuotaHalf, usage: WindowUsageHalf?, scanFailed: Bool
     ) -> some View {
-        DashCard("%@ window".localized(quota.windowLabel), subtitle: stateLine(quota)) {
+        DashCard("%@ window".localized(quota.windowLabel.localized), subtitle: stateLine(quota)) {
             SegmentedPicker(
                 selection: Binding(get: { asUsed }, set: { asUsed = $0 }),
                 options: [(value: false, label: "Remaining"), (value: true, label: "Used")])

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -97,6 +97,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>CFBundleLocalizations</key>
     <array>
         <string>en</string>
+        <string>zh-Hans</string>
         <string>zh-Hant</string>
     </array>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

This PR adds first-class Simplified Chinese (`zh-Hans`) localization support to the TokenBar macOS app.

It introduces a reviewed Simplified Chinese catalog with 488 localization entries, exposes `简体中文` in the app language selector, packages the locale for both direct SwiftPM runs and distributed `.app` bundles, and fixes dynamic strings that previously bypassed localization.

The copy was reviewed in its actual UI context and compared with the existing Traditional Chinese localization. It is not a mechanical character conversion: terminology, word order, punctuation, counters, units, and formatted sentences were adapted for natural Simplified Chinese usage.

## Key localization decisions

The Simplified Chinese copy consistently uses:

- `用量` for usage
- `额度` for quota, including `OAuth 额度`
- `消耗节奏` for pace
- `比预期多消耗` / `比预期少消耗` for deficit and reserve states
- `单日最高` for “Best day”
- `仅警示时上色` for “Color on warning only”
- `建议：不计入订阅` for the corresponding attribution suggestion
- Natural Chinese window labels such as `会话窗口`
- Chinese counters and compact units such as `项`, `个窗口`, `天`, and `小时`

Product names, client names, model names, provider identifiers, and stored window identifiers remain unchanged. Window labels are localized only at the display boundary so quota selection and persisted values continue to use their original identifiers.

## What changed

### Language selection and resource packaging

- Added `zh-Hans` to `AppLanguage`.
- Added `简体中文` to the language selector.
- Reused the existing relaunch-based language switching behavior because Cocoa resolves `AppleLanguages` during startup.
- Added `zh-Hans.lproj` to the SwiftPM resource bundle in `Package.swift`.
- Included `zh-Hans` in `CFBundleLocalizations` when assembling `TokenBar.app`.
- Added `zh-Hans` to the localization resources staged beside direct-run executables, allowing SwiftUI and `Bundle.main` lookups to behave consistently in development and packaged builds.

### Simplified Chinese translation coverage

Added `Sources/TokenBar/Resources/Localizations/zh-Hans.lproj/Localizable.strings`, covering the main macOS app surfaces:

- Top-level tabs and navigation
- Popover controls and loading states
- Empty states and error messages
- Dashboard cards and statistics
- Daily, monthly, hourly, model, and agent views
- Contribution charts and tooltips
- Quota summaries and quota-window cards
- Quota history, trends, heatmaps, and cross-subscription summaries
- Pace, reset, risk, deficit, and reserve messages
- Usage attribution and subscription classification
- Settings sections, controls, explanatory copy, and accessibility labels
- Menu bar item, gauge, and custom text-color settings
- Compact dates, durations, percentages, token counts, message counts, and other formatted values

### Dynamic localization paths

Several values are assembled at runtime and therefore cannot rely on SwiftUI’s implicit localization of string literals. These paths now explicitly resolve complete localization keys before display:

- Dashboard usage-loading failures
- Hourly pagination such as “Show 7 more · 20 of 27”
- Token totals in quota summaries
- Token values in the 3D contribution tooltip
- Current and longest streak day suffixes
- Quota window titles
- Quota window labels in hover subtitles and no-history states

Complete format strings are localized as one semantic unit where Chinese requires different word order. Positional placeholders are used where necessary to preserve argument ordering safely.

### Localization regression coverage

The selftest now:

- Verifies that switching to `zh-Hans` requires a relaunch.
- Reads a requested locale explicitly without changing the process-wide `AppleLanguages`.
- Checks representative Simplified Chinese window, pagination, error, quota, streak, token, and attribution strings.
- Verifies formatted placeholder ordering and expected output.
- Runs the same assertions against both:
  - `Bundle.main`, used by SwiftUI literal localization.
  - `TokenBar_TokenBar.bundle`, used by explicit resource-bundle lookup.

Testing both copies prevents a packaged app from silently passing selftest when only the SwiftPM resource bundle contains the latest localization while the main app bundle is missing or stale.

## Scope and compatibility

This change is limited to the TokenBar macOS app and its localization resources.

It does not change:

- Rust or C ABI behavior
- Usage scanning or aggregation
- Quota calculations or pace algorithms
- Provider or account handling
- Pricing
- Network requests
- Stored quota/window identifiers
- User data or privacy behavior
- The English or Traditional Chinese translation catalogs

The shared display code continues to fall back to the English source string when a locale does not provide a matching entry.

Language changes continue to require an app relaunch, matching the existing English and Traditional Chinese behavior.

## Expected result

After merging:

1. `简体中文` appears in TokenBar’s language settings.
2. Selecting it and relaunching the app loads the `zh-Hans` interface.
3. Major app, dashboard, quota, statistics, chart, and settings surfaces display reviewed Simplified Chinese copy.
4. Runtime-generated labels and formatted messages no longer leak avoidable English fragments.
5. Simplified Chinese resources resolve in both direct development runs and packaged `.app` builds.
6. Existing data processing and non-localization behavior remain unchanged.

## Diff scope

- 4 commits
- 11 files changed
- 641 additions
- 12 deletions
- 1 new localization catalog with 488 entries

## Verification

Completed:

- [x] `git diff --check`
- [x] `plutil -lint` for the English, Simplified Chinese, and Traditional Chinese `.strings` files
- [x] `make build`
- [x] All 10 new Simplified Chinese assertions passed in the bare executable
- [x] All 10 new Simplified Chinese assertions passed from the packaged `TokenBar.app`
- [x] The packaged main-bundle `zh-Hans` catalog matches the source catalog byte for byte
- [x] The packaged SwiftPM resource-bundle `zh-Hans` catalog matches the source catalog byte for byte

Verification limitation:

- [ ] A final completion result for the entire `make selftest` and `make selftest-bundled` suites was not captured. Both runs passed the new localization assertions and continued through the broader suite, but were manually stopped after a prolonged no-output tail.
- [ ] No remote CI run is currently available for this branch; upstream PR CI should provide the integration result.