### PR TITLE
feat(tooling): derive the engine delta count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           submodules: recursive
 
+      # The knowledge checks resolve engine SHAs and count commit ranges, which
+      # a depth-1 submodule cannot answer. Without this they return "cannot ask"
+      # and pass silently, which is how a stale delta count reached main three
+      # advances running.
+      - name: Unshallow the engine submodule
+        run: git -C vendor/tokscale-core fetch --unshallow --quiet || true
+
       - name: Validate knowledge contracts
         run: |
           python3 scripts/check_knowledge.py --self-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,14 @@ jobs:
       # and pass silently, which is how a stale delta count reached main three
       # advances running.
       - name: Unshallow the engine submodule
-        run: git -C vendor/tokscale-core fetch --unshallow --quiet || true
+        run: |
+          set -euo pipefail
+          if [ "$(git -C vendor/tokscale-core rev-parse --is-shallow-repository)" = "false" ]; then
+            echo "engine already complete"
+          else
+            git -C vendor/tokscale-core fetch --unshallow --quiet
+          fi
+          test "$(git -C vendor/tokscale-core rev-parse --is-shallow-repository)" = "false"
 
       - name: Validate knowledge contracts
         run: |

--- a/scripts/check_knowledge.py
+++ b/scripts/check_knowledge.py
@@ -266,13 +266,17 @@ def sha_exists_in_engine(root,sha):
     except (OSError,subprocess.SubprocessError): return None
     return out.returncode==0
 
+UNRESOLVED = object()  # asked and answered no, as distinct from cannot ask
 DELTA_CLAIM = re.compile(r'`([0-9a-f]{7,40})`\s*(?:→|->)\s*`([0-9a-f]{7,40})`\s*delta\s*(?:為|is)\s*([0-9,]+)\s*(?:個\s*)?engine\s*commit')
 
 def engine_rev_count(root,base,head):
-    """Commits in `base..head` inside the submodule, or None when unanswerable.
+    """Commits in `base..head` inside the submodule.
 
