### PR TITLE
fix(quota): read the clock after the provider response, not before it

### DIFF
--- a/crates/tb_core_ffi/src/agent_quota_duration.rs
+++ b/crates/tb_core_ffi/src/agent_quota_duration.rs
@@ -523,6 +523,32 @@ mod tests {
         );
     }
 
+    /// The boundary #296 turned on. A provider answering a window with no
+    /// usage yet reports `reset_at = <its now> + duration`, so the cycle's
+    /// start IS the instant the response was built. Evidence evaluated against
+    /// that instant is Ready; evaluated against a clock reading from one
+    /// second earlier — which is what holding `Utc::now()` across the request
+    /// produced — the same evidence is rejected and the window loses its
+    /// duration, its `window_minutes` and its pace with it.
+    #[test]
+    fn a_window_starting_exactly_now_is_ready_and_one_second_early_is_not() {
+        let response_at = 1_788_848_567;
+        let reset = response_at + 5 * HOUR;
+        let evidence = DurationEvidence::provider(reset, 5 * HOUR);
+
+        assert_eq!(
+            resolve_duration(response_at, Some(reset), Some(evidence), None, None),
+            DurationResolution::Ready {
+                duration_seconds: 5 * HOUR,
+                source: DurationSource::Provider,
+            }
+        );
+        assert_eq!(
+            resolve_duration(response_at - 1, Some(reset), Some(evidence), None, None),
+            DurationResolution::Unavailable(DurationUnavailableReason::InvalidEvidence)
+        );
+    }
+
     #[test]
     fn malformed_present_evidence_is_invalid_without_fallback() {
         let now = 10_000;

--- a/crates/tb_core_ffi/src/agent_usage.rs
+++ b/crates/tb_core_ffi/src/agent_usage.rs
@@ -1462,13 +1462,38 @@ where
     }
 }
 
+/// Takes no `now`: it reads the clock itself, and the outcome it is handed is
+/// proof the response has already arrived.
+///
+/// Every caller used to capture `Utc::now()` on its first line and hold it
+/// across the request, so the timestamp the pace evidence was validated
+/// against was older than the response BY CONSTRUCTION — by the round-trip
+/// time. That is fatal for a window a provider reports as not yet started:
+/// Codex answers a window with no usage with `reset_at = <its now> +
+/// limit_window_seconds`, so the cycle's start IS the instant the response was
+/// built, and `valid_evidence`'s `cycle_started_at <= now` compares it against
+/// a clock reading from before the request. Measured on live data 2026-09-08:
+/// start `1788848567` against `now = 1788848566`, one second apart, which
+/// rejected the provider's duration and left `UsageWindow::unavailable` to
+/// clear `duration_seconds`, `duration_source` and `window_minutes` — no pace,
+/// no length, and a window Swift could no longer place at all (#296).
+///
+/// The comparison is at one-second granularity, so the old ordering failed
+/// only when the round trip crossed a second boundary; the same window was
+/// accepted minutes earlier and rejected later, which is why it read as the
+/// provider being inconsistent rather than as a bug here.
+///
+/// The parameter is gone rather than moved below the `await` at each caller,
+/// so a pre-request timestamp cannot be handed back in.
+/// `apply_provider_outcome_with` still takes one, because a test needs to
+/// state the instant it is asserting about.
 fn apply_provider_outcome(
     client_id: &str,
     account: Option<&str>,
     failure_source: &str,
-    now: DateTime<Utc>,
     outcome: ProviderFetchOutcome,
 ) -> Option<AgentUsageSnapshot> {
+    let now = Utc::now();
     apply_provider_outcome_with(
         &PROVIDER_LAST_GOOD,
         client_id,
@@ -1533,7 +1558,7 @@ async fn fetch_grok() -> Option<AgentUsageSnapshot> {
         Ok(None) => ProviderFetchOutcome::Absent,
         Err(failure) => ProviderFetchOutcome::Failure(failure),
     };
-    apply_provider_outcome("grok", None, "oauth", now, outcome)
+    apply_provider_outcome("grok", None, "oauth", outcome)
 }
 
 async fn fetch_copilot() -> Option<AgentUsageSnapshot> {
@@ -1568,7 +1593,7 @@ async fn fetch_copilot() -> Option<AgentUsageSnapshot> {
             }
         }
     };
-    apply_provider_outcome("copilot", None, "oauth", now, outcome)
+    apply_provider_outcome("copilot", None, "oauth", outcome)
 }
 
 async fn fetch_antigravity() -> AgentUsageSnapshot {
@@ -1592,13 +1617,12 @@ async fn fetch_antigravity() -> AgentUsageSnapshot {
         },
         Err(failure) => ProviderFetchOutcome::Failure(failure),
     };
