### PR TITLE
refactor(test): cut the filter-parity probe tests to the contracts the probe owns

### DIFF
--- a/crates/tb_core_ffi/src/filter_parity_probe.rs
+++ b/crates/tb_core_ffi/src/filter_parity_probe.rs
@@ -512,50 +512,22 @@ mod tests {
                 ProbeStatus::SourceChanged,
                 "boundary {changed_at}"
             );
-            let expected = match changed_at {
-                1 => vec!["token0", "graph", "token1"],
-                2 => vec!["token0", "graph", "token1", "hourly-nil", "token2"],
-                3 => vec![
-                    "token0",
-                    "graph",
-                    "token1",
-                    "hourly-nil",
-                    "token2",
-                    "hourly-full",
-                    "token3",
-                ],
-                4 => vec![
-                    "token0",
-                    "graph",
-                    "token1",
-                    "hourly-nil",
-                    "token2",
-                    "hourly-full",
-                    "token3",
-                    "agents-nil",
-                    "token4",
-                ],
-                5 => vec![
-                    "token0",
-                    "graph",
-                    "token1",
-                    "hourly-nil",
-                    "token2",
-                    "hourly-full",
-                    "token3",
-                    "agents-nil",
-                    "token4",
-                    "agents-full",
-                    "token5",
-                ],
-                _ => unreachable!(),
-            };
+            // Every stage is bracketed by one token read, so a change seen at
+            // boundary `changed_at` ends the log at `token{changed_at}`.
+            let stages = [
+                "graph",
+                "hourly-nil",
+                "hourly-full",
+                "agents-nil",
+                "agents-full",
+            ];
+            let mut expected = vec!["token0".to_string()];
+            for (index, stage) in stages.iter().take(changed_at).enumerate() {
+                expected.push(stage.to_string());
+                expected.push(format!("token{}", index + 1));
+            }
             assert_eq!(
-                calls
-                    .borrow()
-                    .iter()
-                    .map(String::as_str)
-                    .collect::<Vec<_>>(),
+                *calls.borrow(),
                 expected,
                 "stage call log for boundary {changed_at}"
             );
@@ -597,17 +569,6 @@ mod tests {
             &mut agents_fn,
         );
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn hourly_stays_stable_when_only_the_later_agents_boundary_changes() {
-        let result = run_fixture(
-            vec![Ok(1), Ok(1), Ok(1), Ok(1), Ok(1), Ok(2)],
-            vec![Ok(hourly(10, 2, 0.25)), Ok(hourly(10, 2, 0.25))],
-            vec![Ok(agents(10, 2, 0.25)), Ok(agents(10, 2, 0.25))],
-        );
-        assert_eq!(result.hourly.status, ProbeStatus::Match);
-        assert_eq!(result.agents.status, ProbeStatus::SourceChanged);
     }
 
     #[test]
@@ -679,33 +640,5 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["graph", "hourly-nil"]
         );
-    }
-
-    #[test]
-    fn controlled_append_changes_the_real_source_token_by_size() {
-        let root = std::env::temp_dir().join(format!(
-            "tokenbar-filter-parity-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        let source = root.join(".codex/sessions/session.jsonl");
-        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
-        std::fs::write(&source, b"seed\n").unwrap();
-        let options = tokscale_core::LocalParseOptions {
-            home_dir: Some(root.to_string_lossy().into_owned()),
-            use_env_roots: false,
-            clients: Some(vec!["codex".to_string()]),
-            ..Default::default()
-        };
-        let before = tokscale_core::local_source_change_token(&options).unwrap();
-        let mut file = OpenOptions::new().append(true).open(&source).unwrap();
-        file.write_all(b"size-changing append\n").unwrap();
-        file.flush().unwrap();
-        let after = tokscale_core::local_source_change_token(&options).unwrap();
-        let _ = std::fs::remove_dir_all(root);
-        assert_ne!(before, after);
     }
 }


### PR DESCRIPTION
Refs #175. Replaces the approach of #248, which is held at +271/−175: this is the delete-only version of the same slice, measured against today's `main`.

`crates/tb_core_ffi/src/filter_parity_probe.rs`, `mod tests` only. Production probe, C ABI, Swift DTO and the vendored `tests/filter_parity.rs` are untouched (the vendor half moves with a pin bump, not here).

| | Before | After |
|---|---|---|
| File | 711 | 644 |
| `mod tests` | 364 lines / 10 tests | 297 lines / 8 tests |
| `git diff --numstat` | | +15 / −82 (**net −67**) |

## What changed

- `every_relevant_boundary_is_source_changed_and_later_scans_short_circuit`: the five hand-written expected call-log vectors (38 lines) are replaced by one generated expectation — `token0`, then for each stage that ran its name and the next token, ending at `token{changed_at}` — still compared for exact equality. Same contract, one shape.
- `hourly_stays_stable_when_only_the_later_agents_boundary_changes`: deleted; it was the `changed_at == 5` row of the loop above.
- `controlled_append_changes_the_real_source_token_by_size`: deleted; the retained end-to-end append test cannot produce `SourceChanged` on both lanes with a `["graph", "hourly-nil"]` log unless the real token moved.

## Verification

| Gate | Result |
|---|---|
| `cargo test -p tb_core_ffi filter_parity` | 8 passed, 0 failed |
| `rustfmt --check` on the file | clean |
| Mutation: narrow the boundary-2 gate in `run_with` to `[token0, token1]` | `every_relevant_boundary_*` fails at "stage call log for boundary 2" and `controlled_append_between_stages_*` fails; restored tree passes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExnASftkbqektVcG26cSGZ