### PR TITLE
chore(release): emit the cask with postflight_steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,8 @@ jobs:
 
             app "TokenBar.app"
 
-            postflight do
-              system_command "/usr/bin/xattr",
-                args: ["-dr", "com.apple.quarantine", "#{appdir}/TokenBar.app"]
+            postflight_steps do
+              run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{appdir}}/TokenBar.app"]
             end
 
             zap trash: [


### PR DESCRIPTION
The release workflow writes `Casks/tokenbar.rb` with a heredoc that replaces the file wholesale, so the cask's contents live in this repo rather than in the tap. A fix applied in the tap alone is overwritten by the next release, silently — which is what would have happened to [Nanako0129/homebrew-tokenbar#2](https://github.com/Nanako0129/homebrew-tokenbar/pull/2), submitted against the tap by an outside contributor. This is the same change, applied where it survives.

`postflight` with a `system_command` becomes `postflight_steps` with a declarative `run` step, and Ruby's `#{appdir}` interpolation becomes the `{{appdir}}` template Homebrew expands at install time. Behavior is identical: the quarantine attribute is still removed from the staged app after install.

## The stated reason does not hold; the real one is narrower

The report claims every brew command currently prints a deprecation warning. On 6.0.21 it does not — the `odeprecated` call is commented out at `cask/dsl.rb:858`, and the warning text quoted in the report appears nowhere in the source tree. The rubocop that does exist is scoped to first-party casks: `LEGACY_FLIGHT_MSG` reads ``Casks in official Homebrew taps must use `%<steps>s` ``, guarded by `next unless official_homebrew_tap?`. A third-party tap passes `brew audit --strict` either way, before and after.

What makes it worth doing now is the comment directly above that guard:

```ruby
# odeprecated: remove the official-tap scope in the next major or minor release.
next unless official_homebrew_tap?(processed_source.file_path)
```

Upstream has the deprecation written and staged behind a comment. Two lines now costs less than being told later.

## Verified, not taken from the report

All against the locally installed Homebrew 6.0.21.

| Claim | Evidence |
|---|---|
| `postflight_steps` is a real stanza | `rubocops/cask/constants/stanza.rb:74` pairs it with `postflight` |
| `run` is permitted in a cask steps block | `COMMAND_STEP_METHODS = [:run, :terminate_process]`, folded into `CASK_ALLOWED_STEP_METHODS` |
| Template tokens inside `args` are expanded | `install_steps.rb:1217` maps every element through `expand_template_tokens`; `appdir` is in `CONTENT_PATH_TOKENS` at :880 |
| The generator's output is correct | Ran this heredoc with the current `VERSION`/`SHA256`: `{{appdir}}` survives the unquoted heredoc, `#{version}` still reaches Ruby |
| That output is a valid cask | `Cask::CaskLoader::FromContentLoader` reports `PostflightSteps: 1 install step` |

The third row is the one that mattered. Had `appdir` not been a template token, the `xattr` call would have run against a literal `{{appdir}}/TokenBar.app`, left the quarantine attribute in place, and failed silently — an installed app that will not open, with nothing in the install output to say why.

Not verified here: the tap's cask is only regenerated on the next release, so the first artifact carrying this is whatever ships next.