-    apply_provider_outcome("antigravity", None, "oauth", now, outcome)
+    apply_provider_outcome("antigravity", None, "oauth", outcome)
         .expect("Antigravity is a required provider card")
 }
 
 async fn fetch_codex() -> AgentUsageSnapshot {
-    let now = Utc::now();
-    apply_provider_outcome("codex", None, "oauth", now, fetch_codex_inner().await)
+    apply_provider_outcome("codex", None, "oauth", fetch_codex_inner().await)
         .expect("Codex is a required provider card")
 }
 
@@ -1702,9 +1726,8 @@ fn parse_retry_after(value: Option<&reqwest::header::HeaderValue>) -> Option<Dat
 }
 
 async fn fetch_claude() -> AgentUsageSnapshot {
-    let now = Utc::now();
     let (failure_source, outcome) = fetch_claude_inner().await;
-    apply_provider_outcome("claude", None, failure_source, now, outcome)
+    apply_provider_outcome("claude", None, failure_source, outcome)
         .expect("Claude is a required provider card")
 }
 
@@ -1788,9 +1811,8 @@ async fn join_local_ordered<T: 'static>(
 }
 
 async fn fetch_claude_extra_account(config_dir: &str) -> AgentUsageSnapshot {
-    let now = Utc::now();
     let (failure_source, outcome) = fetch_claude_extra_inner(config_dir).await;
-    apply_provider_outcome("claude", Some(config_dir), failure_source, now, outcome)
+    apply_provider_outcome("claude", Some(config_dir), failure_source, outcome)
         .expect("an extra Claude account always produces a card")
 }
 


### PR DESCRIPTION
Fixes #296. A Codex window with no usage yet lost its duration, its pace and its window length, because the pace evidence was validated against a timestamp taken **before** the request that produced it.

## The defect

Every fetcher captured `Utc::now()` on its first line and held it across the request:

```rust
async fn fetch_codex() -> AgentUsageSnapshot {
    let now = Utc::now();                                    // before the request
    apply_provider_outcome("codex", None, "oauth", now, fetch_codex_inner().await)
}
```

`apply_provider_outcome` is where the pace enrichment evaluates duration evidence, so that timestamp is older than the response **by construction** — by the round-trip time.

Codex answers a window with no usage with `reset_at = <its now> + limit_window_seconds`, so the cycle's start IS the instant the response was built, and `valid_evidence` requires `cycle_started_at <= now`. Measured on live data with `--window-probe`:

```
codex Codex Spark  reset_at=1788866567  limit_window_seconds=18000
resolve            now=1788848566       start=1788848567   valid=false
codex Weekly       reset_at=1789440447  limit_window_seconds=604800
resolve            now=1788848566       start=1788835527   valid=true
```

One second apart. `resolve_duration` returned `Unavailable(InvalidEvidence)`, and `UsageWindow::unavailable` then cleared `duration_seconds`, `duration_source` **and** `window_minutes`, so the window reached Swift with a reset and nothing else — no pace, no length, and `WindowResolution.resolve` could not place it at all.

The comparison has one-second granularity, so the old ordering failed only when the round trip crossed a second boundary. The persisted series holds both outcomes for the same window minutes apart, which is why this read as the provider being inconsistent rather than as a defect here.

## The change

`apply_provider_outcome` takes no `now` and reads the clock itself. The outcome it is handed is proof the response has already arrived, so a pre-request timestamp cannot be passed back in.

> The parameter is removed rather than moved below each `await`: the latter is a convention the next caller can break silently, and this one cannot be expressed at all.

`apply_provider_outcome_with` keeps its `now`, because a test has to state the instant it asserts about. The fetchers that capture a pre-request `now` for their own use (grok, copilot and antigravity pass it into the fetch itself) are unaffected — their pace evaluation now uses the post-response reading.

## Verification

Real data, same account, before and after:

| window | before | after |
|---|---|---|
| `codex main.weekly.v1` | UNAVAILABLE | ACTIVE, 9,842 of 10,080 minutes left |
| `codex additional.….primary.v1` (Spark 5h) | UNAVAILABLE | ACTIVE, 299 of 300 minutes left |
| `codex additional.….secondary.v1` (Spark 7d) | UNAVAILABLE | ACTIVE, 10,079 of 10,080 minutes left |

The Spark rows are at 299/300 and 10,079/10,080 minutes — windows that had just begun, which is precisely the state the old ordering rejected.

`cargo test -p tb_core_ffi` passes (422 tests), including the provider-outcome suite that drives `apply_provider_outcome_with` with explicit instants. A new duration test pins the boundary: evidence whose cycle starts exactly at `now` resolves Ready, and the same evidence one second early resolves `InvalidEvidence`. Mutating `cycle_started_at <= now` to `<` fails it, so it discriminates rather than restating the fixture.

No test asserts the capture ORDER, and none can — the parameter that carried the stale timestamp no longer exists, so there is nothing for a test to pass in. Stated here rather than covered by a source scan, which a future edit would relocate around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMsv8BNF1wkNBCpzNptH7Q