-    A shallow clone cannot count a range it does not hold, and returning a
-    number there would be worse than returning nothing.
+    Three outcomes, and collapsing them is how a guard passes while doing
+    nothing: an integer is the answer; None means the question cannot be asked
+    here (no checkout, or a shallow one that does not hold the range); and
+    UNRESOLVED means it was asked and the revisions are not in this engine,
+    which is a defect in the claim rather than a limit of the environment.
     """
     import subprocess
     engine=root/'vendor'/'tokscale-core'
@@ -281,7 +285,7 @@ def engine_rev_count(root,base,head):
         out=subprocess.run(['git','rev-list','--count',f'{base}..{head}'],cwd=engine,
                            capture_output=True,text=True,timeout=10)
     except (OSError,subprocess.SubprocessError): return None
-    if out.returncode!=0: return None
+    if out.returncode!=0: return UNRESOLVED
     return int(out.stdout.strip() or 0)
 
 def check_engine_delta(root,files,errors):
@@ -298,6 +302,10 @@ def check_engine_delta(root,files,errors):
             base,head,claimed=m.group(1),m.group(2),int(m.group(3).replace(',',''))
             actual=engine_rev_count(root,base,head)
             if actual is None or actual==claimed: continue
+            if actual is UNRESOLVED:
+                errors.append(Issue(rel,line_no(text,m.start()),
+                    f'delta endpoints do not resolve in the engine: {base}..{head}'))
+                continue
             errors.append(Issue(rel,line_no(text,m.start()),
                 f'delta count disagrees with the engine\n    claimed {claimed} for {base}..{head}\n    actual  {actual}'))
 
@@ -514,6 +522,18 @@ def self_test():
             self.assertEqual(engine_rev_count(r,base,head),3,'fixture must have a countable range')
             self.append_doc(r,f'\n\n本次 `{base[:7]}` → `{head[:7]}` delta 為 99 個 engine commit。\n')
             self.assertIn('delta count disagrees','\n'.join(map(str,validate(r))))
+        def test_unresolvable_delta_endpoints_are_reported(self):
+            """A typo in an endpoint must not silence the count check.
+
+            `git rev-list` exits non-zero for an unknown revision, which is an
+            answer, not an inability to ask -- collapsing the two lets anyone
+            disable the check by mistyping a SHA."""
+            import subprocess
+            r=self.root(); engine=r/'vendor'/'tokscale-core'; engine.mkdir(parents=True,exist_ok=True)
+            subprocess.run(['git','init','-q'],cwd=engine,capture_output=True,check=True)
+            subprocess.run(['git','-c','user.email=t@t','-c','user.name=t','commit','-q','--allow-empty','-m','c'],cwd=engine,capture_output=True,check=True)
+            self.append_doc(r,'\n\n本次 `deadbee` → `f00dfac` delta 為 3 個 engine commit。\n')
+            self.assertIn('do not resolve in the engine','\n'.join(map(str,validate(r))))
         def test_missing_reviewed_pin_row_is_reported(self):
             r=self.root(); (r/'vendor/README.md').write_text('[Knowledge](../docs/knowledge/vendor-tokscale.md)')
             self.assertIn('reviewed pin row is missing','\n'.join(map(str,validate(r))))

--- a/scripts/check_knowledge.py
+++ b/scripts/check_knowledge.py
@@ -196,6 +196,7 @@ def validate(root):
     if not vendor_doc.exists(): errors.append(Issue('docs/knowledge/vendor-tokscale.md',1,'vendor-tokscale.md is missing'))
     elif not any(t==vendor for t,_,_ in relative_links(root,vendor_doc,vendor_doc.read_text(encoding='utf-8')) if isinstance(t,Path)): errors.append(Issue(vendor_doc.relative_to(root),1,'vendor-tokscale.md must link to the consumer pin document'))
     check_engine_pin(root,files,errors)
+    check_engine_delta(root,files,errors)
     ledger=next((p for p,d in meta.items() if d.get('kind')=='ledger'),None)
     if ledger: check_ledger(root,ledger,meta,errors)
     else: errors.append(Issue('docs/knowledge',1,'migration ledger document is missing'))
@@ -264,6 +265,41 @@ def sha_exists_in_engine(root,sha):
                            capture_output=True,text=True,timeout=10)
     except (OSError,subprocess.SubprocessError): return None
     return out.returncode==0
+
+DELTA_CLAIM = re.compile(r'`([0-9a-f]{7,40})`\s*(?:→|->)\s*`([0-9a-f]{7,40})`\s*delta\s*(?:為|is)\s*([0-9,]+)\s*(?:個\s*)?engine\s*commit')
+
+def engine_rev_count(root,base,head):
+    """Commits in `base..head` inside the submodule, or None when unanswerable.
+
+    A shallow clone cannot count a range it does not hold, and returning a
+    number there would be worse than returning nothing.
+    """
+    import subprocess
+    engine=root/'vendor'/'tokscale-core'
+    if not (engine/'.git').exists() or engine_is_shallow(root): return None
+    try:
+        out=subprocess.run(['git','rev-list','--count',f'{base}..{head}'],cwd=engine,
+                           capture_output=True,text=True,timeout=10)
+    except (OSError,subprocess.SubprocessError): return None
+    if out.returncode!=0: return None
+    return int(out.stdout.strip() or 0)
+
+def check_engine_delta(root,files,errors):
+    """A delta claim names two revisions and a count; the count is derivable.
+
+    Three advances in a row shipped a stale one -- 52 survived into an advance
+    of 10, and 10 into an advance of 7 -- because the prose above it was
+    rewritten while the number under it was not. It is the one part of a
+    consequence paragraph a script can settle.
+    """
+    for p in files:
+        rel=p.relative_to(root); text=p.read_text(encoding='utf-8')
+        for m in DELTA_CLAIM.finditer(text):
+            base,head,claimed=m.group(1),m.group(2),int(m.group(3).replace(',',''))
+            actual=engine_rev_count(root,base,head)
+            if actual is None or actual==claimed: continue
+            errors.append(Issue(rel,line_no(text,m.start()),
+                f'delta count disagrees with the engine\n    claimed {claimed} for {base}..{head}\n    actual  {actual}'))
 
 def check_engine_pin(root,files,errors):
     """The reviewed engine pin is restated across several documents; vendor/README.md owns it.
@@ -444,6 +480,22 @@ def self_test():
             second=subprocess.run(['git','rev-parse','HEAD'],cwd=engine,capture_output=True,text=True).stdout.strip()
             self.assertNotEqual(first,second)
             self.assertEqual(gitlink_pin(r),second,'must track the submodule checkout, not a committed gitlink')
