### PR TITLE
chore(ffi): clear the four dead-code warnings from the release build

### DIFF
--- a/crates/tb_core_ffi/src/agent_account_scope.rs
+++ b/crates/tb_core_ffi/src/agent_account_scope.rs
@@ -107,6 +107,12 @@ impl AuthoritativeIdKind {
 pub(crate) enum AccountScopeError {
     NoTrustedEvidence,
     InvalidEvidence,
+    /// Returned by `SystemBackend::random_bytes` on a target neither secure
+    /// storage path covers, so it is unreachable on macOS and Windows — the
+    /// only two the app ships for. Matching it in `Display` does not count as
+    /// constructing it, which is what the warning is about. Cfg-gating the
+    /// variant would force the same cfg onto that arm for no gain.
+    #[allow(dead_code)]
     UnsupportedPlatform,
     InstallationKeyRead,
     InvalidInstallationKey,
@@ -171,9 +177,15 @@ trait Backend {
     fn random_bytes(&self, length: usize) -> Result<Vec<u8>, AccountScopeError>;
     fn storage_dir(&self) -> Result<PathBuf, AccountScopeError>;
     fn now_seconds(&self) -> i64;
-    fn uses_windows_secure_storage(&self) -> bool {
-        false
-    }
+    /// Every caller sits under `#[cfg(target_os = "windows")]`, so on macOS
+    /// this method is declared and implemented but never reached. Cfg-gating it
+    /// would mean the same cfg on both impls for no gain.
+    ///
+    /// Required rather than defaulted: both implementations answer it, so a
+    /// default body would be code no build can reach. `before_fs` below keeps
+    /// its default because `SystemBackend` does take that one.
+    #[allow(dead_code)]
+    fn uses_windows_secure_storage(&self) -> bool;
     fn before_fs(&self, _operation: FsOperation) -> io::Result<()> {
         Ok(())
     }

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -981,10 +981,6 @@ impl UsageWindow {
         self.pace_status.window_key.as_deref()
     }
 
-    #[cfg(test)]
-    pub(crate) fn pace_reason_for_test(&self) -> Option<&str> {
-        self.pace_status.reason.as_deref()
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -668,24 +668,6 @@ impl Serialize for UsageWindow {
 }
 
 impl UsageWindow {
-    /// Build a window from a "remaining fraction" (0..1) — the shape Antigravity
-    /// reports per model. Used-percent is derived; identity and duration are
-    /// attached by the provider adapter before the snapshot is emitted.
-    pub(crate) fn from_fraction(
-        label: String,
-        remaining_fraction: f64,
-        resets_at: Option<DateTime<Utc>>,
-        now: DateTime<Utc>,
-    ) -> Self {
-        Self::from_used_percent(
-            label,
-            (1.0 - remaining_fraction) * 100.0,
-            resets_at,
-            now,
-            None,
-        )
-    }
-
     /// Build a window from an absolute used-percent (0..100), with an optional
     /// legacy duration hint. The hint is retained only for existing tests and
     /// converted to exact seconds before any wire serialization.

--- a/crates/tb_core_ffi/src/window_usage.rs
+++ b/crates/tb_core_ffi/src/window_usage.rs
@@ -212,6 +212,9 @@ fn account_parse_options(
     })
 }
 
+/// Test instrumentation: the counter exists in every build so `cached` can
+/// increment it, but reading it is only ever a test's business.
+#[cfg(test)]
 pub(crate) fn scan_count() -> usize {
     SCAN_COUNT.load(Ordering::Relaxed)
 }


### PR DESCRIPTION
Fixes #269.

Four `dead_code` warnings from `tb_core_ffi` on a macOS release build, with four different causes, so four different treatments.

## Cross-platform code a single-target build cannot reach

Both keep an `#[allow(dead_code)]` carrying the reason rather than a `cfg`.

`AccountScopeError::UnsupportedPlatform` is constructed only by `SystemBackend::random_bytes` under `#[cfg(not(any(target_os = "macos", target_os = "windows")))]`. Matching it in the `Display` arm does not count as constructing it, so cfg-gating the variant would force the same cfg onto that arm for nothing.

Every call to `Backend::uses_windows_secure_storage` sits under `#[cfg(target_os = "windows")]` — the attribute is on the statement above each call, which is why grepping the call sites does not show it and why my first reading of this one was wrong. Cfg-gating the method would mean the same cfg on both implementations.

The trait method also loses its default body: both implementations override it, so the default was unreachable in every build. That is a tidy-up, not the fix — removing it left the warning in place and moved it onto the method declaration, which is what surfaced the Windows-only call sites.

## Genuinely unused

`UsageWindow::from_fraction` was superseded. The Antigravity adapter builds windows through `UsageWindow::try_from_provider_fraction` (`agent_antigravity.rs:690`), which rejects a fraction that is not finite and within `0..=1`. `from_fraction` is the unchecked original from port commit `54c433cb` and has had no callers since — deleted rather than annotated, because keeping it leaves a constructor that accepts exactly the input the `try_` variant exists to refuse.

`window_usage::scan_count` reads a counter every build increments but only the tests consult, so it takes `#[cfg(test)]` alongside its callers.

## Warning policy

No `-D warnings`. A rustc upgrade introducing a new lint would turn unrelated PRs red, which costs more on a repository this size than it catches. The release build is meant to stay quiet by carrying no dead code, which is why three of the four are deletions or narrowed scope and only the two platform boundaries get an `allow`.

## A fifth, in the test build

Second commit. A fresh-context review of the first one ran `cargo test -p tb_core_ffi` too and found `method pace_reason_for_test is never used`, in the `cfg(test)` build only. It predates this branch (identical on `0aeb3309`, shifted by the deleted lines), but the argument for clearing warnings at all — a standing set of known ones hides the next real one — does not stop at the release profile.

`UsageWindow` exposes seven `*_for_test` accessors. Six have between five and twenty call sites across the antigravity, copilot and grok test modules; this one has none. Deleted rather than annotated, since it is already `#[cfg(test)]` and `pace_status.reason` stays reachable through the field.

## Verification

| Gate | Result |
|---|---|
| `cargo build --release` | warning-free |
| `cargo test -p tb_core_ffi` | 425 passed, 0 failed, 6 ignored, no warnings |

The release gate was independently re-run in a fresh context after `cargo clean -p tb_core_ffi --release`, so it is not a cached silent pass.
