### PR TITLE
fix(quota): decide `declared` per subscription, not per attribution table

### DIFF
--- a/Sources/TokenBar/DashboardModel.swift
+++ b/Sources/TokenBar/DashboardModel.swift
@@ -1454,7 +1454,10 @@ private struct DashboardSnapshot {
                     payload: agentUsage, cardId: key),
                 confirmed: confirmed)
             built[key] = WindowEquivalence.aggregate(
-                declared: !confirmed.isEmpty,
+                // The same `client` the spans above were narrowed to. The fold
+                // asks the table itself; this call site does not get to decide
+                // what "declared" means.
+                subscription: client, records: confirmed,
                 cycles: zip(cycles, spans).map { cycle, span in
                     WindowEquivalence.Cycle(
                         deltaPercent: cycle.usedPercent, spanTokens: span.tokens,

--- a/Sources/TokenBar/SelfTest.swift
+++ b/Sources/TokenBar/SelfTest.swift
@@ -13323,6 +13323,56 @@ enum SelfTest {
             WindowEquivalence.aggregate(declared: true, cycles: [aeCycle(60, 0, 0)])
                 != .undeclared,
             "V15 and the flag is what decides it, not the empty spend those cycles carry")
+        // V18 (issue #320). The flag above is right when the table is empty and
+        // was wrong the moment one unrelated client was declared: every call
+        // site computed it as `!records.isEmpty`, a question about the table
+        // rather than about the subscription being rendered. On the reporting
+        // machine the table declared Claude, and Codex's card said "quota moved
+        // 216%, none of it recorded on this machine" over spans for which
+        // `get_window_usage` returned 1.2 billion tokens.
+        let v18Table = [
+            UsageAttribution.Record(
+                client: "claude", provider: "anthropic", state: .assigned("claude")),
+        ]
+        expect(
+            UsageAttribution.declares(subscription: "claude", records: v18Table),
+            "V18 a subscription with a record routing usage to it is declared")
+        expect(
+            !UsageAttribution.declares(subscription: "codex", records: v18Table),
+            "V18 declaring one client does not declare a different one — the "
+                + "question is about the subscription, not about the table")
+        // Through the overload the shipping call sites use, so this exercises
+        // the same path they do rather than a flag assembled by the test.
+        expect(
+            WindowEquivalence.aggregate(
+                subscription: "codex", records: v18Table, cycles: [aeCycle(60, 0, 0)])
+                == .undeclared,
+            "V18 so an undeclared client's cycles fold to .undeclared even while "
+                + "another client is declared, instead of claiming its usage was "
+                + "never recorded")
+        expect(
+            WindowEquivalence.aggregate(
+                subscription: "claude", records: v18Table, cycles: [aeCycle(60, 0, 0)])
+                != .undeclared,
+            "V18 and the declared client still folds normally through the same "
+                + "overload — the subscription is what separates them")
+        // The two states that must NOT count as declaring this subscription,
+        // because neither routes a single message to it: a record assigning
+        // usage elsewhere, and one excluding it.
+        expect(
+            !UsageAttribution.declares(
+                subscription: "codex",
+                records: [UsageAttribution.Record(
+                    client: "codex", provider: "openai", state: .excluded)]),
+            "V18 excluding a source is a classification, but it routes nothing "
+                + "here, so it cannot answer for this subscription")
+        expect(
+            UsageAttribution.declares(
+                subscription: "codex",
+                records: [UsageAttribution.Record(
+                    client: "claude", provider: "openai", state: .assigned("codex"))]),
+            "V18 and the client the record names is irrelevant — what counts is "
+                + "where it routes, matching the fold that admits by target")
         // V16. Pricing that is unavailable is not usage that is absent. Three
         // cycles with real tokens and no price used to fail the cost-only
         // admission gate and be reported as "none of it recorded on this

--- a/Sources/TokenBar/Views/QuotaHistoryCard.swift
+++ b/Sources/TokenBar/Views/QuotaHistoryCard.swift
@@ -340,7 +340,8 @@ struct QuotaHistoryCard: View {
         if !counted.isEmpty {
             Text(WindowEquivalence.text(
                 WindowEquivalence.aggregate(
-                    declared: !UsageAttribution.parseRaw(attributionRaw).records.isEmpty,
+                    subscription: clientId,
+                    records: UsageAttribution.parseRaw(attributionRaw).records,
                     cycles: counted.map {
                         WindowEquivalence.Cycle(
                             deltaPercent: $0.cycle.usedPercent,

--- a/Sources/TokenBar/WindowProbe.swift
+++ b/Sources/TokenBar/WindowProbe.swift
@@ -188,7 +188,10 @@ enum WindowProbe {
                             // against numbers the app never computes.
                             modelScope: w.modelScope, confirmed: confirmed)
                         return WindowEquivalence.aggregate(
-                            declared: !confirmed.isEmpty,
+                            // Same subscription the spans above were narrowed
+                            // to; the probe measures the shipping calculation,
+                            // so it takes the shipping overload.
+                            subscription: agent.clientId, records: confirmed,
                             cycles: zip(admitted, spans).map { cycle, span in
                                 WindowEquivalence.Cycle(
                                     deltaPercent: cycle.usedPercent,

--- a/Sources/TokenBarCore/UsageAttribution.swift
+++ b/Sources/TokenBarCore/UsageAttribution.swift
@@ -91,6 +91,31 @@ public enum UsageAttribution {
             records: records)
     }
 
+    /// Whether any confirmed record routes usage to `subscription`.
+    ///
+    /// This is the question a window-history card has to ask before it can
+    /// describe an empty span. It must be the SAME question that decides what
+    /// gets counted into that span — `QuotaHistory`'s fold admits a message
+    /// only when `resolve` returns `.assigned(subscription)` — because the two
+    /// together are what separates "the machine recorded nothing" from "the
+    /// machine recorded it and you have not said whose it is". Asking anything
+    /// broader here makes the card claim the first while the second is true.
+    ///
+    /// It lives here, once, because it had been spelled out at three call
+    /// sites and all three spelled it wrong the same way: `!records.isEmpty`,
+    /// which is a question about the TABLE rather than about this
+    /// subscription, so declaring any one client answered for every other.
+    /// A fourth call site gets the answer rather than another chance to
+    /// rewrite it.
+    ///
+    /// `.excluded` deliberately does not count. It is a classification, so the
+    /// user has acted — but nothing it marks will ever be counted toward this
+    /// subscription, and a card that said "classified" while showing an empty
+    /// span would be back to describing an absence it cannot account for.
+    public static func declares(subscription: String, records: [Record]) -> Bool {
+        records.contains { $0.state == .assigned(subscription) }
+    }
+
     /// Parse a raw @AppStorage string. A missing value is an empty writable
     /// table; malformed or semantically invalid data is an empty read-only
     /// table so a later mutation cannot overwrite data this codec does not

--- a/Sources/TokenBarCore/WindowEquivalence.swift
+++ b/Sources/TokenBarCore/WindowEquivalence.swift
@@ -322,13 +322,53 @@ public enum WindowEquivalence {
     /// Denominated in money. Tokens are also returned, but cost is the steadier
     /// of the two here (5% against 7%), which is consistent with providers
     /// metering on something closer to cost than to a token count.
-    /// `declared` is whether the user has classified ANY source. It belongs
-    /// here rather than at the call site because the distinction it makes is
-    /// this type's own: with nothing declared every message resolves to
-    /// unassigned, so every cycle arrives carrying zero spend, and the rules
-    /// below would report that as "the quota moved and none of it was recorded
-    /// on this machine". That sentence describes a data failure. The actual
-    /// state is a missing declaration, and it is the state most users are in.
+    /// `declared` is whether the user has classified anything as belonging to
+    /// THIS subscription — `UsageAttribution.declares(subscription:records:)`
+    /// is the one place that answers it. It belongs as a parameter rather than
+    /// a decision made here because the distinction it makes is this type's
+    /// own: with this subscription undeclared every one of its messages
+    /// resolves to unassigned, so every cycle arrives carrying zero spend, and
+    /// the rules below would report that as "the quota moved and none of it
+    /// was recorded on this machine". That sentence describes a data failure.
+    /// The actual state is a missing declaration, and it is the state most
+    /// users are in.
+    ///
+    /// It used to be documented — and computed — as "has the user classified
+    /// ANY source", which is a question about the table. Declaring one client
+    /// then answered for every other, so an undeclared client's card described
+    /// usage sitting in the same scan as never recorded (issue #320).
+    /// The fold for a subscription, given the attribution table rather than a
+    /// conclusion drawn from it.
+    ///
+    /// This is the overload every shipping call site uses, and it exists
+    /// because the other one was too easy to answer wrongly. Three call sites
+    /// each derived `declared` themselves and each derived it as
+    /// `!records.isEmpty` — a question about the table, not about the
+    /// subscription — so declaring one client made every other client's card
+    /// claim its usage was never recorded (issue #320). Passing the question
+    /// instead of the answer removes the opportunity rather than documenting
+    /// it: there is no boolean here for a caller to compute from the wrong
+    /// subject.
+    ///
+    /// `subscription` must be the same one the spans were narrowed to. The
+    /// fold describes those spans, and describing them by a different
+    /// subscription's declaration state is exactly the defect above.
+    public static func aggregate(
+        subscription: String, records: [UsageAttribution.Record], cycles: [Cycle]
+    ) -> Row {
+        aggregate(
+            declared: UsageAttribution.declares(
+                subscription: subscription, records: records),
+            cycles: cycles)
+    }
+
+    /// Prefer `aggregate(subscription:records:cycles:)`. This overload takes
+    /// the answer; that one takes the question. Every shipping call site uses
+    /// the latter, and issue #320 is why: a caller holding a `Bool` is a
+    /// caller that had to derive it, and all three derived it from the wrong
+    /// subject. Kept public because the fold's own behaviour — that the flag,
+    /// not the empty spend, is what selects `.undeclared` — has to be
+    /// assertable without building an attribution table.
     public static func aggregate(declared: Bool = true, cycles: [Cycle]) -> Row {
         guard declared else { return .undeclared }
         // Admission is about EVIDENCE, not about money. Gating on `spanCost`


### PR DESCRIPTION
A window-history card for an undeclared client says its usage was never recorded, about usage sitting in the same scan.

Refs #320.

## The defect

`WindowEquivalence.aggregate` takes a `declared` flag that separates two very different statements: *the machine recorded nothing* and *the machine recorded it and you have not said whose it is*. Three call sites each computed that flag, and each computed it the same wrong way:

| Call site | Expression |
|---|---|
| `DashboardModel.swift:1457` | `declared: !confirmed.isEmpty` |
| `WindowProbe.swift:191` | `declared: !confirmed.isEmpty` |
| `QuotaHistoryCard.swift:343` | `declared: !UsageAttribution.parseRaw(attributionRaw).records.isEmpty` |

Each asks whether the **table** has anything in it, not whether **this subscription** has been declared. So declaring any one client answers for every other.

`QuotaHistory`'s fold admits a message only when `resolve` returns `.assigned(subscription)`. An undeclared client's spans therefore arrive at zero, and `declared: true` sends those zeros down the `.unaccounted` path — "Quota moved N%, none of it recorded on this machine" — instead of `.undeclared`. On the reporting machine `get_window_usage` returned 1,225,578,311 / 145,397,270 / 388,535,550 tokens for exactly the three spans the card called empty.

The existing V15 assertion cannot catch this. It exercises an empty table, where the flag is right; the flag only becomes wrong once one *unrelated* client is declared.

## The fix is not three corrected expressions

A caller holding a `Bool` is a caller that had to derive it, and the derivation has a wrong answer that looks reasonable — three independent authors reached for the same one. The question moves to where it can be answered once.

**`UsageAttribution.declares(subscription:records:)`** is now the single definition:

```swift
records.contains { $0.state == .assigned(subscription) }
```

It deliberately matches the admit gate at `QuotaHistory.swift:372` (`case let .assigned(target) = state, target == subscription`). The flag describing a span and the rule filling that span now ask the same question — that identity is the property the defect violated, and it is why this predicate and not a broader one.

**`WindowEquivalence.aggregate(subscription:records:cycles:)`** is a new overload that takes the question instead of the answer. All three shipping call sites use it and compute nothing. The `declared:` overload stays public so the fold's own behaviour stays assertable without building a table; its documentation now points at the other one.

`.excluded` deliberately does not count as declaring. It is a classification, so the user has acted — but nothing it marks is ever counted toward this subscription, and a card reporting "classified" over an empty span would be back to describing an absence it cannot account for.

> The issue's suggested `confirmed.contains { $0.target == subscription }` does not compile: `Record` has no `target`, the target lives inside `state`'s `.assigned` case.

## Verification

Six V18 assertions, all hermetic — they build a table in the test rather than reading `UserDefaults.standard`, which SelfTest does not isolate and which would have made the result depend on the running machine's own declarations. They assert states and never copy, as the issue asks: a declared subscription is declared; a different undeclared one is not; that difference reaches `.undeclared` through the same overload the app uses; the declared one still folds normally; `.excluded` does not qualify; and the record's `client` is irrelevant, because what counts is where it routes.

**Mutation-tested.** Reverting `declares` to `!records.isEmpty` fails exactly three V18 assertions:

```
FAIL V18 declaring one client does not declare a different one — the question is about
     the subscription, not about the table
FAIL V18 so an undeclared client's cycles fold to .undeclared even while another client
     is declared, instead of claiming its usage was never recorded
FAIL V18 excluding a source is a classification, but it routes nothing here, so it
     cannot answer for this subscription
```

The suite is green again after restoring.

**V15/V16/V17 do not turn red**, and not because they were adjusted. They call `aggregate(declared:)` directly, whose behaviour is unchanged. The one place a shipping value could have moved is the M3-q fixture, which builds a real `DashboardModel`: its subscription is `claude`, and the flag is unchanged for it in both environments that matter — on a machine declaring `claude` both the old and new expressions are true, and on CI's empty defaults both are false.

`make build` and `make selftest` pass: **1311 assertions, 0 failures**.

## Not addressed here

No test pins the three call sites themselves. A future edit computing `declared` locally again would pass V18. The new overload is what makes that unlikely rather than merely discouraged — the correct call is now also the shorter one — but that is a design property, not an assertion. Pinning it would require `DashboardModel` to take an injectable defaults or records seam, which it has nowhere else and which is a larger change than this defect warrants.

The `.undeclared` copy is unchanged. The issue notes that reaching that state is now actionable ("declare the client in Settings") in a way the old message never was, and the current string already says `Classify your usage in Settings to see what this window is worth`. Whether it should say more is a copy decision, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b6oYpz3XWF8kvs32jNy8e
