### PR TITLE
refactor(test): drop pace and quota-scalar assertions that re-prove a branch

### DIFF
--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -3456,18 +3456,18 @@ enum SelfTest {
 
         // Stage 5D UI presentation: typed state copy and mode gates are pure
         // helper behavior, so these contracts do not depend on SwiftUI layout.
-        for mode in [PaceMode.historical, PaceMode.linear] {
-            expect(
-                AgentLimitsCard.PacePresentation.statusText(
-                    state: .learningDuration, reason: nil, mode: mode)
-                    == "Learning reset duration",
-                "learningDuration copy in \(mode.rawValue) mode")
-            expect(
-                AgentLimitsCard.PacePresentation.statusText(
-                    state: .legacyMissing, reason: nil, mode: mode)
-                    == "Pace unavailable · legacy data",
-                "legacy pace copy in \(mode.rawValue) mode")
-        }
+        // `statusText` ignores `mode` for these two states, so one mode is
+        // the whole proof.
+        expect(
+            AgentLimitsCard.PacePresentation.statusText(
+                state: .learningDuration, reason: nil, mode: .historical)
+                == "Learning reset duration",
+            "learningDuration copy is mode-independent")
+        expect(
+            AgentLimitsCard.PacePresentation.statusText(
+                state: .legacyMissing, reason: nil, mode: .historical)
+                == "Pace unavailable · legacy data",
+            "legacy pace copy is mode-independent")
         expect(
             AgentLimitsCard.PacePresentation.statusText(
                 state: .learningHistory, reason: nil, mode: .historical)
@@ -3513,8 +3513,6 @@ enum SelfTest {
         let linear = UsagePace.compute(window: availableWindow, mode: .linear, now: now)
         expect(linear?.expectedUsedPercent == 50 && linear?.basis == .linear,
             "linear mode ignores available historical")
-        expect(UsagePace.compute(window: availableWindow, now: now)?.basis == .linear,
-            "direct pace compute stays linear")
         // The warning color is basis-independent: a Linear estimate in deficit
         // is colored exactly like a Historical one, so the marker cannot blink
         // out when the Historical fit stops re-qualifying. `linear` is the
@@ -3573,8 +3571,6 @@ enum SelfTest {
         expect(UsagePace.presentation(
             window: learningHistoryWindow, mode: .historical, pace: learningEstimate!).riskText == nil,
             "learningHistory Linear estimate cannot display nested risk")
-        expect(runOutRiskLabel(window: v3Window(used: 50, state: .learningHistory)) == nil,
-            "learningHistory has no historical risk")
 
         let exhaustedWindow = v3Window(
             used: 100, state: .available,
@@ -3680,9 +3676,6 @@ enum SelfTest {
         }
         expect(currentFitRisk == nil, "zero-cycle current fit keeps partial risk absent")
         expect(
-            currentFitPace?.expectedUsedPercent != 40,
-            "zero-cycle current fit does not fall back to Linear")
-        expect(
             unavailable?.paceStatus.state == UsagePaceState.unavailable &&
                 unavailable?.paceStatus.reason == .nonRecurring &&
                 unavailable?.durationSeconds == nil,
@@ -3742,11 +3735,6 @@ enum SelfTest {
             ("duration and windowMinutes contradiction", """
              {"cardId":"weekly.v1","label":"Weekly","usedPercent":50,"remainingPercent":50,
               "windowMinutes":301,"paceStatus":{"state":"learningHistory","windowKey":"weekly.v1",
-              "durationSeconds":18000,"durationSource":"contract","completeCycles":0}}
-             """),
-            ("duration without derived windowMinutes", """
-             {"cardId":"weekly.v1","label":"Weekly","usedPercent":50,"remainingPercent":50,
-              "paceStatus":{"state":"learningHistory","windowKey":"weekly.v1",
               "durationSeconds":18000,"durationSource":"contract","completeCycles":0}}
              """),
         ]
@@ -4761,48 +4749,12 @@ enum SelfTest {
                     && restarted?.object(forKey: TrayAnimator.lastRemainingKey) == nil,
                 "terminal empty provider payload clears scalar across restart")
 
-            defaults.set(80, forKey: TrayAnimator.lastRemainingKey)
-            let settingsTerminal = SettingsWindowView.applyQuotaRemaining(
-                payload: terminalPayload,
-                persistedSelection: QuotaResolver.auto,
-                excluding: [],
-                defaults: defaults)
-            let settingsRestarted = UserDefaults(suiteName: suiteName)
-            expect(
-                settingsTerminal == nil
-                    && defaults.object(forKey: TrayAnimator.lastRemainingKey) == nil
-                    && settingsRestarted?.object(forKey: TrayAnimator.lastRemainingKey) == nil,
-                "Settings terminal payload clears persisted scalar across restart")
-
-            defaults.set(65, forKey: TrayAnimator.lastRemainingKey)
-            let settingsBeforeFailure = defaults.persistentDomain(forName: suiteName)
-            let settingsFailure = SettingsWindowView.applyQuotaRemaining(
-                payload: nil,
-                persistedSelection: QuotaResolver.auto,
-                excluding: [],
-                defaults: defaults)
-            expect(
-                settingsFailure == 65
-                    && NSDictionary(dictionary: defaults.persistentDomain(forName: suiteName) ?? [:])
-                        .isEqual(to: settingsBeforeFailure ?? [:]),
-                "Settings outer quota failure preserves persisted scalar")
-
             let fallback = TrayAnimator.applyQuotaRemaining(
                 payload: quotaPayload, persistedSelection: "grok|billing.weekly.v1", excluding: [],
                 cachedRemaining: 80, defaults: defaults)
             expect(
                 fallback == 1 && defaults.double(forKey: TrayAnimator.lastRemainingKey) == 1,
                 "explicit selection keeps same-binding fallback window despite error")
-
-            let errorOnlyPayload = try! JSONDecoder().decode(
-                AgentUsagePayload.self,
-                from: Data((#"{"generatedAt":"now","agents":[{"clientId":"grok","source":"oauth","updatedAt":"now","windows":[{"cardId":"billing.weekly.v1","label":"Weekly","usedPercent":99,"remainingPercent":1}],"error":"Grok request timed out.","transportDiagnostic":{"category":"timeout"}}]}"#).utf8))
-            let autoError = TrayAnimator.applyQuotaRemaining(
-                payload: errorOnlyPayload, persistedSelection: QuotaResolver.auto,
-                excluding: [], cachedRemaining: 1, defaults: defaults)
-            expect(
-                autoError == nil && defaults.object(forKey: TrayAnimator.lastRemainingKey) == nil,
-                "Auto excludes an error-only fallback payload and clears scalar")
 
             defaults.set(1, forKey: TrayAnimator.lastRemainingKey)
             let optionalAbsentPayload = try! JSONDecoder().decode(
@@ -4829,12 +4781,6 @@ enum SelfTest {
                     .isEqual(to: standardAfter ?? [:]),
                 "nil defaults returns fresh quota without touching live defaults")
 
-            let hiddenAll = TrayAnimator.applyQuotaRemaining(
-                payload: quotaPayload, persistedSelection: QuotaResolver.auto,
-                excluding: ["codex", "claude"], cachedRemaining: 66, defaults: defaults)
-            expect(
-                hiddenAll == nil && defaults.object(forKey: TrayAnimator.lastRemainingKey) == nil,
-                "all-hidden successful payload cannot fall back to cached scalar")
             defaults.removePersistentDomain(forName: suiteName)
         } else {
             expect(false, "isolated quota defaults suite is available")


### PR DESCRIPTION
Refs #162, #163. Delete-only. Each removed assertion re-proved a production branch that a retained assertion already takes on an equivalent input; the production lines are cited in the commit message.

`Sources/TokenBar/SelfTest.swift` only.

| | Before | After |
|---|---|---|
| `git diff --numstat` | | +12 / −66 (**net −54**) |
| `expect(` sites | 1,137 | 1,124 |
| `make selftest` | 1,292 ok | 1,282 ok, 0 FAIL, exit 0 |

| Removed | Why |
|---|---|
| second iteration of the `.learningDuration` / `.legacyMissing` copy loop | `statusText` ignores `mode` for both states (`AgentLimitsCard.swift:167-174`) |
| "direct pace compute stays linear" | same `isDurationReady` + `computeCore` path as the `.linear` call above it (`UsagePace.swift:154-157`, `180-182`) |
| "learningHistory has no historical risk" | same `state == .available` gate the `presentation()` call two lines up already fails (`UsagePace.swift:279`) |
| "zero-cycle current fit does not fall back to Linear" (`!= 40`) | implied by the exact `== 30` on the same value |
| "duration without derived windowMinutes" invalid fixture | same `windowMinutes == durationSeconds / 60` guard as the "contradiction" fixture (`AgentUsage.swift:451-453`) |
| Settings terminal-payload and outer-failure cases | `SettingsWindowView.applyQuotaRemaining` forwards verbatim to `TrayAnimator.applyQuotaRemaining` (`SettingsWindowView.swift:282-295`); identical inputs already run through `TrayAnimator.swift:252-264` |
| "Auto excludes an error-only fallback payload" | `autoCandidate`'s `agent.error == nil` clause drops the agent before its windows are read (`QuotaResolver.swift:129`); same branch as the terminal-empty case |
| "all-hidden successful payload cannot fall back to cached scalar" | same `excluding` clause, payload and exclusions as the hidden-all-across-restart case earlier in the narrative |

Kept on purpose: the `orderedPublicationState` and `trayRaceRejected` ordering cases (ascending at the state-machine level vs descending through the tray consumer; different depth, different side effect), `explicit selection keeps same-binding fallback despite error` (the one proof of the explicit/auto asymmetry), and the optional-provider-absence case (same guard as the missing-client case but framed as a different contract; left for a reader's call).

## Verification

`make build` passes. `make selftest`: 1,282 ok, 0 FAIL, `selftest passed`, exit 0 — ten fewer `ok` lines than `main`'s 1,292, exactly the executions removed. CI green on the first push.

Correction to the first version of this description: it said the local selftest was stalled on this machine. It was not. The suite takes about eleven minutes (eleven checks drive `pollAgentUsage`, and each waits out the sixty-second `RegistryChange.sleep` after cancellation, which is also why the CI step takes 11–13 minutes), and its stdout is block-buffered when redirected, so an earlier run was killed at five minutes and misread as a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExnASftkbqektVcG26cSGZ