+        def test_delta_count_disagreeing_with_the_engine_is_reported(self):
+            import unittest.mock as mock
+            r=self.append_doc(self.root(),'\n\n本次 `aaaaaaa` → `bbbbbbb` delta 為 10 個 engine commit。\n')
+            with mock.patch(f'{__name__}.engine_rev_count',return_value=7):
+                self.assertIn('delta count disagrees','\n'.join(map(str,validate(r))))
+        def test_delta_count_matching_the_engine_passes(self):
+            import unittest.mock as mock
+            r=self.append_doc(self.root(),'\n\n本次 `aaaaaaa` → `bbbbbbb` delta 為 7 個 engine commit。\n')
+            with mock.patch(f'{__name__}.engine_rev_count',return_value=7):
+                self.assertEqual(validate(r),[])
+        def test_uncountable_delta_does_not_block(self):
+            """A shallow clone cannot count a range it does not hold; silence beats a wrong number."""
+            import unittest.mock as mock
+            r=self.append_doc(self.root(),'\n\n本次 `aaaaaaa` → `bbbbbbb` delta 為 999 個 engine commit。\n')
+            with mock.patch(f'{__name__}.engine_rev_count',return_value=None):
+                self.assertEqual(validate(r),[])
         def test_missing_reviewed_pin_row_is_reported(self):
             r=self.root(); (r/'vendor/README.md').write_text('[Knowledge](../docs/knowledge/vendor-tokscale.md)')
             self.assertIn('reviewed pin row is missing','\n'.join(map(str,validate(r))))

--- a/scripts/check_knowledge.py
+++ b/scripts/check_knowledge.py
@@ -496,6 +496,24 @@ def self_test():
             r=self.append_doc(self.root(),'\n\n本次 `aaaaaaa` → `bbbbbbb` delta 為 999 個 engine commit。\n')
             with mock.patch(f'{__name__}.engine_rev_count',return_value=None):
                 self.assertEqual(validate(r),[])
+        def test_delta_count_is_derived_from_a_real_repository(self):
+            """Without mocking `engine_rev_count`, so a check that never runs fails here.
+
+            The mocked tests above prove the comparison; they cannot prove it is
+            reached. In a shallow checkout it is not, which is how a stale count
+            passed CI three advances running."""
+            import subprocess
+            r=self.root(); engine=r/'vendor'/'tokscale-core'; engine.mkdir(parents=True,exist_ok=True)
+            def git(*a): subprocess.run(['git',*a],cwd=engine,capture_output=True,check=True)
+            git('init','-q')
+            shas=[]
+            for i in range(4):
+                git('-c','user.email=t@t','-c','user.name=t','commit','-q','--allow-empty','-m',f'c{i}')
+                shas.append(subprocess.run(['git','rev-parse','HEAD'],cwd=engine,capture_output=True,text=True).stdout.strip())
+            base,head=shas[0],shas[3]
+            self.assertEqual(engine_rev_count(r,base,head),3,'fixture must have a countable range')
+            self.append_doc(r,f'\n\n本次 `{base[:7]}` → `{head[:7]}` delta 為 99 個 engine commit。\n')
+            self.assertIn('delta count disagrees','\n'.join(map(str,validate(r))))
         def test_missing_reviewed_pin_row_is_reported(self):
             r=self.root(); (r/'vendor/README.md').write_text('[Knowledge](../docs/knowledge/vendor-tokscale.md)')
             self.assertIn('reviewed pin row is missing','\n'.join(map(str,validate(r))))


### PR DESCRIPTION
Three pin advances in a row shipped a stale delta count. Each time the paragraph above the number was rewritten and the number was not.

| Advance | Prose said | Actual | Caught by |
|---|---:|---:|---|
| `434b95ff` → `47c7241` | — | 52 | — |
| `47c7241` → `ffe5a2d` | 52 | 10 | #290 round 3 |
| `ffe5a2d` → `044153f` | 10 | 7 | #297 round 1 |

#291 listed the delta count as machine-decidable. #294 implemented five other checks and skipped this one, so it stayed the single thing that kept going wrong.

## What it does

Reads a claim of the shape ``` `<base>` → `<head>` delta 為 N 個 engine commit ```, counts `base..head` in the submodule, and reports a disagreement — with the correct number in the message, so the fix is in the error rather than a separate lookup:

```
docs/knowledge/architecture.md:70: delta count disagrees with the engine
    claimed 10 for ffe5a2d..044153f
    actual  7
```

Unanswerable is not wrong: a shallow clone cannot count a range it does not hold, so `engine_rev_count` returns `None` there and the check stays silent. Same split as `sha_exists_in_engine`, for the same reason — a check that cannot tell "no" from "cannot ask" fails every CI build.

## Verified against the failures that happened

Writing 10 or 52 where the tree says 7 each produces one error at the right line with the right correction. Three tests hold the behaviour, including that an uncountable delta does not block. 40 tests total.

## Coverage after this

Machine-decided: pin equals gitlink, every engine SHA resolves, reviewed-pin claims equal the pin, bare permalinks equal the pin, labelled permalinks match their targets, delta counts match the engine.

Still human: whether the consequence prose describes this advance, and whether the previous one was correctly demoted. #291 keeps the rest — `tb_core_ffi`-unchanged and `ctb.h` no-ABI-change claims, and `last_verified` freshness.
