### PR TITLE
fix(i18n): translate the last window-label site and close the zh-Hant key gap

### DIFF
--- a/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Sources/TokenBar/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -29,6 +29,7 @@
 "Refresh usage data (⌘R) — showing data from %@" = "重新整理用量資料（⌘R）— 顯示的是%@的資料";
 "Updating usage data" = "正在更新用量資料";
 "Loading usage…" = "正在載入用量…";
+"Failed to load usage: %@" = "載入用量失敗：%@";
 "Loading…" = "載入中…";
 "Settings" = "設定";
 "Quit" = "結束";
@@ -55,6 +56,7 @@
 "Token Usage" = "Token 用量";
 "Streaks" = "連續紀錄";
 "Agent limits" = "Agent 額度";
+"OAuth quota" = "OAuth 額度";
 "Live session" = "即時工作階段";
 "Models by cost" = "模型費用排行";
 "Agents by cost" = "Agent 費用排行";
@@ -119,6 +121,7 @@
 "Price" = "費用";
 "Show less" = "收合";
 "Show %lld more" = "再顯示 %lld 筆";
+"Show %lld more · %lld of %lld" = "再顯示 %1$lld 筆 · 已顯示 %2$lld／共 %3$lld 筆";
 "Show more" = "顯示更多";
 "Prices updated %@" = "價格更新於 %@";
 "LiteLLM pricing data; refreshes automatically about once an hour" = "LiteLLM 價格資料，大約每小時自動更新一次";

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -1077,11 +1077,11 @@ enum SelfTest {
             !AppLanguage.requiresRelaunch(from: "en", to: "unsupported"),
             "invalid language does not prompt for relaunch")
 
-        let zhHansBundles = [
+        let localizationBundles = [
             (name: "main bundle", bundle: Bundle.main),
             (name: "SwiftPM resource bundle", bundle: Bundle.tokenBarResources),
         ]
-        for (bundleName, bundle) in zhHansBundles {
+        for (bundleName, bundle) in localizationBundles {
             let zhHansWindow = AppLanguage.localizedString(
                 "Session", locale: "zh-Hans", bundle: bundle)
             let zhHansWindowFormat = AppLanguage.localizedString(
@@ -1122,6 +1122,22 @@ enum SelfTest {
                         "Suggested: not a subscription", locale: "zh-Hans", bundle: bundle)
                         == "建议：不计入订阅",
                 "Simplified Chinese attribution terms resolve from the \(bundleName)")
+
+            // The three keys zh-Hans introduced. A missing entry renders as
+            // English rather than breaking, so nothing else in this suite can
+            // notice one catalog carrying a key the other does not.
+            let zhHantMore = AppLanguage.localizedString(
+                "Show %lld more · %lld of %lld", locale: "zh-Hant", bundle: bundle)
+            let zhHantError = AppLanguage.localizedString(
+                "Failed to load usage: %@", locale: "zh-Hant", bundle: bundle)
+            expect(
+                zhHantMore.map { String(format: $0, Int64(7), Int64(20), Int64(27)) }
+                    == "再顯示 7 筆 · 已顯示 20／共 27 筆"
+                    && zhHantError.map { String(format: $0, "offline") }
+                        == "載入用量失敗：offline"
+                    && AppLanguage.localizedString(
+                        "OAuth quota", locale: "zh-Hant", bundle: bundle) == "OAuth 額度",
+                "Traditional Chinese carries the keys zh-Hans added, from the \(bundleName)")
         }
 
         let popoverResizeResult = MainActor.assumeIsolated { () -> (Bool, Bool) in

--- a/Sources/TokenBar/Views/WindowUsageCard.swift
+++ b/Sources/TokenBar/Views/WindowUsageCard.swift
@@ -426,8 +426,13 @@ struct WindowUsageCard: View {
     @ViewBuilder
     private func scopeNote(_ usage: WindowUsageHalf?, label: String) -> some View {
         if let usage, usage.scopeMatchedNothing {
+            // The label is a window identifier, so it arrives in English like
+            // every other stored value — the third display site in this file
+            // that has to translate it, alongside the two DashCard titles and
+            // `hoverSubtitle`. Resolving it inside this helper rather than at
+            // the single call site keeps the next caller from missing it.
             Text("No local usage matched %@, though this subscription has other usage in this window"
-                .localized(label))
+                .localized(label.localized))
                 .font(.system(size: 9))
                 .foregroundStyle(.orange)
                 .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Summary

Two loose ends from #268, both of which leave an English fragment inside an otherwise translated card.

## The third window-label display site

`window.label` is a stored identifier, so it arrives in English and has to be translated at each display boundary. `QuotaHeatmapCard` and `QuotaHistoryStripCard` already did this; #268 added the two `DashCard` titles and `hoverSubtitle` in `WindowUsageCard`. `scopeNote` was the one left, so a card titled `会话窗口` could carry `No local usage matched Session` underneath it.

Resolved inside `scopeNote` rather than at its call site. It is a private helper with one caller today, and `docs/knowledge/architecture.md` already prefers converging `.localized` inside a shared helper over repeating it at every call site — that is also what keeps the next caller from missing it.

## Three keys Traditional Chinese did not have

#268 introduced `Failed to load usage: %@`, `Show %lld more · %lld of %lld` and `OAuth quota`. Those were English before it, so Traditional Chinese was not regressed — but Simplified was ahead of it. Now both catalogs carry the same 488 keys.

The pagination string reuses the counter already established by `"Show %lld more" = "再顯示 %lld 筆"` and keeps positional placeholders, since Chinese reorders the arguments.

## Verification

A missing entry renders as English rather than failing, so no existing assertion could notice one catalog carrying a key the other does not. The new check reads all three keys and compares the formatted output, against both `Bundle.main` and the SwiftPM resource bundle — the same pair #268 established, since a packaged app can otherwise pass while shipping a stale catalog.

| Gate | Result |
|---|---|
| `make selftest` | passed |
| `plutil -lint` on both catalogs | OK |
| `make selftest-bundled` | reached both new assertions green, but stopped short of completion twice under local memory pressure — CI covers the rest |

Mutation: deleting the `OAuth quota` line from `zh-Hant.lproj` fails exactly the two new assertions and nothing else, with 1299 checks still green and a non-zero exit.
