### PR TITLE
fix(quota): scan for window history when the live window cannot be placed

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -1635,14 +1635,27 @@ private struct DashboardSnapshot {
             rebuildQuotaEquivalences()
             return
         }
-        guard let windowStart = WindowCardLoader.unionStart(
-            payload: agentUsage, clients: [client], nowMs: now)
-        else { return }
         // The history's oldest cycle CONTAINS the active window, so this widens
         // one scan rather than issuing a second. Measured 2026-08-16 on live
         // data: 5.4 days, 45,844 messages, 4.6s — an order of magnitude below
         // the 14.93-day union this replaced, and paid only on the Quota lens.
-        let from = min(windowStart, quotaCycles.last?.evidenceStartMs ?? windowStart)
+        //
+        // EITHER bound is a range on its own, which is why this is a `min` over
+        // whichever exist rather than a window start the cycles may widen. A
+        // window resolves only when the provider gave BOTH a reset and a
+        // duration, and a provider can stop giving one: Codex served `resetsAt`
+        // with no `limit_window_seconds` for all three of its windows (measured
+        // 2026-09-08), so `unionStart` returned nil, this function returned
+        // before scanning, and no scan covering that client's cycles was ever
+        // cached. `rebuildQuotaHistory` then refused to join — correctly, since
+        // another client's narrower scan would under-count — and every row of
+        // the history card sat on "Reading local usage…" permanently, for a
+        // card that needs the cycles and not the live window at all.
+        guard let from = [
+            WindowCardLoader.unionStart(
+                payload: agentUsage, clients: [client], nowMs: now),
+            quotaCycles.last?.evidenceStartMs,
+        ].compactMap({ $0 }).min() else { return }
         // Serve the cached scan while it still covers the range and is fresh.
         // Rescanning on every reopen was the whole complaint: the staging made
         // the wait visible, it did not make it rare.

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -11641,6 +11641,57 @@ enum SelfTest {
         expect((scanCounts?.open ?? 0) >= 1,
                "SC1 an open agent tab does scan, so the bound above is not vacuous")
 
+        // SC2. The scan range used to be anchored on the live window, so a
+        // provider that reports a reset without a window length took the whole
+        // history down with it: `unionStart` returned nil, `refreshWindowUsage`
+        // returned before scanning, and no scan covering this client's cycles
+        // was ever cached — leaving every row of the history card on "Reading
+        // local usage…" permanently rather than for the length of a scan.
+        // Measured on live Codex data 2026-09-08: all three of its windows
+        // carried `resetsAt` with `durationSeconds` nil.
+        //
+        // The cycles are their own range, so both numbers are asserted: a scan
+        // that runs but produces no joined row would satisfy the count alone.
+        let hsReset = wNow - 7_200
+        let hsPayload: AgentUsagePayload = {
+            let json = """
+            {"generatedAt":"t","publicationGeneration":7,"agents":[
+              {"clientId":"codex","source":"oauth","updatedAt":"t","windows":[
+                {"cardId":"main.weekly.v1","label":"Weekly","usedPercent":0,
+                 "remainingPercent":100,"resetsAt":"\(wIso)",
+                 "paceStatus":{"state":"unavailable","windowKey":"main.weekly.v1",
+                               "completeCycles":0,"reason":"invalidEvidence"}}
+              ]}
+            ]}
+            """
+            return try! JSONDecoder().decode(AgentUsagePayload.self, from: Data(json.utf8))
+        }()
+        let durationlessScan: (scans: Int, rows: Int)? = awaitMainActorValue {
+            let src = WindowScanCountingSource(payload: hsPayload)
+            src.curve = windowCurve(
+                resetAtSecs: hsReset, durationSecs: 18_000,
+                at: [(hsReset - 15_000, 4), (hsReset - 600, 40)], isActive: false)
+            let m = DashboardModel(source: src, initialYear: nil)
+            let poll = Task { await m.pollAgentUsage() }
+            var spins = 0
+            while m.agentUsage == nil, spins < 2_000 {
+                try? await Task.sleep(nanoseconds: 1_000_000)
+                spins += 1
+            }
+            poll.cancel()
+            _ = await poll.value
+            m.windowCardClients = ["codex"]
+            m.windowUsageClient = "codex"
+            m.refreshWindowQuotaHalves()
+            src.scans = 0
+            await m.refreshWindowUsage()
+            return (scans: src.scans, rows: m.quotaHistory.count)
+        }
+        expect(durationlessScan?.scans == 1,
+               "SC2 a window with no provider duration still scans for its history")
+        expect(durationlessScan?.rows == 1,
+               "SC2 and the scan reaches the history rows rather than only running")
+
         // SS1. `windowCardClients` is assigned from `displayClients`, which
         // arrives with graph data, so it is briefly empty on every top-level
         // view change. Recomputing the strip summaries from an empty client set


### PR DESCRIPTION
Every row of the window-history card sits on "Reading local usage…" forever whenever the provider stops reporting a window length. Observed on Codex today.

## The chain

The message scan that fills the history card was anchored on the live window: `refreshWindowUsage` returned early unless `WindowCardLoader.unionStart` produced a start, and only then widened the range to the oldest recorded cycle. A window resolves only when the provider supplied **both** a reset and a duration (`WindowResolution.swift:21`).

Measured on live data 2026-09-08 with `--window-probe`:

```
main.weekly.v1         resetsAt=2026-09-15T02:28:26Z  dur=nil  pace=unavailable(invalidEvidence)
additional.…primary    resetsAt=2026-09-08T07:28:26Z  dur=nil  pace=unavailable(invalidEvidence)
additional.…secondary  resetsAt=2026-09-15T02:28:26Z  dur=nil  pace=unavailable(invalidEvidence)

claude session.v1      resetsAt=2026-09-08T07:10:00Z  dur=18000   pace=learningHistory
claude weekly.v1       resetsAt=2026-09-09T10:00:00Z  dur=604800  pace=learningHistory
```

All three Codex windows carry a reset with no duration, because `agent_usage.rs:5168` only builds duration evidence when `limit_window_seconds != 0`. What follows is mechanical:

```
unionStart -> nil
  -> refreshWindowUsage returns before scanning
  -> no scan covering codex's cycles is ever cached
  -> rebuildQuotaHistory's covers(start: oldest.evidenceStartMs) is false
     against every other client's narrower scan
  -> quotaHistory = []  ->  every row draws "Reading local usage…"
```

Permanently, not for the length of a scan. The refusal in `rebuildQuotaHistory` is correct — joining from a scan that starts after the cycle did would silently under-count — so the repair belongs where the range is chosen.

> Worth recording while measuring this: scan cost is not what it was. 26.69 days and 108,387 messages took 2,071 ms, and a 7-day range took 1,468 ms. The "14.93 days = 67 seconds" figure quoted in several comments is long stale.

## The change

The range is now the minimum of whichever bounds exist, rather than a window start that the cycles may widen:

```swift
guard let from = [
    WindowCardLoader.unionStart(payload: agentUsage, clients: [client], nowMs: now),
    quotaCycles.last?.evidenceStartMs,
].compactMap({ $0 }).min() else { return }
```

The cycles are a complete range on their own, and the history card wants them and not the live window — it draws recorded cycles joined to the messages inside them. For a client whose window does resolve, behaviour is unchanged: `min` over both bounds is exactly what the previous line computed.

This does not attempt to explain why Codex stopped sending window lengths. That is a provider-side question, and the history card must not depend on the answer.

## Verification

`make selftest` passes with two new `SC2` cases driving `DashboardModel` through `WindowScanCountingSource`. A payload whose only window carries a reset with no duration, plus a curve holding one closed cycle, now produces exactly **one scan** and **one joined history row**.

Restoring the previous guard fails both (exit 1), so the pair discriminates. Both numbers are asserted because a scan that runs and joins nothing would satisfy the count alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMsv8BNF1wkNBCpzNptH7Q
